### PR TITLE
RSDK-236 RSDK-248 - rpc: use single changestream per mongoDBWebRTCCallQueue

### DIFF
--- a/perf/metrics.go
+++ b/perf/metrics.go
@@ -17,6 +17,5 @@ func registerApplicationViews() error {
 	return multierr.Combine(
 		registerGrpcViews(),
 		registerHTTPViews(),
-		registerMongoDBViews(),
 	)
 }

--- a/perf/mongodb.go
+++ b/perf/mongodb.go
@@ -14,11 +14,6 @@ import (
 	"go.viam.com/utils/perf/statz/units"
 )
 
-func registerMongoDBViews() error {
-	// TODO(erd): add views
-	return nil
-}
-
 // from https://github.com/entropyx/mongo-opencensus
 
 type config struct {

--- a/rpc/dial_test.go
+++ b/rpc/dial_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/edaniels/golog"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/multierr"
@@ -45,7 +46,7 @@ func TestDialWithMongoDBQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
+	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
 	testDial(t, signalingCallQueue, logger)
 	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)

--- a/rpc/dial_test.go
+++ b/rpc/dial_test.go
@@ -38,8 +38,10 @@ func TestDialWithMemoryQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	signalingCallQueue := NewMemoryWebRTCCallQueue(logger)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testDial(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 func TestDialWithMongoDBQueue(t *testing.T) {
@@ -48,8 +50,10 @@ func TestDialWithMongoDBQueue(t *testing.T) {
 	client := testutils.BackingMongoDBClient(t)
 	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testDial(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 //nolint:thelper

--- a/rpc/wrtc_call_queue.go
+++ b/rpc/wrtc_call_queue.go
@@ -43,7 +43,7 @@ func setDefaultOfferDeadline(deafultOfferDeadline time.Duration) func() {
 type WebRTCCallQueue interface {
 	// SendOfferInit initializes an offer associated with the given SDP to the given host.
 	// It returns a UUID to track/authenticate the offer over time, a channel receive offer updates
-	// on over time, and a cancel func to stop inform the sender to stop.
+	// on over time, and a cancel func to inform the sender to stop.
 	SendOfferInit(ctx context.Context, host, sdp string, disableTrickle bool) (
 		uuid string, respCh <-chan WebRTCCallAnswer, respDone <-chan struct{}, cancel func(), err error)
 

--- a/rpc/wrtc_call_queue_memory_test.go
+++ b/rpc/wrtc_call_queue_memory_test.go
@@ -8,8 +8,12 @@ import (
 )
 
 func TestMemoryWebRTCCallQueue(t *testing.T) {
-	logger := golog.NewTestLogger(t)
-	callQueue := NewMemoryWebRTCCallQueue(logger)
-	testWebRTCCallQueue(t, callQueue)
-	test.That(t, callQueue.Close(), test.ShouldBeNil)
+	testWebRTCCallQueue(t, func(t *testing.T) (WebRTCCallQueue, WebRTCCallQueue, func()) {
+		t.Helper()
+		logger := golog.NewTestLogger(t)
+		callQueue := NewMemoryWebRTCCallQueue(logger)
+		return callQueue, callQueue, func() {
+			test.That(t, callQueue.Close(), test.ShouldBeNil)
+		}
+	})
 }

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -582,9 +582,13 @@ func (queue *mongoDBWebRTCCallQueue) processNextSubscriptionEvent(next mongoutil
 			}
 			event := mongodbCallEvent{Call: callResp}
 			for answerChan := range answerChans {
-				// we will send on this channel just once and it will eventually
+				// We will send on this channel just once and it will eventually
 				// unsubscribe. We are not concerned with looping over channels
-				// we have already sent once on.
+				// we have already sent once on. For rationale behind this,
+				// look at the comments in RecvOffer around using events. Briefly
+				// though, we want to send the events as fast as possible as mentioned
+				// above and cannot block on the send to see if the receiver locked
+				// the document.
 				if answerChan.Send(event) {
 					return
 				}

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -32,7 +32,7 @@ func init() {
 
 var (
 	callChangeStreamFailures = statz.NewCounter1[string]("rpc.webrtc/call_change_stream_failures", statz.MetricConfig{
-		Description: "The number of failures making a change stream to listen to calls.",
+		Description: "The number of times making a change stream fails.",
 		Unit:        units.Dimensionless,
 		Labels: []statz.Label{
 			{Name: "operator_id", Description: "The queue operator ID."},
@@ -324,8 +324,8 @@ const (
 	operatorHeartbeatWindow     = time.Second * 10
 )
 
-// The operatorLivenessLoop keeps the distributed queue aware of this operator is existence in
-// addition to the hosts its listening to calls for in order to keep track of eventually
+// The operatorLivenessLoop keeps the distributed queue aware of this operator's existence, in
+// addition to the hosts its listening to calls for, in order to keep track of eventually
 // consistent queue maximums.
 func (queue *mongoDBWebRTCCallQueue) operatorLivenessLoop() {
 	ticker := time.NewTicker(operatorStateUpdateInterval)
@@ -572,7 +572,8 @@ func (queue *mongoDBWebRTCCallQueue) processNextSubscriptionEvent(next mongoutil
 
 		if next.Event.OperationType == mongoutils.ChangeEventOperationTypeInsert {
 			if _, ok := queue.csTrackingHosts[callResp.Host]; !ok {
-				// not interestsed in this
+				// no one connected to this operator is currently subscribed to insert
+				// events for this host; skip
 				return
 			}
 			answerChans := queue.waitingForNewCallSubs[callResp.Host]

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1068,8 +1068,8 @@ func (queue *mongoDBWebRTCCallQueue) RecvOffer(ctx context.Context, hosts []stri
 						return false, nil
 					}
 
-					// Someone else took it; take it from the top. you would
-					// expect you can just keep receiving on events but since
+					// Someone else took it; take it from the top. You would
+					// expect you can just keep receiving on events, but since
 					// the underlying change stream is shared and we do not
 					// want to block often while delivering new calls, we use
 					// buffered channels to deliver events meaning once this
@@ -1081,10 +1081,10 @@ func (queue *mongoDBWebRTCCallQueue) RecvOffer(ctx context.Context, hosts []stri
 					// gets dropped for the reasons just mentioned. That means
 					// we need to subscribe once more but more importantly,
 					// run the findOneAndUpdate again. If each caller/answerer
-					// had their own change streaming, the buffering would be
-					// done on the MongoDB side but that has its own performance
-					// downsides that were explored in previous versions of this
-					// code.
+					// had their own change streams, the buffering would be
+					// done on the MongoDB database side but that has its own
+					// performance downsides that were explored in previous versions
+					// of this code.
 					return true, nil
 				}
 			}

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1032,7 +1032,7 @@ func (queue *mongoDBWebRTCCallQueue) RecvOffer(ctx context.Context, hosts []stri
 		err = result.Decode(&callReq)
 		if err != nil {
 			if !errors.Is(err, mongo.ErrNoDocuments) {
-				return callReq, false, err
+				return mongodbWebRTCCall{}, false, err
 			}
 			getFirstResult := func() (bool, error) {
 				if err := recvOfferCtx.Err(); err != nil {

--- a/rpc/wrtc_call_queue_mongodb_test.go
+++ b/rpc/wrtc_call_queue_mongodb_test.go
@@ -3,19 +3,125 @@ package rpc
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/edaniels/golog"
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.viam.com/test"
 
 	"go.viam.com/utils/testutils"
 )
 
 func TestMongoDBWebRTCCallQueue(t *testing.T) {
-	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	callQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
-	test.That(t, err, test.ShouldBeNil)
 
-	testWebRTCCallQueue(t, callQueue)
-	test.That(t, callQueue.Close(), test.ShouldBeNil)
+	testWebRTCCallQueue(t, func(t *testing.T) (WebRTCCallQueue, WebRTCCallQueue, func()) {
+		t.Helper()
+		logger := golog.NewTestLogger(t)
+		callQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
+		test.That(t, err, test.ShouldBeNil)
+		return callQueue, callQueue, func() {
+			test.That(t, callQueue.Close(), test.ShouldBeNil)
+		}
+	})
+}
+
+func TestMongoDBWebRTCCallQueueMulti(t *testing.T) {
+	client := testutils.BackingMongoDBClient(t)
+
+	const maxCallerQueueSize = 3
+	setupQueues := func(t *testing.T) (WebRTCCallQueue, WebRTCCallQueue, func()) {
+		t.Helper()
+		logger := golog.NewTestLogger(t)
+		callerQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString()+"-caller", maxCallerQueueSize, client, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		answererQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString()+"-answerer", maxCallerQueueSize, client, logger)
+		test.That(t, err, test.ShouldBeNil)
+		return callerQueue, answererQueue, func() {
+			test.That(t, callerQueue.Close(), test.ShouldBeNil)
+			test.That(t, answererQueue.Close(), test.ShouldBeNil)
+		}
+	}
+
+	testWebRTCCallQueue(t, setupQueues)
+
+	t.Run("max queue size", func(t *testing.T) {
+		callerQueue, answererQueue, teardown := setupQueues(t)
+		defer teardown()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		host := primitive.NewObjectID().Hex()
+
+		type offerState struct {
+			Done   <-chan struct{}
+			Cancel func()
+		}
+		offers := make([]offerState, 0, maxCallerQueueSize)
+		defer func() {
+			for _, offer := range offers {
+				offer.Cancel()
+				<-offer.Done
+			}
+		}()
+
+		t.Logf("start up %d callers (the max)", maxCallerQueueSize)
+		for i := 0; i < maxCallerQueueSize; i++ {
+			_, _, respDone, cancel, err := callerQueue.SendOfferInit(ctx, host, "somesdp", false)
+			test.That(t, err, test.ShouldBeNil)
+			offers = append(offers, offerState{Done: respDone, Cancel: cancel})
+			time.Sleep(2 * time.Second)
+		}
+
+		t.Logf("the next caller should fail from either queue")
+		_, _, _, _, err := callerQueue.SendOfferInit(ctx, host, "somesdp", false)
+		test.That(t, err, test.ShouldResemble, errTooManyConns)
+		_, _, _, _, err = answererQueue.SendOfferInit(ctx, host, "somesdp", false)
+		test.That(t, err, test.ShouldResemble, errTooManyConns)
+
+		t.Logf("but canceling one should allow the next")
+		offers[0].Cancel()
+		<-offers[0].Done
+
+		time.Sleep(2 * time.Second)
+
+		_, _, respDone, cancel, err := callerQueue.SendOfferInit(ctx, host, "somesdp", false)
+		test.That(t, err, test.ShouldBeNil)
+		offers[0] = offerState{Done: respDone, Cancel: cancel}
+
+		exchanges := make([]WebRTCCallOfferExchange, 0, maxHostAnswerersSize)
+		defer func() {
+			for _, exchange := range exchanges {
+				test.That(t, exchange.AnswererDone(ctx), test.ShouldBeNil)
+				<-exchange.CallerDone()
+			}
+		}()
+
+		t.Logf("start up %d answerers (the max)", maxHostAnswerersSize)
+		for i := 0; i < maxHostAnswerersSize; i++ {
+			exchange, err := answererQueue.RecvOffer(ctx, []string{host})
+			test.That(t, err, test.ShouldBeNil)
+			exchanges = append(exchanges, exchange)
+		}
+
+		time.Sleep(2 * time.Second)
+
+		t.Logf("the next answerer should fail from either queue")
+		_, err = answererQueue.RecvOffer(ctx, []string{host})
+		test.That(t, err, test.ShouldResemble, errTooManyConns)
+		_, err = callerQueue.RecvOffer(ctx, []string{host})
+		test.That(t, err, test.ShouldResemble, errTooManyConns)
+
+		t.Logf("but canceling one should allow the next")
+		test.That(t, exchanges[0].AnswererDone(ctx), test.ShouldBeNil)
+		<-exchanges[0].CallerDone()
+
+		time.Sleep(2 * time.Second)
+
+		exchange, err := answererQueue.RecvOffer(ctx, []string{host})
+		test.That(t, err, test.ShouldBeNil)
+		exchanges[0] = exchange
+	})
 }

--- a/rpc/wrtc_client_test.go
+++ b/rpc/wrtc_client_test.go
@@ -311,6 +311,8 @@ func TestWebRTCClientDialConcurrentWithMongoDBQueue(t *testing.T) {
 	testWebRTCClientDialConcurrent(t, signalingCallQueue, logger)
 }
 
+// this is a good integration test against mongoDBWebRTCCallQueue
+//
 //nolint:thelper
 func testWebRTCClientDialConcurrent(t *testing.T, signalingCallQueue WebRTCCallQueue, logger golog.Logger) {
 	signalingServer := NewWebRTCSignalingServer(signalingCallQueue, nil, logger)
@@ -345,6 +347,7 @@ func testWebRTCClientDialConcurrent(t *testing.T, signalingCallQueue WebRTCCallQ
 
 	dialErrCh := make(chan error, 2)
 	go func() {
+		t.Log("starting dial 1")
 		cc, err := DialWebRTC(
 			context.Background(),
 			grpcListener.Addr().String(),
@@ -360,6 +363,7 @@ func testWebRTCClientDialConcurrent(t *testing.T, signalingCallQueue WebRTCCallQ
 		dialErrCh <- err
 	}()
 	go func() {
+		t.Log("starting dial 2")
 		cc, err := DialWebRTC(
 			context.Background(),
 			grpcListener.Addr().String(),
@@ -375,9 +379,11 @@ func testWebRTCClientDialConcurrent(t *testing.T, signalingCallQueue WebRTCCallQ
 		dialErrCh <- err
 	}()
 
+	t.Log("answer client 1 is receiving")
 	offer1, err := answerClient1.Recv()
 	test.That(t, err, test.ShouldBeNil)
 
+	t.Log("answer client 2 is receiving")
 	offer2, err := answerClient2.Recv()
 	test.That(t, err, test.ShouldBeNil)
 

--- a/rpc/wrtc_client_test.go
+++ b/rpc/wrtc_client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/edaniels/golog"
+	"github.com/google/uuid"
 	"github.com/pion/webrtc/v3"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.viam.com/test"
@@ -34,7 +35,7 @@ func TestWebRTCClientServerWithMongoDBQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
+	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
 	testWebRTCClientServer(t, signalingCallQueue, logger)
 	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
@@ -121,7 +122,7 @@ func TestWebRTCClientDialCancelWithMongoDBQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
+	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
 	testWebRTCClientDialCancel(t, signalingCallQueue, logger)
 	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
@@ -202,7 +203,7 @@ func TestWebRTCClientDialReflectAnswererErrorWithMongoDBQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
+	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
 	testWebRTCClientDialReflectAnswererError(t, signalingCallQueue, logger)
 	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
@@ -288,7 +289,7 @@ func TestWebRTCClientDialConcurrentWithMongoDBQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
+	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
 	testWebRTCClientDialConcurrent(t, signalingCallQueue, logger)
 	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
@@ -416,7 +417,7 @@ func TestWebRTCClientAnswerConcurrentWithMongoDBQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
+	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
 	testWebRTCClientAnswerConcurrent(t, signalingCallQueue, logger)
 	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)

--- a/rpc/wrtc_client_test.go
+++ b/rpc/wrtc_client_test.go
@@ -27,8 +27,10 @@ func TestWebRTCClientServerWithMemoryQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	signalingCallQueue := NewMemoryWebRTCCallQueue(logger)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientServer(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 func TestWebRTCClientServerWithMongoDBQueue(t *testing.T) {
@@ -37,8 +39,10 @@ func TestWebRTCClientServerWithMongoDBQueue(t *testing.T) {
 	client := testutils.BackingMongoDBClient(t)
 	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientServer(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 //nolint:thelper
@@ -114,8 +118,10 @@ func TestWebRTCClientDialCancelWithMemoryQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	signalingCallQueue := NewMemoryWebRTCCallQueue(logger)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientDialCancel(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 func TestWebRTCClientDialCancelWithMongoDBQueue(t *testing.T) {
@@ -124,8 +130,10 @@ func TestWebRTCClientDialCancelWithMongoDBQueue(t *testing.T) {
 	client := testutils.BackingMongoDBClient(t)
 	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientDialCancel(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 //nolint:thelper
@@ -195,8 +203,10 @@ func TestWebRTCClientDialReflectAnswererErrorWithMemoryQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	signalingCallQueue := NewMemoryWebRTCCallQueue(logger)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientDialReflectAnswererError(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 func TestWebRTCClientDialReflectAnswererErrorWithMongoDBQueue(t *testing.T) {
@@ -205,8 +215,10 @@ func TestWebRTCClientDialReflectAnswererErrorWithMongoDBQueue(t *testing.T) {
 	client := testutils.BackingMongoDBClient(t)
 	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientDialReflectAnswererError(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 //nolint:thelper
@@ -281,8 +293,10 @@ func TestWebRTCClientDialConcurrentWithMemoryQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	signalingCallQueue := NewMemoryWebRTCCallQueue(logger)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientDialConcurrent(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 func TestWebRTCClientDialConcurrentWithMongoDBQueue(t *testing.T) {
@@ -291,8 +305,10 @@ func TestWebRTCClientDialConcurrentWithMongoDBQueue(t *testing.T) {
 	client := testutils.BackingMongoDBClient(t)
 	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientDialConcurrent(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 //nolint:thelper
@@ -409,8 +425,10 @@ func TestWebRTCClientAnswerConcurrentWithMemoryQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	signalingCallQueue := NewMemoryWebRTCCallQueue(logger)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientAnswerConcurrent(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 func TestWebRTCClientAnswerConcurrentWithMongoDBQueue(t *testing.T) {
@@ -419,8 +437,10 @@ func TestWebRTCClientAnswerConcurrentWithMongoDBQueue(t *testing.T) {
 	client := testutils.BackingMongoDBClient(t)
 	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCClientAnswerConcurrent(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 //nolint:thelper

--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/edaniels/golog"
+	"github.com/google/uuid"
 	"github.com/pion/webrtc/v3"
 	"go.viam.com/test"
 	"google.golang.org/grpc"
@@ -31,7 +32,7 @@ func TestWebRTCSignalingWithMongoDBQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	client := testutils.BackingMongoDBClient(t)
-	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), client, logger)
+	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
 	testWebRTCSignaling(t, signalingCallQueue, logger)
 	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)

--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -24,8 +24,10 @@ func TestWebRTCSignalingWithMemoryQueue(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	signalingCallQueue := NewMemoryWebRTCCallQueue(logger)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCSignaling(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 func TestWebRTCSignalingWithMongoDBQueue(t *testing.T) {
@@ -34,8 +36,10 @@ func TestWebRTCSignalingWithMongoDBQueue(t *testing.T) {
 	client := testutils.BackingMongoDBClient(t)
 	signalingCallQueue, err := NewMongoDBWebRTCCallQueue(context.Background(), uuid.NewString(), 50, client, logger)
 	test.That(t, err, test.ShouldBeNil)
+	defer func() {
+		test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
+	}()
 	testWebRTCSignaling(t, signalingCallQueue, logger)
-	test.That(t, signalingCallQueue.Close(), test.ShouldBeNil)
 }
 
 //nolint:thelper


### PR DESCRIPTION
This improvement has been a long time coming. This makes using the MongoDB queue much more efficient while also adding in some nice soft-limits.