### PR TITLE
Revert "RSDK-2425 Add OnUnexpectedExit to managed processes"

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -53,7 +53,6 @@ func NewManagedProcess(config ProcessConfig, logger golog.Logger) ManagedProcess
 		cwd:              config.CWD,
 		oneShot:          config.OneShot,
 		shouldLog:        config.Log,
-		onUnexpectedExit: config.OnUnexpectedExit,
 		managingCh:       make(chan struct{}),
 		killCh:           make(chan struct{}),
 		stopSig:          config.StopSignal,
@@ -75,7 +74,6 @@ type managedProcess struct {
 	cmd       *exec.Cmd
 
 	stopped          bool
-	onUnexpectedExit func(int) bool
 	managingCh       chan struct{}
 	killCh           chan struct{}
 	stopSig          syscall.Signal
@@ -175,13 +173,12 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	return nil
 }
 
-// manage is the watchdog of the process. If the process has ended
-// unexpectedly, onUnexpectedExit will be called. If onUnexpectedExit is unset
-// or returns true, manage will restart the process. Note that onUnexpectedExit
-// may be called multiple times if it returns true. It's possible and okay for
-// a restart to be in progress while a Stop is happening. As a means of
-// simplifying implementation, a restart spawns new goroutines by calling Start
-// again and lets the original goroutine die off.
+// manage is the watchdog of the process. Any time it detects
+// the process has ended unexpectedly, it will restart it. It's
+// possible and okay for a restart to be in progress while a Stop
+// is happening. As a means simplifying implementation, a restart
+// spawns new goroutines by calling Start again and lets the original
+// goroutine die off.
 func (p *managedProcess) manage(stdOut, stdErr io.ReadCloser) {
 	// If no restart is going to happen after this function exits,
 	// then we want to notify anyone listening that this process
@@ -266,13 +263,6 @@ func (p *managedProcess) manage(stdOut, stdErr io.ReadCloser) {
 	case <-p.killCh:
 		return
 	default:
-	}
-
-	// Run onUnexpectedExit if it exists. Do not attempt restart if
-	// onUnexpectedExit returns false.
-	if p.onUnexpectedExit != nil &&
-		!p.onUnexpectedExit(p.cmd.ProcessState.ExitCode()) {
-		return
 	}
 
 	// Otherwise, let's try restarting the process.

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -30,12 +30,6 @@ type ProcessConfig struct {
 	LogWriter   io.Writer
 	StopSignal  syscall.Signal
 	StopTimeout time.Duration
-	// OnUnexpectedExit will be called when the manage goroutine detects an
-	// unexpected exit of the process. The exit code of the crashed process will
-	// be passed in. If the returned bool is true, the manage goroutine will
-	// attempt to restart the process. Otherwise, the manage goroutine will
-	// simply return.
-	OnUnexpectedExit func(int) bool
 }
 
 // Validate ensures all parts of the config are valid.
@@ -78,7 +72,6 @@ func (config *ProcessConfig) UnmarshalJSON(data []byte) error {
 		CWD:     temp.CWD,
 		OneShot: temp.OneShot,
 		Log:     temp.Log,
-		// OnUnexpectedExit cannot be specified in JSON.
 	}
 
 	if temp.StopTimeout != "" {
@@ -113,7 +106,6 @@ func (config ProcessConfig) MarshalJSON() ([]byte, error) {
 		Log:         config.Log,
 		StopSignal:  stopSig,
 		StopTimeout: config.StopTimeout.String(),
-		// OnUnexpectedExit cannot be converted to JSON.
 	}
 	return json.Marshal(temp)
 }


### PR DESCRIPTION
Reverts viamrobotics/goutils#155

Reverting as this change causes issues when reflection is used to marshal `OnUnexpectedExit` within `ProcessConfig`.