### PR TITLE
Use npm publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install, Build, and Publish
-        run: |
-          make build-web
-          cd rpc/js
-          npm install -g @jsdevtools/npm-publish
-          npm-publish --token=${{ secrets.NPM_TOKEN }}
+      - name: Install Build
+        run: make build-web
+
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: rpc/js


### PR DESCRIPTION
This will make publishes consistent with our other JS repos. By default this gracefully aborts if there is no JS version bump (as opposed to https://github.com/viamrobotics/goutils/commit/90cacc93efe0c62ceae13fd718960d1a8c043595)