### PR TITLE
Fixing workflow

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -33,8 +33,7 @@ jobs:
     strategy:
       matrix:
         repo:
-          - 'viamrobotics/python-sdk'
-          - 'viamrobotics/rust-sdk'
+          - ['viamrobotics/python-sdk','viamrobotics/rust-sdk']
     steps:
       - name: Notify Proto Watchers
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
Repo dispatch syntax is not what I expected therefore dispatch action are only applied to python-sdk and not rust-sdk

See [here](https://github.com/marketplace/actions/repository-dispatch) for the proper syntax