### PR TITLE
APP-1153 - Support using access token with external auth in JS

### DIFF
--- a/rpc/examples/echo/Makefile
+++ b/rpc/examples/echo/Makefile
@@ -42,6 +42,23 @@ run-server-auth-external: build setup-auth
 		-tls-key=${ROOT_DIR}/etc/test_keys/localhost/key.pem \
 		-external-auth 8081
 
+run-server-auth-with-access-token: build setup-auth
+	go run server/cmd/main.go -instance-name=echo-server-external -api-key=supersecretkeyohmy \
+		-auth-private-key=${ROOT_DIR}/etc/test_keys/pkcs8.key \
+		-tls-cert=${ROOT_DIR}/etc/test_keys/localhost/cert.pem \
+		-tls-key=${ROOT_DIR}/etc/test_keys/localhost/key.pem \
+		-use-access-token
+
+run-server-auth-with-external-access-token: build setup-auth
+	go run server/cmd/main.go -instance-name=echo-server-external -api-key=supersecretkeyohmy \
+		-auth-private-key=${ROOT_DIR}/etc/test_keys/pkcs8.key \
+		-auth-public-key=${ROOT_DIR}/etc/test_keys/public-key.pem \
+		-tls-cert=${ROOT_DIR}/etc/test_keys/localhost/cert.pem \
+		-tls-key=${ROOT_DIR}/etc/test_keys/localhost/key.pem \
+		-use-access-token \
+		-external-auth-addr=https://localhost:8081 \
+		-external-auth 8081
+
 run-server-auth-internal-as-external: build setup-auth
 	go run server/cmd/main.go -instance-name=echo-server -api-key=supersecretkeyohmy \
 		-auth-public-key=${ROOT_DIR}/etc/test_keys/public-key.pem \

--- a/rpc/examples/echo/frontend/src/index.ts
+++ b/rpc/examples/echo/frontend/src/index.ts
@@ -12,29 +12,39 @@ declare global {
 		creds?: Credentials;
 		externalAuthAddr?: string;
 		externalAuthToEntity?: string;
+		accessToken?: string;
 	}
 }
 
 async function getClients() {
 	const webrtcHost = window.webrtcHost;
 	const opts: DialOptions = {
-		credentials: window.creds,
 		externalAuthAddress: window.externalAuthAddr,
 		externalAuthToEntity: window.externalAuthToEntity,
 		webrtcOptions: {
 			disableTrickleICE: false,
-			signalingCredentials: window.creds,
 		}
 	};
+
+	if (!window.accessToken) {
+		opts.credentials = window.creds;
+		opts.webrtcOptions!.signalingCredentials = window.creds;
+	} else {
+		opts.accessToken = window.accessToken;
+	}
+
 	if (opts.externalAuthAddress) {
-		// we are authenticating against the external address and then
-		// we will authenticate for externalAuthToEntity.
-		opts.authEntity = opts.externalAuthAddress.replace(/^(.*:\/\/)/, '');
+		if (!window.accessToken) {
+			// we are authenticating against the external address and then
+			// we will authenticate for externalAuthToEntity.
+			opts.authEntity = opts.externalAuthAddress.replace(/^(.*:\/\/)/, '');
+		}
 
 		// do similar for WebRTC
 		opts.webrtcOptions!.signalingExternalAuthAddress = opts.externalAuthAddress;
 		opts.webrtcOptions!.signalingExternalAuthToEntity = opts.externalAuthToEntity;
 	}
+
 	console.log("WebRTC")
 	const webRTCConn = await dialWebRTC(thisHost, webrtcHost, opts);
 	const webrtcClient = new EchoServiceClient(webrtcHost, { transport: webRTCConn.transportFactory });

--- a/rpc/examples/echo/server/templates/index.html
+++ b/rpc/examples/echo/server/templates/index.html
@@ -9,6 +9,7 @@
       window.creds = {{ .Credentials }}
       window.externalAuthAddr = {{ .ExternalAuthAddr }}
       window.externalAuthToEntity = {{ .ExternalAuthToEntity }}
+      window.accessToken = {{ .AccessToken }}
     </script>
     <script src="./static/main.js"></script>
   </head>


### PR DESCRIPTION
JS RPC library updated to allow authToAddress and authToEntity with accessToken set in the dial options. This will force the accessToken to be used for the AuthenticateTo request but use the returned access token in signaling or direct rpc calls.

If authTo options are omitted while an accessToken is present all Authenticate/AuthenticateTo calls will be bypassed.