### PR TITLE
Allow for Lax Session Cookie.

### DIFF
--- a/web/sessions.go
+++ b/web/sessions.go
@@ -106,7 +106,7 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, r *http.Request, w 
 		Path:     "/",
 		MaxAge:   -1,
 		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,
 	})
 
@@ -139,7 +139,7 @@ func (s *Session) Save(ctx context.Context, r *http.Request, w http.ResponseWrit
 			Path:     "/",
 			MaxAge:   86400 * 7,
 			Secure:   r.TLS != nil,
-			SameSite: http.SameSiteStrictMode,
+			SameSite: http.SameSiteLaxMode,
 			HttpOnly: true,
 		})
 		s.isNew = false


### PR DESCRIPTION
- Allows being able to link from external web page to Viam.com and have auth work. Still protects against most CSRF assuming GET requests has no affect on system.