### PR TITLE
RSDK-2425 Add OnUnexpectedExit to managed processes (redo)

### DIFF
--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -113,6 +114,22 @@ func TestManagedProcessStart(t *testing.T) {
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 1")
 		})
+		t.Run("OnUnexpectedExit is ignored", func(t *testing.T) {
+			logger := golog.NewTestLogger(t)
+
+			tempFile := testutils.TempFile(t, "something.txt")
+			defer tempFile.Close()
+			proc := NewManagedProcess(ProcessConfig{
+				Name:             "bash",
+				Args:             []string{"-c", "exit 1"},
+				OneShot:          true,
+				Log:              true,
+				OnUnexpectedExit: func(int) bool { panic("this should not panic") },
+			}, logger)
+			err := proc.Start(context.Background())
+			test.That(t, err, test.ShouldNotBeNil)
+			test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 1")
+		})
 	})
 	t.Run("Managed", func(t *testing.T) {
 		t.Run("starting with a canceled context should have no effect", func(t *testing.T) {
@@ -188,6 +205,43 @@ func TestManagedProcessManage(t *testing.T) {
 		<-watcher.Events
 
 		err = proc.Stop()
+		// sometimes we simply cannot get the status
+		if err != nil {
+			test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 1")
+		}
+	})
+	t.Run("OnUnexpectedExit", func(t *testing.T) {
+		logger := golog.NewTestLogger(t)
+
+		onUnexpectedExitCalledEnough := make(chan struct{})
+		var (
+			onUnexpectedExitCallCount atomic.Uint64
+			receivedExitCode          atomic.Int64
+		)
+		proc := NewManagedProcess(ProcessConfig{
+			Name: "bash",
+			Args: []string{"-c", "exit 1"},
+			OnUnexpectedExit: func(exitCode int) bool {
+				receivedExitCode.Store(int64(exitCode))
+
+				// Close channel and return false (no restart) after 5 restarts.
+				// Further calls to this function will cause a double close panic, so
+				// we can be sure function is called only 5 times.
+				if onUnexpectedExitCallCount.Add(1) >= 5 {
+					close(onUnexpectedExitCalledEnough)
+					return false
+				}
+				return true
+			},
+		}, logger)
+		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
+
+		<-onUnexpectedExitCalledEnough
+		test.That(t, onUnexpectedExitCallCount.Load(), test.ShouldEqual, 5)
+		// Assert that last received exit code was 1 from 'exit 1'.
+		test.That(t, receivedExitCode.Load(), test.ShouldEqual, 1)
+
+		err := proc.Stop()
 		// sometimes we simply cannot get the status
 		if err != nil {
 			test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 1")
@@ -463,6 +517,33 @@ done`, tempFile.Name()))
 		test.That(t, countTerms(tempFile1), test.ShouldEqual, 1)
 		test.That(t, countTerms(tempFile2), test.ShouldEqual, 1)
 		test.That(t, countTerms(tempFile3), test.ShouldEqual, 2)
+	})
+	t.Run("stop does not call OnUnexpectedExit", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("cannot test this on windows")
+		}
+		logger := golog.NewTestLogger(t)
+
+		tempFile := testutils.TempFile(t, "something.txt")
+		defer tempFile.Close()
+
+		watcher1, err := fsnotify.NewWatcher()
+		test.That(t, err, test.ShouldBeNil)
+		defer watcher1.Close()
+		watcher1.Add(tempFile.Name())
+
+		proc := NewManagedProcess(ProcessConfig{
+			Name: "bash",
+			Args: []string{
+				"-c",
+				fmt.Sprintf("while true; do echo hello >> '%s'; sleep 1; done", tempFile.Name()),
+			},
+			StopTimeout:      time.Second * 5,
+			OnUnexpectedExit: func(int) bool { panic("this should not panic") },
+		}, logger)
+		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
+		<-watcher1.Events
+		test.That(t, proc.Stop(), test.ShouldBeNil)
 	})
 }
 

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -30,6 +30,12 @@ type ProcessConfig struct {
 	LogWriter   io.Writer
 	StopSignal  syscall.Signal
 	StopTimeout time.Duration
+	// OnUnexpectedExit will be called when the manage goroutine detects an
+	// unexpected exit of the process. The exit code of the crashed process will
+	// be passed in. If the returned bool is true, the manage goroutine will
+	// attempt to restart the process. Otherwise, the manage goroutine will
+	// simply return.
+	OnUnexpectedExit func(int) bool
 }
 
 // Validate ensures all parts of the config are valid.
@@ -72,6 +78,7 @@ func (config *ProcessConfig) UnmarshalJSON(data []byte) error {
 		CWD:     temp.CWD,
 		OneShot: temp.OneShot,
 		Log:     temp.Log,
+		// OnUnexpectedExit cannot be specified in JSON.
 	}
 
 	if temp.StopTimeout != "" {
@@ -106,6 +113,7 @@ func (config ProcessConfig) MarshalJSON() ([]byte, error) {
 		Log:         config.Log,
 		StopSignal:  stopSig,
 		StopTimeout: config.StopTimeout.String(),
+		// OnUnexpectedExit cannot be converted to JSON.
 	}
 	return json.Marshal(temp)
 }

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -35,7 +35,10 @@ type ProcessConfig struct {
 	// be passed in. If the returned bool is true, the manage goroutine will
 	// attempt to restart the process. Otherwise, the manage goroutine will
 	// simply return.
-	OnUnexpectedExit func(int) bool
+	//
+	// NOTE(benjirewis): use `jsonschema:"-"` struct tag to avoid issues with
+	// jsonschema reflection (go functions cannot be encoded to JSON).
+	OnUnexpectedExit func(int) bool `jsonschema:"-"`
 }
 
 // Validate ensures all parts of the config are valid.


### PR DESCRIPTION
[RSDK-2425](https://viam.atlassian.net/browse/RSDK-2425)

Same as #155, but with `jsonschema:"-"` on `OnUnexpectedExit` to avoid panics when trying to reflect the schema of `ProcessConfig` (functions cannot be encoded to JSON).

[RSDK-2425]: https://viam.atlassian.net/browse/RSDK-2425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cc @sbal13 