### PR TITLE
Support better error logging in the HTTP service.

### DIFF
--- a/web/error.go
+++ b/web/error.go
@@ -39,12 +39,19 @@ func HandleError(w http.ResponseWriter, err error, logger golog.Logger, context 
 
 	logger.Info(err)
 
+	statusCode := http.StatusInternalServerError
+
 	var er ErrorResponse
 	if errors.As(err, &er) {
-		w.WriteHeader(er.Status())
-	} else {
-		w.WriteHeader(http.StatusInternalServerError)
+		statusCode = er.Status()
 	}
+
+	// Log internal errors.
+	if statusCode >= 500 {
+		logger.Errorf("Error during http response: %s", err)
+	}
+
+	w.WriteHeader(statusCode)
 
 	var b bytes.Buffer
 

--- a/web/panic_capture.go
+++ b/web/panic_capture.go
@@ -1,0 +1,29 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/edaniels/golog"
+)
+
+// PanicCapture allows recovery during a request handler from panics. It prints a
+// formatted log to the underlying logger.
+type PanicCapture struct {
+	Logger golog.Logger
+}
+
+// Recover captures and prints the error if recover() has an error.
+func (p *PanicCapture) Recover(w http.ResponseWriter, r *http.Request) {
+	err := recover()
+	if err == nil {
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusInternalServerError)
+	if _, err := w.Write([]byte("internal server error")); err != nil {
+		p.Logger.Warnf("failed to write to response: %s", err)
+	}
+
+	p.Logger.Errorf("Unhandled error: %s", err)
+}

--- a/web/panic_capture_test.go
+++ b/web/panic_capture_test.go
@@ -1,0 +1,31 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/test"
+)
+
+func TestPanicCapture(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+	logger, observedLogs := golog.NewObservedTestLogger(t)
+	capture := PanicCapture{Logger: logger}
+
+	handlerWithError := func(err error, w http.ResponseWriter) {
+		defer capture.Recover(w, req)
+		panic(err)
+	}
+
+	w := httptest.NewRecorder()
+	handlerWithError(errors.New("some error"), w)
+
+	test.That(t, w.Code, test.ShouldEqual, http.StatusInternalServerError)
+	test.That(t, w.Body.String(), test.ShouldEqual, "internal server error")
+	test.That(t, observedLogs.All(), test.ShouldHaveLength, 1)
+	test.That(t, observedLogs.All()[0].Message, test.ShouldContainSubstring, "Unhandled error: some error")
+}


### PR DESCRIPTION
I found cases today where we are panicing in the app but the logs go unnoticed because the logs are split between stackdriver lines.

This includes a panic capure to the template handler and api handler.

It includes basic error logging for cases where we return a 5xx to the user.