### PR TITLE
Turn off CI npm publishing until bug is fixed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,25 +1,28 @@
-name: NPM Publish
+### Temporarily turned off due to an issue in CI.
+### See: https://github.com/viamrobotics/goutils/actions/runs/3207545693/jobs/5242534039
 
-on:
-  push:
-    branches:
-      - main
+# name: NPM Publish
 
-jobs:
-  publish:
-    runs-on: ubuntu-latest
+# on:
+#   push:
+#     branches:
+#       - main
 
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2.4.0
-        with:
-          persist-credentials: false
+# jobs:
+#   publish:
+#     runs-on: ubuntu-latest
 
-      - name: Install and Build 🔧
-        run: |
-          make build-web
+#     steps:
+#       - name: Checkout 🛎️
+#         uses: actions/checkout@v2.4.0
+#         with:
+#           persist-credentials: false
 
-      - name: Publish 🚀
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }} 
+#       - name: Install and Build 🔧
+#         run: |
+#           make build-web
+
+#       - name: Publish 🚀
+#         uses: JS-DevTools/npm-publish@v1
+#         with:
+#           token: ${{ secrets.NPM_TOKEN }} 


### PR DESCRIPTION
CI publishing of the RPC NPM library isn't working. I'm unsure of what the problem is [but it seems related to the golang linter](https://github.com/viamrobotics/goutils/actions/runs/3207545693/jobs/5242534039). For now I'm disabling the step so that others can produce clean builds with nice green checkmarks.