### PR TITLE
Add goleak ignore lines for net/http

### DIFF
--- a/leak.go
+++ b/leak.go
@@ -9,5 +9,9 @@ func FindGoroutineLeaks() error {
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 		goleak.IgnoreTopFunction("github.com/desertbit/timer.timerRoutine"),              // gRPC uses this
 		goleak.IgnoreTopFunction("github.com/letsencrypt/pebble/va.VAImpl.processTasks"), // no way to stop it
+
+		// net/http.(*Transport).CloseIdleConnections() doesn't interrupt in-progress connection attempts
+		goleak.IgnoreTopFunction("net.(*netFD).connect.func2"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 	)
 }


### PR DESCRIPTION
Found the leak I was discussing with @edaniels earlier today. In RDK, the artifact system opens a grpc connection to google during VerifyMainTest() but the cache.Close() can only attempt net/http.(*Transport).CloseIdleConnections(). This doesn't interrupt in-progress connections, or yet-to-complete dial attempts, which need a full second or so at times to establish before they can be closed and become idle (and get closed for real.) As such, very short tests can leak two (related) routines while the Transport still has new connections dialing.