### PR TITLE
Use npm publish action v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         run: make build-web
 
       - name: Publish
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: rpc/js
+          package: rpc/js/package.json


### PR DESCRIPTION
Ran into an issue similar [to this one](https://github.com/JS-DevTools/npm-publish/issues/78), and seems like the advice is to upgrade to the v2 action. 

I also updated config to point to the package.json file instead of just the sub-directory (seems like either should work based on the docs but [the advice to specify the `package.json` file is a bit more explicit](https://github.com/JS-DevTools/npm-publish#usage-1))