### PR TITLE
pexec: better support windows

### DIFF
--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -1,0 +1,117 @@
+//go:build linux || darwin
+
+package pexec
+
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func sigStr(sig syscall.Signal) string {
+	//nolint:exhaustive
+	switch sig {
+	case syscall.SIGHUP:
+		return "SIGHUP"
+	case syscall.SIGINT:
+		return "SIGINT"
+	case syscall.SIGQUIT:
+		return "SIGQUIT"
+	case syscall.SIGABRT:
+		return "SIGABRT"
+	case syscall.SIGUSR1:
+		return "SIGUSR1"
+	case syscall.SIGUSR2:
+		return "SIGUSR2"
+	case syscall.SIGTERM:
+		return "SIGTERM"
+	default:
+		return "<UNKNOWN>"
+	}
+}
+
+var knownSignals = []syscall.Signal{
+	syscall.SIGHUP,
+	syscall.SIGINT,
+	syscall.SIGQUIT,
+	syscall.SIGABRT,
+	syscall.SIGUSR1,
+	syscall.SIGUSR2,
+	syscall.SIGTERM,
+}
+
+func parseSignal(sigStr, name string) (syscall.Signal, error) {
+	switch sigStr {
+	case "":
+		return 0, nil
+	case "HUP", "SIGHUP", "hangup", "1":
+		return syscall.SIGHUP, nil
+	case "INT", "SIGINT", "interrupt", "2":
+		return syscall.SIGINT, nil
+	case "QUIT", "SIGQUIT", "quit", "3":
+		return syscall.SIGQUIT, nil
+	case "ABRT", "SIGABRT", "aborted", "abort", "6":
+		return syscall.SIGABRT, nil
+	case "KILL", "SIGKILL", "killed", "kill", "9":
+		return syscall.SIGKILL, nil
+	case "TERM", "SIGTERM", "terminated", "terminate", "15":
+		return syscall.SIGTERM, nil
+	default:
+		return 0, errors.Errorf("unknown %q name", sigStr)
+	}
+}
+
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+func (p *managedProcess) kill() (bool, error) {
+	p.logger.Infof("stopping process %d with signal %s", p.cmd.Process.Pid, p.stopSig)
+	// First let's try to directly signal the process.
+	if err := p.cmd.Process.Signal(p.stopSig); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return false, errors.Wrapf(err, "error signaling process %d with signal %s", p.cmd.Process.Pid, p.stopSig)
+	}
+
+	// In case the process didn't stop, or left behind any orphan children in its process group,
+	// we now send a signal to everything in the process group after a brief wait.
+	timer := time.NewTimer(p.stopWaitInterval)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		p.logger.Infof("stopping entire process group %d with signal %s", p.cmd.Process.Pid, p.stopSig)
+		if err := syscall.Kill(-p.cmd.Process.Pid, p.stopSig); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return false, errors.Wrapf(err, "error signaling process group %d with signal %s", p.cmd.Process.Pid, p.stopSig)
+		}
+	case <-p.managingCh:
+		timer.Stop()
+	}
+
+	// Lastly, kill everything in the process group that remains after a longer wait
+	var forceKilled bool
+	timer2 := time.NewTimer(p.stopWaitInterval * 2)
+	defer timer2.Stop()
+	select {
+	case <-timer2.C:
+		p.logger.Infof("killing entire process group %d", p.cmd.Process.Pid)
+		if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return false, errors.Wrapf(err, "error killing process group %d", p.cmd.Process.Pid)
+		}
+		forceKilled = true
+	case <-p.managingCh:
+		timer2.Stop()
+	}
+
+	return forceKilled, nil
+}
+
+func isWaitErrUnknown(err string, forceKilled bool) bool {
+	// This can easily happen if the process does not handle interrupts gracefully
+	// and it won't provide us any exit code info.
+	switch err {
+	case "signal: interrupt", "signal: terminated", "signal: killed":
+		return true
+	}
+	return false
+}

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -1,0 +1,109 @@
+//go:build windows
+
+package pexec
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func sigStr(sig syscall.Signal) string {
+	return "<UNKNOWN>"
+}
+
+var knownSignals []syscall.Signal = nil
+
+func parseSignal(sigStr, name string) (syscall.Signal, error) {
+	if sigStr == "" {
+		return 0, nil
+	}
+	return 0, errors.New("signals not supported on Windows")
+}
+
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func (p *managedProcess) kill() (bool, error) {
+	const mustForce = "This process can only be terminated forcefully"
+	pidStr := strconv.Itoa(p.cmd.Process.Pid)
+	p.logger.Infof("killing process %d", p.cmd.Process.Pid)
+	// First let's try to ask the process to stop. If it's a console application, this is
+	// very unlikely to work.
+	var shouldJustForce bool
+	if out, err := exec.Command("taskkill", "/pid", pidStr).CombinedOutput(); err != nil {
+		switch {
+		case strings.Contains(string(out), mustForce):
+			p.logger.Debug("must force terminate process")
+			shouldJustForce = true
+		case strings.Contains(string(out), "not found"):
+			return false, nil
+		default:
+			return false, errors.Wrapf(err, "error killing process %d", p.cmd.Process.Pid)
+		}
+	}
+
+	if !shouldJustForce {
+		// In case the process didn't stop, or left behind any orphan children in its process group,
+		// we now ask everything in the process tree to stop after a brief wait.
+		timer := time.NewTimer(p.stopWaitInterval)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			p.logger.Infof("killing entire process tree %d", p.cmd.Process.Pid)
+			if out, err := exec.Command("taskkill", "/t", "/pid", pidStr).CombinedOutput(); err != nil {
+				switch {
+				case strings.Contains(string(out), mustForce):
+					p.logger.Debug("must force terminate process tree")
+					shouldJustForce = true
+				case strings.Contains(string(out), "not found"):
+					return false, nil
+				default:
+					return false, errors.Wrapf(err, "error killing process tree %d", p.cmd.Process.Pid)
+				}
+			}
+		case <-p.managingCh:
+			timer.Stop()
+		}
+	}
+
+	// Lastly, kill everything in the process tree that remains after a longer wait or now. This is
+	// going to likely result in an "exit status 1" that we will have to interpret.
+	// FUTURE(erd): find a way to do this better. Research has not come up with much and is
+	// program dependent.
+	var forceKilled bool
+	if !shouldJustForce {
+		timer2 := time.NewTimer(p.stopWaitInterval * 2)
+		defer timer2.Stop()
+		select {
+		case <-timer2.C:
+			p.logger.Infof("force killing entire process tree %d", p.cmd.Process.Pid)
+			if err := exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Run(); err != nil {
+				return false, errors.Wrapf(err, "error force killing process tree %d", p.cmd.Process.Pid)
+			}
+			forceKilled = true
+		case <-p.managingCh:
+			timer2.Stop()
+		}
+	} else {
+		if err := exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Run(); err != nil {
+			return false, errors.Wrapf(err, "error force killing process tree %d", p.cmd.Process.Pid)
+		}
+		forceKilled = true
+	}
+
+	return forceKilled, nil
+}
+
+func isWaitErrUnknown(err string, forceKilled bool) bool {
+	if !forceKilled {
+		return false
+	}
+	// when we force kill, it's very easy to get 1.
+	return err == "exit status 1"
+}

--- a/pexec/process_test.go
+++ b/pexec/process_test.go
@@ -3,6 +3,7 @@ package pexec
 import (
 	"bytes"
 	"encoding/json"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -25,7 +26,17 @@ func TestProcessConfigRoundTripJSON(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	var rt ProcessConfig
-	test.That(t, json.Unmarshal(md, &rt), test.ShouldBeNil)
+	err = json.Unmarshal(md, &rt)
+	if runtime.GOOS == "windows" {
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "not supported")
+
+		config.StopSignal = 0
+		md, err = json.Marshal(config)
+		test.That(t, err, test.ShouldBeNil)
+	} else {
+		test.That(t, err, test.ShouldBeNil)
+	}
 	test.That(t, rt, test.ShouldResemble, config)
 
 	var rtLower ProcessConfig

--- a/pexec/verify_main_test.go
+++ b/pexec/verify_main_test.go
@@ -1,6 +1,9 @@
 package pexec
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"testing"
 
 	testutilsext "go.viam.com/utils/testutils/ext"
@@ -8,5 +11,9 @@ import (
 
 // TestMain is used to control the execution of all tests run within this package (including _test packages).
 func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to find bash for testing: %v", err)
+		os.Exit(1)
+	}
 	testutilsext.VerifyTestMain(m)
 }

--- a/testutils/file.go
+++ b/testutils/file.go
@@ -29,3 +29,13 @@ func TempDir(dir, pattern string) (string, error) {
 	}
 	return dir, err
 }
+
+// TempFile returns a new unique temporary file using the given name.
+func TempFile(t *testing.T, name string) *os.File {
+	t.Helper()
+	tempFile := filepath.Join(t.TempDir(), name)
+	//nolint:gosec
+	f, err := os.Create(tempFile)
+	test.That(t, err, test.ShouldBeNil)
+	return f
+}


### PR DESCRIPTION
I'll add a runner later to support this but need to deal with other issues first. Essentially, killing in Windows is very hard without signals and a custom made binary.