### PR TITLE
Remove development metrics logger

### DIFF
--- a/perf/exporters.go
+++ b/perf/exporters.go
@@ -8,7 +8,6 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"github.com/edaniels/golog"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 
 	"go.viam.com/utils"
@@ -153,14 +152,12 @@ func (r *gaeResource) MonitoredResource() (resType string, labels map[string]str
 // NewDevelopmentExporter creates a new exporter that outputs the console.
 func NewDevelopmentExporter() Exporter {
 	return &developmentExporter{
-		trace:  newNiceLoggingSpanExporter(),
-		metric: newPrintExporter(),
+		trace: newNiceLoggingSpanExporter(),
 	}
 }
 
 type developmentExporter struct {
-	metric view.Exporter
-	trace  trace.Exporter
+	trace trace.Exporter
 }
 
 // Starts the applications stats/span monitoring. Registers views and starts trace/metric exporters to console.
@@ -169,7 +166,6 @@ func (e *developmentExporter) Start() error {
 		return err
 	}
 
-	view.RegisterExporter(e.metric)
 	trace.RegisterExporter(e.trace)
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
@@ -178,6 +174,5 @@ func (e *developmentExporter) Start() error {
 
 // Stop all exporting.
 func (e *developmentExporter) Stop() {
-	view.UnregisterExporter(e.metric)
 	trace.UnregisterExporter(e.trace)
 }

--- a/perf/metrics.go
+++ b/perf/metrics.go
@@ -1,10 +1,6 @@
 package perf
 
 import (
-	"fmt"
-	"log"
-
-	"go.opencensus.io/stats/view"
 	"go.uber.org/multierr"
 )
 
@@ -14,46 +10,4 @@ func registerApplicationViews() error {
 		registerGrpcViews(),
 		registerHTTPViews(),
 	)
-}
-
-// indent these many spaces.
-const indent = "  "
-
-// newPrintExporter creates a new metric exporter that prints to the console.
-// This should NOT be used for production workloads.
-func newPrintExporter() view.Exporter {
-	return &printExporter{}
-}
-
-// printExporter is a stats and trace exporter that logs
-// the exported data to the console.
-//
-// The intent is help new users familiarize themselves with the
-// capabilities of opencensus.
-//
-// This should NOT be used for production workloads.
-type printExporter struct{}
-
-// ExportView prints the metric data to the console.
-func (e *printExporter) ExportView(vd *view.Data) {
-	for _, row := range vd.Rows {
-		log.Printf("%v %-45s", vd.End.Format("15:04:05"), vd.View.Name)
-
-		var info string
-		switch v := row.Data.(type) {
-		case *view.DistributionData:
-			info = fmt.Sprintf("distribution: min=%.1f max=%.1f mean=%.1f", v.Min, v.Max, v.Mean)
-		case *view.CountData:
-			info = fmt.Sprintf("count:        value=%v", v.Value)
-		case *view.SumData:
-			info = fmt.Sprintf("sum:          value=%v", v.Value)
-		case *view.LastValueData:
-			info = fmt.Sprintf("last:         value=%v", v.Value)
-		}
-		log.Println(info)
-
-		for _, tag := range row.Tags {
-			log.Printf("%v- %v=%v\n", indent, tag.Key.Name(), tag.Value)
-		}
-	}
 }


### PR DESCRIPTION
In dev mode we were printing the metrics recorded ever 5 seconds. This was a lot and not useful. Getting rid of it. Trace logging stays since that is our only local HTTP request(ish) logging in the app locally.