### PR TITLE
RSDK-1660 - Fix deadlock in cachedDialer

### DIFF
--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -141,7 +141,7 @@ func (cd *cachedDialer) DialFunc(
 func (cd *cachedDialer) Close() error {
 	cd.mu.Lock()
 	// need a copy of cd.conns as we can't hold the lock, since .Close() fires the onUnref() set (above) in DialFunc()
-	// that uses the same lock and directly modifies cd.conns when the dialer is reused at different layers (e.g. auth)
+	// that uses the same lock and directly modifies cd.conns when the dialer is reused at different layers (e.g. auth and multi)
 	var conns []*refCountedConnWrapper
 	for _, c := range cd.conns {
 		conns = append(conns, c)

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -140,8 +140,8 @@ func (cd *cachedDialer) DialFunc(
 
 func (cd *cachedDialer) Close() error {
 	cd.mu.Lock()
-	// need a copy of cd.conns as we can't hold the lock, since .Close() fires the onUnref()
-	// which uses the same lock and directly modifies cd.conns
+	// need a copy of cd.conns as we can't hold the lock, since .Close() fires the onUnref() set (above) in DialFunc()
+	// that uses the same lock and directly modifies cd.conns when the dialer is reused at different layers (e.g. auth)
 	var conns []*refCountedConnWrapper
 	for _, c := range cd.conns {
 		conns = append(conns, c)

--- a/rpc/dialer_test.go
+++ b/rpc/dialer_test.go
@@ -148,6 +148,44 @@ func TestCachedDialer(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
+// this replicates the deadlock in RSDK-1660.
+func TestCachedDialerDeadlock(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	rpcServer, err := NewServer(
+		logger,
+		WithAuthHandler(CredentialsTypeAPIKey, MakeSimpleAuthHandler([]string{"foo"}, "bar")),
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	httpListener, err := net.Listen("tcp", "localhost:0")
+	test.That(t, err, test.ShouldBeNil)
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- rpcServer.Serve(httpListener)
+	}()
+
+	cachedDialer := NewCachedDialer()
+	ctx := ContextWithDialer(context.Background(), cachedDialer)
+
+	_, err = Dial(
+		ctx,
+		httpListener.Addr().String(),
+		logger,
+		WithInsecure(),
+		WithDialDebug(),
+		WithEntityCredentials("foo", Credentials{Type: CredentialsTypeAPIKey, Payload: "bar"}),
+	)
+	test.That(t, err, test.ShouldBeNil)
+
+	// this would previously hang on lock contention
+	test.That(t, cachedDialer.Close(), test.ShouldBeNil)
+
+	test.That(t, rpcServer.Stop(), test.ShouldBeNil)
+	err = <-errChan
+	test.That(t, err, test.ShouldBeNil)
+}
+
 func TestReffedConn(t *testing.T) {
 	tracking := &closeReffedConn{}
 	wrapper := newRefCountedConnWrapper("proto", tracking, nil)

--- a/rpc/dialer_test.go
+++ b/rpc/dialer_test.go
@@ -148,7 +148,6 @@ func TestCachedDialer(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
-// this replicates the deadlock in RSDK-1660.
 func TestCachedDialerDeadlock(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	rpcServer, err := NewServer(
@@ -168,6 +167,8 @@ func TestCachedDialerDeadlock(t *testing.T) {
 	cachedDialer := NewCachedDialer()
 	ctx := ContextWithDialer(context.Background(), cachedDialer)
 
+	// leave connection open that will come from "multi" which ends up referring to a cached
+	// WebRTC or gRPC Direct connection.
 	_, err = Dial(
 		ctx,
 		httpListener.Addr().String(),
@@ -178,7 +179,6 @@ func TestCachedDialerDeadlock(t *testing.T) {
 	)
 	test.That(t, err, test.ShouldBeNil)
 
-	// this would previously hang on lock contention
 	test.That(t, cachedDialer.Close(), test.ShouldBeNil)
 
 	test.That(t, rpcServer.Stop(), test.ShouldBeNil)


### PR DESCRIPTION
Comments inline to explain, but tl;dr is lock contention. The cachedDialer can be put into the context, and thus gets reused by various dial functions. Dialing with Auth, for example, reuses the dialer from different layers, resulting in the possibility of nested refCountedConnWrapper and thus, deadlock on Close.

Note: RDK needs to be bumped with this update after this merges.