### PR TITLE
Support for protojson encoding in API Middleware and Template Middleware

### DIFF
--- a/web/api.go
+++ b/web/api.go
@@ -13,6 +13,7 @@ import (
 	"go.opencensus.io/trace"
 
 	"go.viam.com/utils"
+	"go.viam.com/utils/web/protojson"
 )
 
 // APIHandler what a user has to implement to use APIMiddleware.
@@ -24,6 +25,8 @@ type APIHandler interface {
 
 // APIMiddleware simple layer between http.Handler interface that does json marshalling and error handling.
 type APIMiddleware struct {
+	protojson.MarshalingOptions
+
 	Handler APIHandler
 	Logger  golog.Logger
 
@@ -112,7 +115,8 @@ func (am *APIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	js, err := json.Marshal(data)
+	marshaler := protojson.Marshaler{am.MarshalingOptions}
+	js, err := marshaler.Marshal(data)
 	if handleAPIError(w, err, am.Logger, nil) {
 		return
 	}

--- a/web/api_test.go
+++ b/web/api_test.go
@@ -1,0 +1,113 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/test"
+
+	rpcpb "go.viam.com/utils/proto/rpc/v1"
+	"go.viam.com/utils/web/protojson"
+)
+
+func TestAPIPRotoJSONEncoding(t *testing.T) {
+	t.Run("protojson enabled with proto resp", func(t *testing.T) {
+		opts := protojson.MarshalingOptions{EnableProtoJSON: true}
+		resp := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+		testAPIWithOptionsAndResponse(t, opts, resp, `{"accessToken":"access-token"}`)
+	})
+
+	t.Run("protojson enabled with proto array resp", func(t *testing.T) {
+		opts := protojson.MarshalingOptions{EnableProtoJSON: true}
+		resp := []*rpcpb.AuthenticateResponse{
+			{AccessToken: "access-token1"},
+			{AccessToken: "access-token2"},
+		}
+
+		testAPIWithOptionsAndResponse(t, opts, resp, `[{"accessToken":"access-token1"},{"accessToken":"access-token2"}]`)
+	})
+
+	t.Run("protojson enabled with proto array resp with proto names", func(t *testing.T) {
+		opts := protojson.MarshalingOptions{EnableProtoJSON: true, JSONOptions: protojson.JSONOptions{UseProtoNames: true}}
+		resp := []*rpcpb.AuthenticateResponse{
+			{AccessToken: "access-token1"},
+			{AccessToken: "access-token2"},
+		}
+
+		testAPIWithOptionsAndResponse(t, opts, resp, `[{"access_token":"access-token1"},{"access_token":"access-token2"}]`)
+	})
+
+	t.Run("protojson enabled with proto array resp with proto names", func(t *testing.T) {
+		opts := protojson.MarshalingOptions{EnableProtoJSON: false}
+		resp := []*rpcpb.AuthenticateResponse{
+			{AccessToken: "access-token1"},
+			{AccessToken: "access-token2"},
+		}
+
+		testAPIWithOptionsAndResponse(t, opts, resp, `[{"access_token":"access-token1"},{"access_token":"access-token2"}]`)
+	})
+
+	t.Run("protojson enabled with proto field names with proto resp", func(t *testing.T) {
+		opts := protojson.MarshalingOptions{EnableProtoJSON: true, JSONOptions: protojson.JSONOptions{UseProtoNames: true}}
+		resp := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+		testAPIWithOptionsAndResponse(t, opts, resp, `{"access_token":"access-token"}`)
+	})
+
+	t.Run("protojson disabled with proto resp", func(t *testing.T) {
+		opts := protojson.MarshalingOptions{EnableProtoJSON: false}
+		resp := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+		testAPIWithOptionsAndResponse(t, opts, resp, `{"access_token":"access-token"}`)
+	})
+
+	t.Run("protojson enabled with non-proto resp", func(t *testing.T) {
+		opts := protojson.MarshalingOptions{EnableProtoJSON: true}
+		resp := struct {
+			NameWithSnake string `json:"name_with_snake"`
+			ID            string `json:"-"`
+			OtherName     string
+		}{
+			NameWithSnake: "snake",
+			ID:            "id-will-be-missing",
+			OtherName:     "otherName",
+		}
+		testAPIWithOptionsAndResponse(t, opts, resp, `{"name_with_snake":"snake","OtherName":"otherName"}`)
+	})
+}
+
+func testAPIWithOptionsAndResponse(t *testing.T, opts protojson.MarshalingOptions, resp interface{}, expectedBody string) {
+	t.Helper()
+
+	logger := golog.NewTestLogger(t)
+
+	mw := APIMiddleware{
+		MarshalingOptions: opts,
+		Handler:           staticResponseHandler(resp, nil),
+		Logger:            logger,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	test.That(t, err, test.ShouldBeNil)
+	rr := httptest.NewRecorder()
+
+	mw.ServeHTTP(rr, req)
+
+	test.That(t, rr.Body.String(), test.ShouldEqual, expectedBody)
+}
+
+func staticResponseHandler(data interface{}, err error) APIHandler {
+	return &testHandler{
+		h: func(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+			return data, err
+		},
+	}
+}
+
+type testHandler struct {
+	h func(http.ResponseWriter, *http.Request) (interface{}, error)
+}
+
+func (t *testHandler) ServeAPI(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	return t.h(w, r)
+}

--- a/web/error.go
+++ b/web/error.go
@@ -37,8 +37,6 @@ func HandleError(w http.ResponseWriter, err error, logger golog.Logger, context 
 		return false
 	}
 
-	logger.Info(err)
-
 	statusCode := http.StatusInternalServerError
 
 	var er ErrorResponse
@@ -49,6 +47,8 @@ func HandleError(w http.ResponseWriter, err error, logger golog.Logger, context 
 	// Log internal errors.
 	if statusCode >= 500 {
 		logger.Errorf("Error during http response: %s", err)
+	} else {
+		logger.Infof("Error with non-5xx status during http response: %s", err)
 	}
 
 	w.WriteHeader(statusCode)

--- a/web/protojson/marshaler.go
+++ b/web/protojson/marshaler.go
@@ -1,0 +1,153 @@
+// Package protojson provides helpers to marshal proto.Message to json
+package protojson
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"reflect"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	protoMessageType = reflect.TypeOf((*proto.Message)(nil)).Elem()
+
+	defaultMarshaler = Marshaler{DefaultMarshalingOptions()}
+)
+
+// Marshaler used to marshal data to json repecting proto.Message types.
+type Marshaler struct {
+	Opts MarshalingOptions
+}
+
+// Marshal encodes the interface to json. It identifies if a proto.Message or an slice/array of
+// proto.Message are passed in and for those types uses the protobuf protojson marshaler. Otherwise
+// uses the standard json.Marshal().
+//
+// Note beware of its limitations:
+//   - Does not support proto.Message within a map.
+//   - Does not support proto.Message embedded within another struct.
+func (m *Marshaler) Marshal(data interface{}) ([]byte, error) {
+	protoMarshaler := m.Opts.JSONOptions
+
+	// If protojson enabled and type is proto.Message encode with protojson
+	if m.Opts.EnableProtoJSON && isProtoMessage(data) {
+		return protoMarshaler.Marshal(data.(proto.Message))
+	} else if m.Opts.EnableProtoJSON && isSliceOfProtoMessage(data) {
+		return marshalSliceOfProtos(protoMarshaler, data)
+	}
+
+	// fallback to default json marshaler
+	return json.Marshal(data)
+}
+
+// MarshalToInterface encodes the interface to generic json map interface. It identifies if a proto.Message or an slice/array of
+// proto.Message are passed in and for those types uses the protobuf protojson marshaler. Otherwise
+// uses the standard json.Marshal().
+//
+// Note beware of its limitations:
+//   - Does not support proto.Message within a map.
+//   - Does not support proto.Message embedded within another struct.
+func (m *Marshaler) MarshalToInterface(data interface{}) (interface{}, error) {
+	out, err := m.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var x interface{}
+	err = json.Unmarshal(out, &x)
+	if err != nil {
+		return nil, err
+	}
+
+	return x, nil
+}
+
+// Marshal encodes the interface to json. It identifies if a proto.Message or an slice/array of
+// proto.Message are passed in and for those types uses the protobuf protojson marshaler. Otherwise
+// uses the standard json.Marshal().
+//
+// Note beware of its limitations:
+//   - Does not support proto.Message within a map.
+//   - Does not support proto.Message embedded within another struct.
+func Marshal(data interface{}) ([]byte, error) {
+	return defaultMarshaler.Marshal(data)
+}
+
+// MarshalToInterface encodes the interface to generic json map interface. It identifies if a proto.Message or an slice/array of
+// proto.Message are passed in and for those types uses the protobuf protojson marshaler. Otherwise
+// uses the standard json.Marshal().
+//
+// Note beware of its limitations:
+//   - Does not support proto.Message within a map.
+//   - Does not support proto.Message embedded within another struct.
+func MarshalToInterface(data interface{}) (interface{}, error) {
+	return defaultMarshaler.MarshalToInterface(data)
+}
+
+func isSliceOfProtoMessage(input interface{}) bool {
+	t := reflect.TypeOf(input)
+	if t.Kind() == reflect.Array || t.Kind() == reflect.Slice {
+		return t.Elem().Implements(protoMessageType)
+	}
+	return false
+}
+
+func isProtoMessage(input interface{}) bool {
+	_, ok := input.(proto.Message)
+	return ok
+}
+
+// A bit of a hack to encode an slice of protos. The protojson implementation only supports
+// a single proto.Message being encoded. This loops through a input array using reflection and
+// encodes each element to json using the protojson marshaler and contructs the array.
+func marshalSliceOfProtos(marshaler protojson.MarshalOptions, input interface{}) ([]byte, error) {
+	inputType := reflect.ValueOf(input)
+
+	if inputType.Len() == 0 {
+		return []byte("[]"), nil
+	}
+
+	var b bytes.Buffer
+	x := bufio.NewWriter(&b)
+
+	_, err := x.WriteString("[")
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < inputType.Len(); i++ {
+		protoItem := inputType.Index(i).Interface().(proto.Message)
+		jsItem, err := marshaler.Marshal(protoItem)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = x.WriteString(string(jsItem))
+		if err != nil {
+			return nil, err
+		}
+
+		if i != inputType.Len()-1 {
+			_, err = x.WriteString(",")
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	_, err = x.WriteString("]")
+	if err != nil {
+		return nil, err
+	}
+
+	err = x.Flush()
+	if err != nil {
+		return nil, err
+	}
+
+	js := b.Bytes()
+	return js, nil
+}

--- a/web/protojson/marshaler_test.go
+++ b/web/protojson/marshaler_test.go
@@ -1,0 +1,133 @@
+package protojson
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+
+	rpcpb "go.viam.com/utils/proto/rpc/v1"
+)
+
+type testData struct {
+	NameWithSnake string `json:"name_with_snake"`
+	ID            string `json:"-"`
+	OtherName     string
+}
+
+func TestMarshal(t *testing.T) {
+	t.Run("Marshal proto enabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true}
+		in := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in, `{"accessToken":"access-token"}`)
+	})
+
+	t.Run("Marshal proto disabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: false}
+		in := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in, `{"access_token":"access-token"}`)
+	})
+
+	t.Run("Marshal proto enabled with field names", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true, JSONOptions: JSONOptions{UseProtoNames: true}}
+		in := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in, `{"access_token":"access-token"}`)
+	})
+
+	t.Run("Marshal struct enabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true, JSONOptions: JSONOptions{UseProtoNames: true}}
+		in := &testData{NameWithSnake: "name", ID: "id", OtherName: "other"}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in, `{"name_with_snake":"name","OtherName":"other"}`)
+	})
+
+	t.Run("Marshal proto slice enabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true}
+		in := []*rpcpb.AuthenticateResponse{
+			{AccessToken: "access-token1"},
+			{AccessToken: "access-token2"},
+		}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in, `[{"accessToken":"access-token1"},{"accessToken":"access-token2"}]`)
+	})
+
+	t.Run("Marshal proto slice enabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true}
+		in := []*testData{
+			{NameWithSnake: "name1", ID: "id", OtherName: "other"},
+			{NameWithSnake: "name2", ID: "id", OtherName: "other"},
+		}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in,
+			`[{"name_with_snake":"name1","OtherName":"other"},{"name_with_snake":"name2","OtherName":"other"}]`)
+	})
+
+	t.Run("Marshal empty slice", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true}
+		in := []*testData{}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in, `[]`)
+	})
+
+	t.Run("Marshal empty proto slice", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true}
+		in := []*rpcpb.AuthenticateResponse{}
+
+		validateMarshal(t, Marshaler{Opts: opts}, in, `[]`)
+	})
+}
+
+func TestMarshalToInterface(t *testing.T) {
+	t.Run("Marshal proto enabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true}
+		in := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+		expected := map[string]interface{}{
+			"accessToken": "access-token",
+		}
+
+		validateMarshalToInterface(t, Marshaler{Opts: opts}, in, expected)
+	})
+
+	t.Run("Marshal proto disabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: false}
+		in := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+		expected := map[string]interface{}{
+			"access_token": "access-token",
+		}
+
+		validateMarshalToInterface(t, Marshaler{Opts: opts}, in, expected)
+	})
+
+	t.Run("Marshal proto slice enabled", func(t *testing.T) {
+		opts := MarshalingOptions{EnableProtoJSON: true}
+		in := []*rpcpb.AuthenticateResponse{
+			{AccessToken: "access-token1"},
+			{AccessToken: "access-token2"},
+		}
+
+		expected := []interface{}{
+			map[string]interface{}{"accessToken": "access-token1"},
+			map[string]interface{}{"accessToken": "access-token2"},
+		}
+
+		validateMarshalToInterface(t, Marshaler{Opts: opts}, in, expected)
+	})
+}
+
+func validateMarshal(t *testing.T, m Marshaler, data interface{}, expected string) {
+	t.Helper()
+
+	out, err := m.Marshal(data)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, string(out), test.ShouldEqual, expected)
+}
+
+func validateMarshalToInterface(t *testing.T, m Marshaler, data, expected interface{}) {
+	t.Helper()
+
+	out, err := m.MarshalToInterface(data)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, out, test.ShouldResemble, expected)
+}

--- a/web/protojson/options.go
+++ b/web/protojson/options.go
@@ -1,0 +1,28 @@
+package protojson
+
+import "google.golang.org/protobuf/encoding/protojson"
+
+// JSONOptions is the underlying protojson marshal options.
+type JSONOptions = protojson.MarshalOptions
+
+// MarshalingOptions has options for how web http middleware marshals data to the clients.
+type MarshalingOptions struct {
+	// Enable protojson encoding in API responses and any json encoding.
+	EnableProtoJSON bool
+
+	// Options used for protojson marshaling
+	JSONOptions
+}
+
+// DefaultMarshalingOptions returns a default set of options. It has protojson disabled by default.
+func DefaultMarshalingOptions() MarshalingOptions {
+	return MarshalingOptions{
+		// Disabled by default.
+		EnableProtoJSON: false,
+
+		JSONOptions: JSONOptions{
+			UseProtoNames: true,
+			AllowPartial:  true,
+		},
+	}
+}

--- a/web/templates_test.go
+++ b/web/templates_test.go
@@ -1,0 +1,96 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/test"
+
+	rpcpb "go.viam.com/utils/proto/rpc/v1"
+	"go.viam.com/utils/web/protojson"
+)
+
+func TestTemlpateProtoJson(t *testing.T) {
+	t.Run("test template rendering with protoJson with proto.Message", func(t *testing.T) {
+		resp := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+		validateTemplateRendering(t, "protoJson.html", resp, `{"accessToken":"access-token"}`)
+	})
+
+	t.Run("test template rendering with protoJson with array of proto.Message", func(t *testing.T) {
+		resp := []*rpcpb.AuthenticateResponse{
+			{AccessToken: "access-token1"},
+			{AccessToken: "access-token2"},
+		}
+		validateTemplateRendering(t, "protoJson.html", resp, `[{"accessToken":"access-token1"},{"accessToken":"access-token2"}]`)
+	})
+
+	t.Run("test template rendering with protoJson non proto.Message", func(t *testing.T) {
+		resp := struct {
+			NameWithSnake string `json:"name_with_snake"`
+			ID            string `json:"-"`
+			OtherName     string
+		}{
+			NameWithSnake: "snake",
+			ID:            "id-will-be-missing",
+			OtherName:     "otherName",
+		}
+		validateTemplateRendering(t, "protoJson.html", resp, `{"OtherName":"otherName","name_with_snake":"snake"}`)
+	})
+}
+
+func TestTemlpateJson(t *testing.T) {
+	t.Run("test template rendering with json with proto.Message", func(t *testing.T) {
+		resp := &rpcpb.AuthenticateResponse{AccessToken: "access-token"}
+		validateTemplateRendering(t, "nonProtoJson.html", resp, `{"access_token":"access-token"}`)
+	})
+
+	t.Run("test template rendering with json with array of proto.Message", func(t *testing.T) {
+		resp := []*rpcpb.AuthenticateResponse{
+			{AccessToken: "access-token1"},
+			{AccessToken: "access-token2"},
+		}
+		validateTemplateRendering(t, "nonProtoJson.html", resp, `[{"access_token":"access-token1"},{"access_token":"access-token2"}]`)
+	})
+
+	t.Run("test template rendering with protoJson non proto.Message", func(t *testing.T) {
+		resp := struct {
+			NameWithSnake string `json:"name_with_snake"`
+			ID            string `json:"-"`
+			OtherName     string
+		}{
+			NameWithSnake: "snake",
+			ID:            "id-will-be-missing",
+			OtherName:     "otherName",
+		}
+		validateTemplateRendering(t, "nonProtoJson.html", resp, `{"name_with_snake":"snake","OtherName":"otherName"}`)
+	})
+}
+
+func validateTemplateRendering(t *testing.T, template string, resp interface{}, expectedBody string) {
+	t.Helper()
+
+	logger := golog.NewTestLogger(t)
+
+	opts := protojson.MarshalingOptions{EnableProtoJSON: true}
+	tm, err := NewTemplateManagerFSWithOptions("testdata/templates", opts)
+	test.That(t, err, test.ShouldBeNil)
+
+	mw := NewTemplateMiddleware(tm, staticHandler(template, resp, nil), logger)
+
+	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	test.That(t, err, test.ShouldBeNil)
+	rr := httptest.NewRecorder()
+
+	mw.ServeHTTP(rr, req)
+
+	test.That(t, rr.Code, test.ShouldEqual, 200)
+	test.That(t, rr.Body.String(), test.ShouldContainSubstring, expectedBody)
+}
+
+func staticHandler(template string, data interface{}, err error) TemplateHandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) (*Template, interface{}, error) {
+		return NamedTemplate(template), data, err
+	}
+}

--- a/web/testdata/templates/nonProtoJson.html
+++ b/web/testdata/templates/nonProtoJson.html
@@ -1,0 +1,3 @@
+<script type="module">
+    window.theData = {{.}};
+</script>

--- a/web/testdata/templates/protoJson.html
+++ b/web/testdata/templates/protoJson.html
@@ -1,0 +1,3 @@
+<script type="module">
+  window.theData = {{protoJson .}};
+</script>


### PR DESCRIPTION
This changes includes a custom json marshaler that wraps the normal json.Marshal and protojson.Marshal. It will determine if the passed in data is a proto.Message or slice of proto.Messages and if so use the protojson.Marshal instead of the json.Marshal. Otherwise it will fallback to json.Marshal()

It also includes a new template function called `protoJson` which uses the custom marshaler. We can use this now in our templates when we pass data to the window that should be serialized with the protjson.