### PR TITLE
[RSDK-731] Handle wrtc noisy client

### DIFF
--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -275,6 +275,9 @@ func (ch *webrtcClientChannel) writeReset(stream *webrtcpb.Stream) error {
 func logFinalClientLine(ctx context.Context, startTime time.Time, err error, msg string) {
 	code := grpc_logging.DefaultErrorToCode(err)
 	level := grpc_zap.DefaultCodeToLevel(code)
+	if err == nil {
+		level = zap.DebugLevel
+	}
 	duration := grpc_zap.DefaultDurationToField(time.Since(startTime))
 	grpc_zap.DefaultMessageProducer(ctx, msg, level, code, err, duration)
 }


### PR DESCRIPTION
wrtc client is currently really noisy and we want the client logs to be set to debug if no error is found