### PR TITLE
fix: Allow 10m for a user to login through google/auth0

### DIFF
--- a/web/auth0.go
+++ b/web/auth0.go
@@ -118,7 +118,10 @@ type callbackHandler struct {
 	logger golog.Logger
 }
 
-const auth0RedirectStateCookieName = "auth0_redirect_state"
+const (
+	auth0RedirectStateCookieName   = "auth0_redirect_state"
+	auth0RedirectStateCookieMaxAge = time.Second * 60
+)
 
 func (h *callbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -320,7 +323,7 @@ func (h *loginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Name:     auth0RedirectStateCookieName,
 		Value:    fmt.Sprintf("%s:%s", session.id, state),
 		Path:     "/",
-		MaxAge:   60,
+		MaxAge:   int(auth0RedirectStateCookieMaxAge.Seconds()),
 		Secure:   r.TLS != nil,
 		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,


### PR DESCRIPTION
Currently it is set at 1 minute which does not give enough time to some users. Users may get side tracked during the login flow or take a while to sign up with google + two factor login.

This increases the time to 10m.

However we should also gracefully handle the error in a further fix like redirecting to the /login handler again.