### PR TITLE
Dial support for external auth with static credentials

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -124,7 +124,7 @@ func dial(
 			// This path is also called by an mdns direct connection and ignores that case.
 			// This will skip all Authenticate/AuthenticateTo calls for the signaler.
 			if !dOpts.usingMDNS && dOpts.authMaterial == "" && dOpts.webrtcOpts.SignalingExternalAuthAuthMaterial != "" {
-				logger.Debugw("using singaling's external auth as auth material")
+				logger.Debug("using signaling's external auth as auth material")
 				dOpts.authMaterial = dOpts.webrtcOpts.SignalingExternalAuthAuthMaterial
 				dOpts.creds = Credentials{}
 			}

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -114,28 +114,20 @@ func dial(
 				// try WebRTC at same address
 				signalingAddress = address
 			}
-
-			var target string
-			var port uint16
-			if strings.Contains(signalingAddress, ":") {
-				host, portStr, err := net.SplitHostPort(signalingAddress)
-				if err != nil {
-					return nil, false, err
-				}
-				if strings.Contains(host, ":") {
-					host = fmt.Sprintf("[%s]", host)
-				}
-				target = host
-				portParsed, err := strconv.ParseUint(portStr, 10, 16)
-				if err != nil {
-					return nil, false, err
-				}
-				port = uint16(portParsed)
-			} else {
-				target = signalingAddress
-				port = 443
+			target, port, err := getWebRTCTargetFromAddressWithDefaults(signalingAddress)
+			if err != nil {
+				return nil, false, err
 			}
 			fixupWebRTCOptions(dOpts, target, port)
+
+			// When connecting to an external signaler for WebRTC, we assume we can use the external auth's material.
+			// This path is also called by an mdns direct connection and ignores that case.
+			// This will skip all Authenticate/AuthenticateTo calls for the signaler.
+			if !dOpts.usingMDNS && dOpts.authMaterial == "" && dOpts.webrtcOpts.SignalingExternalAuthAuthMaterial != "" {
+				logger.Debugw("using singaling's external auth as auth material")
+				dOpts.authMaterial = dOpts.webrtcOpts.SignalingExternalAuthAuthMaterial
+				dOpts.creds = Credentials{}
+			}
 		}
 
 		if dOpts.debug {
@@ -240,10 +232,18 @@ func dialMulticastDNS(
 	}
 
 	dOptsCopy := *dOpts
+
+	// Let downstream calls know when mdns was used. This is helpful to inform
+	// when determining if we want to use the external auth credentials for the signaling
+	// in cases where the external signaling is the same as the external auth. For mdns
+	// this isn't the case.
+	dOptsCopy.usingMDNS = true
+
 	if dOptsCopy.mdnsOptions.RemoveAuthCredentials {
 		dOptsCopy.creds = Credentials{}
 		dOptsCopy.authEntity = ""
 		dOptsCopy.externalAuthToEntity = ""
+		dOptsCopy.externalAuthMaterial = ""
 	}
 
 	if hasWebRTC {
@@ -251,13 +251,14 @@ func dialMulticastDNS(
 		if dOptsCopy.mdnsOptions.RemoveAuthCredentials {
 			dOptsCopy.webrtcOpts.SignalingAuthEntity = ""
 			dOptsCopy.webrtcOpts.SignalingCreds = Credentials{}
+			dOptsCopy.webrtcOpts.SignalingExternalAuthAuthMaterial = ""
 		}
 	} else {
 		dOptsCopy.webrtcOpts.Disable = true
 	}
 	var tlsConfig *tls.Config
 	if dOptsCopy.tlsConfig == nil {
-		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		tlsConfig = newDefaultTLSConfig()
 	} else {
 		tlsConfig = dOptsCopy.tlsConfig.Clone()
 	}
@@ -293,6 +294,9 @@ func fixupWebRTCOptions(dOpts *dialOptions, target string, port uint16) {
 	if dOpts.webrtcOpts.SignalingExternalAuthToEntity == "" {
 		dOpts.webrtcOpts.SignalingExternalAuthToEntity = dOpts.externalAuthToEntity
 	}
+	if dOpts.webrtcOpts.SignalingExternalAuthAuthMaterial == "" {
+		dOpts.webrtcOpts.SignalingExternalAuthAuthMaterial = dOpts.externalAuthMaterial
+	}
 
 	// It's always okay to pass over entity and credentials since next section
 	// will assume secure settings based on public internet or not.
@@ -310,4 +314,27 @@ func fixupWebRTCOptions(dOpts *dialOptions, target string, port uint16) {
 	if dOpts.webrtcOpts.SignalingCreds.Type == "" {
 		dOpts.webrtcOpts.SignalingCreds = dOpts.creds
 	}
+}
+
+func getWebRTCTargetFromAddressWithDefaults(signalingAddress string) (target string, port uint16, err error) {
+	if strings.Contains(signalingAddress, ":") {
+		host, portStr, err := net.SplitHostPort(signalingAddress)
+		if err != nil {
+			return "", 0, err
+		}
+		if strings.Contains(host, ":") {
+			host = fmt.Sprintf("[%s]", host)
+		}
+		target = host
+		portParsed, err := strconv.ParseUint(portStr, 10, 16)
+		if err != nil {
+			return "", 0, err
+		}
+		port = uint16(portParsed)
+	} else {
+		target = signalingAddress
+		port = 443
+	}
+
+	return target, port, nil
 }

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -41,7 +41,11 @@ type dialOptions struct {
 	externalAuthAddr     string
 	externalAuthToEntity string
 	externalAuthInsecure bool
+	// static auth material used when an external auth service is used. This is also used for the signaler
+	// when the webrtc options are empty. See fixupWebRTCOptions.
+	externalAuthMaterial string
 
+	// static auth material used when directly connecting to the endpoint. If set all externalAuth options are ignored.
 	authMaterial string
 
 	// debug is helpful to turn on when the library isn't working quite right.
@@ -49,6 +53,8 @@ type dialOptions struct {
 	debug bool
 
 	mdnsOptions DialMulticastDNSOptions
+	// set when the connection is using mdns flow.
+	usingMDNS bool
 
 	disableDirect bool
 
@@ -159,6 +165,17 @@ func WithStaticAuthenticationMaterial(authMaterial string) DialOption {
 		o.authEntity = ""
 		o.creds = Credentials{}
 		o.authMaterial = authMaterial
+	})
+}
+
+// WithStaticExternalAuthenticationMaterial returns a DialOption which sets the already authenticated
+// material (opaque) to use for authenticated requests against an external auth service. Ignored if
+// WithStaticAuthenticationMaterial() is set.
+func WithStaticExternalAuthenticationMaterial(authMaterial string) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.authEntity = ""
+		o.creds = Credentials{}
+		o.externalAuthMaterial = authMaterial
 	})
 }
 

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -58,6 +58,11 @@ type DialWebRTCOptions struct {
 	// SignalingCreds are used to authenticate the request to the signaling server.
 	SignalingCreds Credentials
 
+	// SignalingExternalAuthAuthMaterial is used when the credentials for the signaler
+	// have already been used to exchange an auth payload. In those cases this can be set
+	// to bypass the Authenticate/AuthenticateTo rpc auth flow.
+	SignalingExternalAuthAuthMaterial string
+
 	// DisableTrickleICE controls whether to disable Trickle ICE or not.
 	// Disabling Trickle ICE can slow down connection establishment.
 	DisableTrickleICE bool
@@ -120,6 +125,9 @@ func dialWebRTC(
 	dOptsCopy.externalAuthAddr = dOpts.webrtcOpts.SignalingExternalAuthAddress
 	dOptsCopy.externalAuthToEntity = dOpts.webrtcOpts.SignalingExternalAuthToEntity
 	dOptsCopy.externalAuthInsecure = dOpts.webrtcOpts.SignalingExternalAuthInsecure
+	dOptsCopy.externalAuthMaterial = dOpts.webrtcOpts.SignalingExternalAuthAuthMaterial
+
+	// ignore AuthEntity when auth material is available.
 	if dOptsCopy.authEntity == "" {
 		if dOptsCopy.externalAuthAddr == "" {
 			// if we are not doing external auth, then the entity is assumed to be the actual host.
@@ -144,7 +152,7 @@ func dialWebRTC(
 		err = multierr.Combine(err, conn.Close())
 	}()
 
-	logger.Debug("connected")
+	logger.Debugw("connected", "host", host)
 
 	md := metadata.New(map[string]string{RPCHostMetadataField: host})
 	signalCtx := metadata.NewOutgoingContext(dialCtx, md)


### PR DESCRIPTION
- Support external auth with a static credential.
- Smart enough to figure out that when an external auth / signaler is used vs a local signaler when on mdns.