### PR TITLE
Github Actions tests pass on skipped

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check Results
         run: |
           echo Main Tests: ${{ needs.build_and_test.result }}
-          [ "${{ needs.build_and_test.result }}" == "success" ]
+          [ "${{ needs.build_and_test.result }}" == "success" || "${{ needs.build_and_test.result }}" == "skipped" ]
 
   build_and_test:
     name: Build and Test


### PR DESCRIPTION
See https://github.com/viamrobotics/goutils/actions/runs/4137170424/jobs/7152865166#step:2:40

This issue is causing a failure in my PR https://github.com/viamrobotics/goutils/pull/136. `build_and_test` is `skipped`. `"skipped" != "success"`. Therefore, `test_passing` fails.

Edit: It's actually causing the same failure here. Not sure if there's a way to just push this through.
