### PR TITLE
Add AppImage detection and workaround

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/secretmanager v1.0.0
 	cloud.google.com/go/storage v1.10.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/alessio/shellescape v1.4.1
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/edaniels/golinters v0.0.5-0.20210512224240-495d3b8eed19
 	github.com/edaniels/golog v0.0.0-20210326173913-16d408aa7a5e

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pOcUuw=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=


### PR DESCRIPTION
The AppImage runtime does a lot of "magic" to hook execve() (and related) calls, and detects if the target is inside or outside of the appimage, and swaps out the libc and ld-linux interpreter. The problem is that Go doesn't use libc but instead codes syscalls directly in assembly. So it can't be hooked by the normal AppImage runtime tricks, and on systems where the appimage libc/ld-linux are in use, execing external binaries then fails.

This adds a short block that detects the APPIMAGE environment variable, and if found, basically runs processes through bash (included in the appimage) instead of directly, and thus the real execve() can be properly hooked.

If there's a better way to do this, I'm all ears, as this feels very hackish... but so does the rest of the AppImage "magic."
