### PR TITLE
Add example make recipes to top-level makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,11 @@ cover:
 
 test:
 	go test -tags=no_skip -race ./...
+
+# examples
+
+example-echo/%: build-web
+	$(MAKE) -C rpc/examples/echo $*
+
+example-fileupload/%: build-web
+	$(MAKE) -C rpc/examples/fileupload $*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
 
 This is a set of go utilities you can use via importing `go.viam.com/utils`. 
 
+## Examples
+
+This library includes examples that demonstrate grpc functionality for a variety of contexts - see links for more information:
+* [echo](https://github.com/viamrobotics/goutils/blob/main/rpc/example/echo/README.md)
+* [fileupload](https://github.com/viamrobotics/goutils/blob/main/rpc/example/fileupload/README.md)
+
+As a convenience, you can run the `make` recipes for these examples from the root of this repository via:
+```
+make example-{name}/{recipe}
+```
+
+For example, try running a simple echo server with:
+```
+make example-echo/run-server
+```
+
 ## License 
 Copyright 2021-2022 Viam Inc.
 


### PR DESCRIPTION
Allows example make recipes to be run from the root of this repository.

For example, the echo server can be run via:

```
make example-echo/run-server
```