### PR TITLE
APP-1218: Adding unauth option for health check

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -44,6 +44,8 @@ import (
 const (
 	generatedRSAKeyBits = 4096
 	mDNSerr             = "mDNS setup failed; continuing with mDNS disabled"
+	healthCheckMethod   = "/grpc.health.v1.Health/Check"
+	healthWatchMethod   = "/grpc.health.v1.Health/Watch"
 )
 
 // A Server provides a convenient way to get a gRPC server up and running
@@ -364,6 +366,11 @@ func NewServer(logger golog.Logger, opts ...ServerOption) (Server, error) {
 		}
 		// Update this if the proto method or path changes
 		server.exemptMethods["/proto.rpc.v1.AuthService/Authenticate"] = true
+	}
+
+	if sOpts.allowUnauthenticatedHealthCheck {
+		server.exemptMethods[healthCheckMethod] = true
+		server.exemptMethods[healthWatchMethod] = true
 	}
 
 	if sOpts.authToHandler != nil {

--- a/rpc/server_options.go
+++ b/rpc/server_options.go
@@ -30,6 +30,9 @@ type serverOptions struct {
 	// unauthenticated determines if requests should be authenticated.
 	unauthenticated bool
 
+	// allowUnauthenticatedHealthCheck allows the server to have an unauthenticated healthcheck endpoint
+	allowUnauthenticatedHealthCheck bool
+
 	// authRSAPrivateKey is used to sign JWTs for authentication
 	authRSAPrivateKey *rsa.PrivateKey
 
@@ -419,6 +422,15 @@ func WithUnknownServiceHandler(streamHandler grpc.StreamHandler) ServerOption {
 func WithStatsHandler(handler stats.Handler) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) error {
 		o.statsHandler = handler
+		return nil
+	})
+}
+
+// WithAllowUnauthenticatedHealthCheck returns a server option that
+// allows the health check to be unauthenticated.
+func WithAllowUnauthenticatedHealthCheck() ServerOption {
+	return newFuncServerOption(func(o *serverOptions) error {
+		o.allowUnauthenticatedHealthCheck = true
 		return nil
 	})
 }


### PR DESCRIPTION
We want to add a health check to grpc for deployment. To do so, we need to bypass the authentication methods required for the rest of the app. 

This is part of 3 prs that will need to be merged, but this is the first:
https://github.com/viamrobotics/api/pull/258


