### PR TITLE
Changes to support Modular Resources (Includes RSDK-472 )

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -98,6 +98,7 @@ func (p *managedProcess) Start(ctx context.Context) error {
 		// to finish running.
 		//nolint:gosec
 		cmd := exec.CommandContext(ctx, p.name, p.args...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		cmd.Dir = p.cwd
 		var runErr error
 		if p.shouldLog || p.logWriter != nil {
@@ -128,6 +129,7 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	// use the CommandContext variant.
 	//nolint:gosec
 	cmd := exec.Command(p.name, p.args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Dir = p.cwd
 
 	var stdOut, stdErr io.ReadCloser

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -94,10 +94,17 @@ func dial(
 	tryLocal bool,
 ) (ClientConn, bool, error) {
 	var isJustDomain bool
-	if strings.ContainsRune(address, ':') {
-		isJustDomain = false
+	if strings.HasPrefix(address, "unix://") {
+		dOpts.mdnsOptions.Disable = true
+		dOpts.webrtcOpts.Disable = true
+		dOpts.insecure = true
+		dOpts.disableDirect = false
 	} else {
-		isJustDomain = net.ParseIP(address) == nil
+		if strings.ContainsRune(address, ':') {
+			isJustDomain = false
+		} else {
+			isJustDomain = net.ParseIP(address) == nil
+		}
 	}
 
 	if !dOpts.mdnsOptions.Disable && tryLocal && isJustDomain {

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -254,3 +254,12 @@ func WithStreamClientInterceptor(interceptor grpc.StreamClientInterceptor) DialO
 		}
 	})
 }
+
+// WithForceDirectGRPC forces direct dialing first.
+func WithForceDirectGRPC() DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.mdnsOptions.Disable = true
+		o.webrtcOpts.Disable = true
+		o.disableDirect = false
+	})
+}


### PR DESCRIPTION
Two changes needed to support modular resources. (Note, this PR should probably not be merged until the big mod resources PR in RDK is ready to merge, in case other changes are needed here.)

1. This adds support to make a direct connection attempt the primary for unix sockets (and an option to do so for other possible use cases in the future.)

2. It adds Segpgid to ManagedProcess configuration. This prevents background processes spawned from getting foreground signals. For example, without this, hitting CTRL+C on a running viam-server also directly sent that SIGINT to the module. Now it will only be seen by the parent viam-server process, which can then handle stopping the background process/module in a clean way.

3. It switches the pexec final SIGKILL to signal the entire progress group (set above) so that children/grandchildren aren't left running and orphaned. 