### PR TITLE
fix: increase redirect cookie max age to 10m

### DIFF
--- a/web/auth0.go
+++ b/web/auth0.go
@@ -120,7 +120,7 @@ type callbackHandler struct {
 
 const (
 	auth0RedirectStateCookieName   = "auth0_redirect_state"
-	auth0RedirectStateCookieMaxAge = time.Second * 60
+	auth0RedirectStateCookieMaxAge = time.Minute * 10
 )
 
 func (h *callbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
So somehow i didn't actually update the max age of the cookie when i submitted https://github.com/viamrobotics/goutils/pull/126/files i just refactored it :(