### PR TITLE
APP-70 Add JSON tags to UserInfo

### DIFF
--- a/web/user.go
+++ b/web/user.go
@@ -9,8 +9,8 @@ import (
 
 // UserInfo basic info about a user from a session.
 type UserInfo struct {
-	LoggedIn   bool
-	Properties map[string]interface{}
+	LoggedIn   bool                   `json:"loggedIn"`
+	Properties map[string]interface{} `json:"properties"`
 }
 
 // GetEmail the email.


### PR DESCRIPTION
Adds JSON tags to the `UserInfo` struct to match standard casing when used in `app`.