### PR TITLE
[DATA-298] Support getting log lines from managed processes

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -107,7 +107,7 @@ func (p *managedProcess) Start(ctx context.Context) error {
 					p.logger.Debugw("process output", "name", p.name, "output", string(out))
 				}
 				if p.logWriter != nil {
-					if _, err := (*p.logWriter).Write(out); err != nil && err != io.ErrClosedPipe {
+					if _, err := (*p.logWriter).Write(out); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 						return errors.Wrapf(err, "error writing process output to log writer")
 					}
 				}
@@ -206,7 +206,7 @@ func (p *managedProcess) manage(stdOut, stdErr io.ReadCloser) {
 						_, err = (*p.logWriter).Write([]byte("\n"))
 					}
 					if err != nil {
-						if err != io.ErrClosedPipe {
+						if !errors.Is(err, io.ErrClosedPipe) {
 							p.logger.Errorw("error writing process output to log writer", "name", name, "error", err)
 						}
 						if !p.shouldLog {

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
+
 	"go.viam.com/utils"
 )
 

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -255,14 +255,12 @@ func TestManagedProcessStop(t *testing.T) {
 func TestManagedProcessLogWriter(t *testing.T) {
 	t.Run("Extract output of a one shot", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
-		var logReader io.Reader
-		var logWriter io.Writer
-		logReader, logWriter = io.Pipe()
+		logReader, logWriter := io.Pipe()
 		proc := NewManagedProcess(ProcessConfig{
 			Name:      "bash",
 			Args:      []string{"-c", "echo hello"},
 			OneShot:   true,
-			LogWriter: &logWriter,
+			LogWriter: logWriter,
 		}, logger)
 		var activeReaders sync.WaitGroup
 		activeReaders.Add(1)
@@ -280,13 +278,11 @@ func TestManagedProcessLogWriter(t *testing.T) {
 
 	t.Run("Get log lines from a process", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
-		var logReader io.Reader
-		var logWriter io.Writer
-		logReader, logWriter = io.Pipe()
+		logReader, logWriter := io.Pipe()
 		proc := NewManagedProcess(ProcessConfig{
 			Name:      "bash",
 			Args:      []string{"-c", "echo hello"},
-			LogWriter: &logWriter,
+			LogWriter: logWriter,
 		}, logger)
 		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 		bufferedLogReader := bufio.NewReader(logReader)

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -5,16 +5,21 @@
 // when configured.
 package pexec
 
-import "go.viam.com/utils"
+import (
+	"io"
+
+	"go.viam.com/utils"
+)
 
 // A ProcessConfig describes how to manage a system process.
 type ProcessConfig struct {
-	ID      string   `json:"id"`
-	Name    string   `json:"name"`
-	Args    []string `json:"args"`
-	CWD     string   `json:"cwd"`
-	OneShot bool     `json:"one_shot"`
-	Log     bool     `json:"log"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Args      []string   `json:"args"`
+	CWD       string     `json:"cwd"`
+	OneShot   bool       `json:"one_shot"`
+	Log       bool       `json:"log"`
+	LogWriter *io.Writer `json:"-"`
 }
 
 // Validate ensures all parts of the config are valid.

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -13,13 +13,13 @@ import (
 
 // A ProcessConfig describes how to manage a system process.
 type ProcessConfig struct {
-	ID        string     `json:"id"`
-	Name      string     `json:"name"`
-	Args      []string   `json:"args"`
-	CWD       string     `json:"cwd"`
-	OneShot   bool       `json:"one_shot"`
-	Log       bool       `json:"log"`
-	LogWriter *io.Writer `json:"-"`
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Args      []string  `json:"args"`
+	CWD       string    `json:"cwd"`
+	OneShot   bool      `json:"one_shot"`
+	Log       bool      `json:"log"`
+	LogWriter io.Writer `json:"-"`
 }
 
 // Validate ensures all parts of the config are valid.


### PR DESCRIPTION
There are 3 PRs necessary to reserve the port in the slam process:

https://github.com/viamrobotics/slam/pull/29: orbslam reserves and logs the port
https://github.com/viamrobotics/goutils/pull/50 (this PR): add support for extracting log lines from managed processes
https://github.com/viamrobotics/rdk/pull/1269: slam service reads port from orbslam logs

https://github.com/viamrobotics/rdk/pull/1269 must be merged after https://github.com/viamrobotics/slam/pull/29 and https://github.com/viamrobotics/goutils/pull/50.