### PR TITLE
[RSDK-1676] Replace . with - when advertising robot over mdns.

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -224,7 +224,7 @@ func dialMulticastDNS(
 	}
 	// lookup for candidates for backward compatibility
 	entry, err := candidateLookup(ctx, candidates)
-	if err != nil {
+	if err != nil || entry == nil {
 		return nil, false, err
 	}
 	var hasGRPC, hasWebRTC bool

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -220,7 +220,7 @@ func dialMulticastDNS(
 				return entry, nil
 			}
 		}
-		return nil, errors.New("exhausted mDNS candidates")
+		return nil, ctx.Err()
 	}
 	// lookup for candidates for backward compatibility
 	entry, err := candidateLookup(ctx, candidates)

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -220,15 +220,12 @@ func dialMulticastDNS(
 				return entry, nil
 			}
 		}
-		return nil, nil
+		return nil, errors.New("exhausted mDNS candidates")
 	}
 	// lookup for candidates for backward compatibility
 	entry, err := candidateLookup(ctx, candidates)
 	if err != nil {
 		return nil, false, err
-	}
-	if entry == nil {
-		return nil, false, ctx.Err()
 	}
 	var hasGRPC, hasWebRTC bool
 	for _, field := range entry.Text {

--- a/rpc/dial_test.go
+++ b/rpc/dial_test.go
@@ -1162,7 +1162,6 @@ func TestDialMulticastDNS(t *testing.T) {
 		test.That(t, rpcServer.Start(), test.ShouldBeNil)
 		test.That(t, rpcServer.InstanceNames(), test.ShouldHaveLength, 1)
 
-
 		conn, err := Dial(
 			context.Background(),
 			rpcServer.InstanceNames()[0],
@@ -1172,7 +1171,6 @@ func TestDialMulticastDNS(t *testing.T) {
 		)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
-
 
 		conn, err = Dial(
 			context.Background(),

--- a/rpc/dial_test.go
+++ b/rpc/dial_test.go
@@ -1162,7 +1162,7 @@ func TestDialMulticastDNS(t *testing.T) {
 		test.That(t, rpcServer.Start(), test.ShouldBeNil)
 		test.That(t, rpcServer.InstanceNames(), test.ShouldHaveLength, 1)
 
-		//test old instance name : this.is.a.test.cloud._rpc._tcp.local
+
 		conn, err := Dial(
 			context.Background(),
 			rpcServer.InstanceNames()[0],
@@ -1173,7 +1173,7 @@ func TestDialMulticastDNS(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 
-		//test fixed instance name : this-is-a-test-cloud._rpc._tcp.local
+
 		conn, err = Dial(
 			context.Background(),
 			strings.ReplaceAll(rpcServer.InstanceNames()[0], ".", "-"),
@@ -1184,7 +1184,6 @@ func TestDialMulticastDNS(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, conn.Close(), test.ShouldBeNil)
 		test.That(t, rpcServer.Stop(), test.ShouldBeNil)
-
 	})
 
 	t.Run("unauthenticated", func(t *testing.T) {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -413,35 +413,41 @@ func NewServer(logger golog.Logger, opts ...ServerOption) (Server, error) {
 				break
 			}
 			for _, host := range instanceNames {
-				mdnsServer, err := zeroconf.RegisterProxy(
-					host,
-					"_rpc._tcp",
-					"local.",
-					mDNSAddress.Port,
-					hostname,
-					[]string{"127.0.0.1"},
-					supportedServices,
-					[]net.Interface{loopbackIfc},
-				)
-				if err != nil {
-					return nil, err
+				hosts := []string{host, strings.ReplaceAll(host, ".", "-")}
+				for _, host := range hosts {
+					mdnsServer, err := zeroconf.RegisterProxy(
+						host,
+						"_rpc._tcp",
+						"local.",
+						mDNSAddress.Port,
+						hostname,
+						[]string{"127.0.0.1"},
+						supportedServices,
+						[]net.Interface{loopbackIfc},
+					)
+					if err != nil {
+						return nil, err
+					}
+					server.mdnsServers = append(server.mdnsServers, mdnsServer)
 				}
-				server.mdnsServers = append(server.mdnsServers, mdnsServer)
 			}
 		} else {
 			for _, host := range instanceNames {
-				mdnsServer, err := zeroconf.RegisterDynamic(
-					host,
-					"_rpc._tcp",
-					"local.",
-					mDNSAddress.Port,
-					supportedServices,
-					nil,
-				)
-				if err != nil {
-					return nil, err
+				hosts := []string{host, strings.ReplaceAll(host, ".", "-")}
+				for _, host := range hosts {
+					mdnsServer, err := zeroconf.RegisterDynamic(
+						host,
+						"_rpc._tcp",
+						"local.",
+						mDNSAddress.Port,
+						supportedServices,
+						nil,
+					)
+					if err != nil {
+						return nil, err
+					}
+					server.mdnsServers = append(server.mdnsServers, mdnsServer)
 				}
-				server.mdnsServers = append(server.mdnsServers, mdnsServer)
 			}
 		}
 	}


### PR DESCRIPTION
This PR replace any  '.' in robot's fqdn or local_fqdn with '-' ('.' are not skipped properly when sending the advertisement packets therefore violating mDNS RFC) . The robot's mDNS records can now be properly parsed by other mDNS discovery tools, the robot can also question record from other implementation (mini-rdk) properly
The former service advertisement is kept for backward compatibility.

