### PR TITLE
RSDK-2545 Allow fail-through for mDNS

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -429,24 +429,26 @@ func NewServer(logger golog.Logger, opts ...ServerOption) (Server, error) {
 				loopbackIfc = ifc
 				break
 			}
-			for _, host := range instanceNames {
-				hosts := []string{host, strings.ReplaceAll(host, ".", "-")}
-				for _, host := range hosts {
-					mdnsServer, err := zeroconf.RegisterProxy(
-						host,
-						"_rpc._tcp",
-						"local.",
-						mDNSAddress.Port,
-						hostname,
-						[]string{"127.0.0.1"},
-						supportedServices,
-						[]net.Interface{loopbackIfc},
-						logger,
-					)
-					if err != nil {
-						return nil, err
+			if loopbackIfc.Index > 0 {
+				for _, host := range instanceNames {
+					hosts := []string{host, strings.ReplaceAll(host, ".", "-")}
+					for _, host := range hosts {
+						mdnsServer, err := zeroconf.RegisterProxy(
+							host,
+							"_rpc._tcp",
+							"local.",
+							mDNSAddress.Port,
+							hostname,
+							[]string{"127.0.0.1"},
+							supportedServices,
+							[]net.Interface{loopbackIfc},
+							logger,
+						)
+						if err != nil {
+							return nil, err
+						}
+						server.mdnsServers = append(server.mdnsServers, mdnsServer)
 					}
-					server.mdnsServers = append(server.mdnsServers, mdnsServer)
 				}
 			}
 		} else {


### PR DESCRIPTION
This covers a case where the loopback adapter doesn't support multicast, such as in some docker containers (usually cross-architecture emulation.)