### PR TITLE
APP-1068 - Add subject and kid support in JWT

### DIFF
--- a/jwks/jwksutils/utils.go
+++ b/jwks/jwksutils/utils.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/lestrrat-go/jwx/jwk"
 	"go.viam.com/test"
 
@@ -38,7 +39,7 @@ func ServeFakeOIDCEndpoint(t *testing.T, keyset jwks.KeySet) (string, func()) {
 		TokenURL:    fmt.Sprintf("%s/oauth/token", baseURL),
 		JWKSURL:     fmt.Sprintf("%s/.well-known/jwks.json", baseURL),
 		UserInfoURL: fmt.Sprintf("%s/userinfo", baseURL),
-		Algorithms:  []string{"HS256", "RS256"},
+		Algorithms:  []string{jwt.SigningMethodRS256.Alg(), jwt.SigningMethodHS256.Alg()},
 	}
 
 	mux.Handle("/.well-known/openid-configuration", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -128,7 +129,7 @@ func NewTestKeySet(numberOfKeys int) (jwks.KeySet, []*rsa.PrivateKey, error) {
 			return nil, nil, err
 		}
 
-		err = jwkKey.Set("alg", "RSA256")
+		err = jwkKey.Set("alg", jwt.SigningMethodRS256.Alg())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -3,7 +3,10 @@ package rpc
 import (
 	"context"
 	"crypto/rsa"
+	//nolint:gosec // using for fingerprint
+	"crypto/sha1"
 	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -227,4 +230,16 @@ const (
 type Credentials struct {
 	Type    CredentialsType `json:"type"`
 	Payload string          `json:"payload"`
+}
+
+// RSAPublicKeyThumbprint returns SHA1 of the public key's modulus Base64 URL encoded without padding.
+func RSAPublicKeyThumbprint(key *rsa.PublicKey) (string, error) {
+	//nolint:gosec // using for fingerprint
+	thumbPrint := sha1.New()
+	_, err := thumbPrint.Write(key.N.Bytes())
+	if err != nil {
+		return "", err
+	}
+
+	return base64.RawURLEncoding.EncodeToString(thumbPrint.Sum(nil)), nil
 }

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -188,3 +188,18 @@ func TestWithPublicKeyProvider(t *testing.T) {
 	})
 	test.That(t, err, test.ShouldBeNil)
 }
+
+func TestRSAPublicKeyThumbprint(t *testing.T) {
+	privKey1, err := rsa.GenerateKey(rand.Reader, 512)
+	test.That(t, err, test.ShouldBeNil)
+
+	privKey2, err := rsa.GenerateKey(rand.Reader, 512)
+	test.That(t, err, test.ShouldBeNil)
+
+	thumbPrint1, err := RSAPublicKeyThumbprint(&privKey1.PublicKey)
+	test.That(t, err, test.ShouldBeNil)
+	thumbPrint2, err := RSAPublicKeyThumbprint(&privKey2.PublicKey)
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, thumbPrint1, test.ShouldNotResemble, thumbPrint2)
+}

--- a/rpc/oauth/testutils/utils.go
+++ b/rpc/oauth/testutils/utils.go
@@ -1,0 +1,40 @@
+// Package testutils contains test helper methods for the rpc/oauth package
+package testutils
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"go.viam.com/utils/rpc"
+)
+
+// SignWebAuthAccessToken returns an access jwt access token typically done by auth0 during access token flow.
+func SignWebAuthAccessToken(key *rsa.PrivateKey, entity, aud, iss, keyID string) (string, error) {
+	token := &jwt.Token{
+		Header: map[string]interface{}{
+			"typ": "JWT",
+			"alg": jwt.SigningMethodRS256.Alg(),
+			"kid": keyID,
+		},
+		Claims: rpc.JWTClaims{
+			RegisteredClaims: jwt.RegisteredClaims{
+				Audience: []string{aud},
+				Issuer:   iss,
+				// in prod this may not be 1:1 to the email. This is usually the user id from auth0. For testing ensure it does not
+				// match the email of the the entity.
+				Subject:  fmt.Sprintf("viam/%s", entity),
+				IssuedAt: jwt.NewNumericDate(time.Now()),
+			},
+			AuthCredentialsType: rpc.CredentialsType("oauth-web-auth"), // avoid circular dependency
+			AuthMetadata: map[string]string{
+				"email": entity,
+			},
+		},
+		Method: jwt.SigningMethodRS256,
+	}
+
+	return token.SignedString(key)
+}

--- a/rpc/server_auth_test.go
+++ b/rpc/server_auth_test.go
@@ -708,3 +708,107 @@ type customClaims struct {
 	JWTClaims
 	CustomClaim string `json:"custom-claim"`
 }
+
+func TestServerAuthToHandler(t *testing.T) {
+	testutils.SkipUnlessInternet(t)
+	logger := golog.NewTestLogger(t)
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 512)
+	test.That(t, err, test.ShouldBeNil)
+	thumbprint, err := RSAPublicKeyThumbprint(&privKey.PublicKey)
+	test.That(t, err, test.ShouldBeNil)
+
+	rpcServer, err := NewServer(
+		logger,
+		WithAuthRSAPrivateKey(privKey),
+		WithAuthHandler("fake", MakeSimpleAuthHandler([]string{"entity1", "entity2"}, "mypayload")),
+		WithAuthenticateToHandler("fake", func(ctx context.Context, entity string) (map[string]string, error) {
+			test.That(t, entity, test.ShouldEqual, "entity2")
+			return map[string]string{"test": "value"}, nil
+		}),
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	echoServer := &echoserver.Server{
+		ContextAuthEntity: MustContextAuthEntity,
+		ContextAuthClaims: func(ctx context.Context) interface{} {
+			return ContextAuthClaims(ctx)
+		},
+		ContextAuthSubject:  MustContextAuthSubject,
+		ExpectedAuthSubject: "entity1",
+	}
+	echoServer.SetAuthorized(true)
+	echoServer.SetExpectedAuthEntity("entity2")
+
+	err = rpcServer.RegisterServiceServer(
+		context.Background(),
+		&pb.EchoService_ServiceDesc,
+		echoServer,
+		pb.RegisterEchoServiceHandlerFromEndpoint,
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	httpListener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- rpcServer.Serve(httpListener)
+	}()
+
+	conn, err := grpc.DialContext(
+		context.Background(),
+		httpListener.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, conn.Close(), test.ShouldBeNil)
+	}()
+
+	// First authenticate using the fake auth handler.
+	authClient := rpcpb.NewAuthServiceClient(conn)
+	authResp, err := authClient.Authenticate(context.Background(), &rpcpb.AuthenticateRequest{
+		Entity: "entity1",
+		Credentials: &rpcpb.Credentials{
+			Type:    "fake",
+			Payload: "mypayload",
+		},
+	},
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	md := make(metadata.MD)
+	md.Set("authorization", fmt.Sprintf("Bearer %s", authResp.AccessToken))
+	authCtx := metadata.NewOutgoingContext(context.Background(), md)
+
+	// Use the credential bearer token from the Authenticate request to the AuthenticateTo the "foo" entity.
+	authToClient := rpcpb.NewExternalAuthServiceClient(conn)
+	authToResp, err := authToClient.AuthenticateTo(authCtx, &rpcpb.AuthenticateToRequest{Entity: "entity2"})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, authToResp.AccessToken, test.ShouldNotBeEmpty)
+
+	// Verify the resulting claims match the expected values.
+	var claims JWTClaims
+	token, err := jwt.ParseWithClaims(authToResp.AccessToken, &claims, func(token *jwt.Token) (interface{}, error) {
+		return &privKey.PublicKey, nil
+	})
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, claims.Subject(), test.ShouldEqual, "entity1")
+	test.That(t, claims.Audience, test.ShouldContain, "entity2")
+	test.That(t, token.Header["kid"], test.ShouldEqual, thumbprint)
+
+	md = make(metadata.MD)
+	md.Set("authorization", fmt.Sprintf("Bearer %s", authToResp.AccessToken))
+	authCtx = metadata.NewOutgoingContext(context.Background(), md)
+
+	client := pb.NewEchoServiceClient(conn)
+	_, err = client.Echo(authCtx, &pb.EchoRequest{Message: "hello"})
+	test.That(t, err, test.ShouldBeNil)
+
+	test.That(t, rpcServer.Stop(), test.ShouldBeNil)
+	err = <-errChan
+	test.That(t, err, test.ShouldBeNil)
+}


### PR DESCRIPTION
Distinguish between `aud` (audience) and `sub` (subject) claims. Audience should generally be used to indicate what the authentication token is used against. While the `sub` indicates who the owner of the token is. Eg. user entity.

By default simple auth handlers and Authenticate request only accept an entity which is used as both the audience and the subject.

However AuthenticateTo now uses the entity of the original Authenticate request as the subject and the audience as the entity its Authenticating To.

Add SHA-1 thumbprint as the `kid` to all JWTs created by the RPC framework.

Background on JWT claim usage: See: https://www.rfc-editor.org/rfc/rfc7519#section-4.1

[4.1.2](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.2).  "sub" (Subject) Claim

   The "sub" (subject) claim identifies the principal that is the
   subject of the JWT.  The claims in a JWT are normally statements
   about the subject.  The subject value MUST either be scoped to be
   locally unique in the context of the issuer or be globally unique.
   The processing of this claim is generally application specific.  The
   "sub" value is a case-sensitive string containing a StringOrURI
   value.  Use of this claim is OPTIONAL.

[4.1.3](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3).  "aud" (Audience) Claim

   The "aud" (audience) claim identifies the recipients that the JWT is
   intended for.  Each principal intended to process the JWT MUST
   identify itself with a value in the audience claim.  If the principal
   processing the claim does not identify itself with a value in the
   "aud" claim when this claim is present, then the JWT MUST be
   rejected.  In the general case, the "aud" value is an array of case-
   sensitive strings, each containing a StringOrURI value.  In the
   special case when the JWT has one audience, the "aud" value MAY be a
   single case-sensitive string containing a StringOrURI value.  The
   interpretation of audience values is generally application specific.
   Use of this claim is OPTIONAL.