### PR TITLE
rpc: mitigate some client close error races

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -759,35 +759,36 @@ func (ss *simpleServer) Stop() error {
 	}
 	ss.stopped = true
 	var err error
+	ss.logger.Info("stopping")
+	for idx, answerer := range ss.webrtcAnswerers {
+		ss.logger.Debugw("stopping WebRTC answerer", "num", idx)
+		answerer.Stop()
+		ss.logger.Debugw("WebRTC answerer stopped", "num", idx)
+	}
 	if ss.signalingServer != nil {
 		ss.signalingServer.Close()
 	}
 	if ss.signalingCallQueue != nil {
 		err = multierr.Combine(err, ss.signalingCallQueue.Close())
 	}
-	ss.logger.Info("stopping server")
+	ss.logger.Debug("stopping gRPC server")
 	defer ss.grpcServer.Stop()
-	ss.logger.Info("canceling service servers for gateway")
+	ss.logger.Debug("canceling service servers for gateway")
 	for _, cancel := range ss.serviceServerCancels {
 		cancel()
 	}
-	ss.logger.Info("service servers for gateway canceled")
-	for idx, answerer := range ss.webrtcAnswerers {
-		ss.logger.Infow("stopping WebRTC answerer", "num", idx)
-		answerer.Stop()
-		ss.logger.Infow("WebRTC answerer stopped", "num", idx)
-	}
+	ss.logger.Debug("service servers for gateway canceled")
 	if ss.webrtcServer != nil {
-		ss.logger.Info("stopping WebRTC server")
+		ss.logger.Debug("stopping WebRTC server")
 		ss.webrtcServer.Stop()
-		ss.logger.Info("WebRTC server stopped")
+		ss.logger.Debug("WebRTC server stopped")
 	}
 	for _, mdnsServer := range ss.mdnsServers {
 		mdnsServer.Shutdown()
 	}
-	ss.logger.Info("shutting down HTTP server")
+	ss.logger.Debug("shutting down HTTP server")
 	err = multierr.Combine(err, ss.httpServer.Shutdown(context.Background()))
-	ss.logger.Info("HTTP server shut down")
+	ss.logger.Debug("HTTP server shut down")
 	ss.activeBackgroundWorkers.Wait()
 	ss.logger.Info("stopped cleanly")
 	return err

--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -144,11 +144,11 @@ func (ch *webrtcBaseChannel) closeWithReason(err error) error {
 	ch.closedReason = err
 	ch.cancel()
 	ch.bufferWriteCond.Broadcast()
-	ch.activeBackgroundWorkers.Wait()
 	return ch.peerConn.Close()
 }
 
 func (ch *webrtcBaseChannel) Close() error {
+	defer ch.activeBackgroundWorkers.Wait()
 	return ch.closeWithReason(nil)
 }
 

--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -203,7 +203,6 @@ func (ch *webrtcBaseChannel) write(msg proto.Message) error {
 		ch.bufferWriteCond.L.Unlock()
 		break
 	}
-
 	if err := ch.dataChannel.Send(data); err != nil {
 		if strings.Contains(err.Error(), "sending payload data in non-established state") {
 			return io.ErrClosedPipe

--- a/rpc/wrtc_client_channel_test.go
+++ b/rpc/wrtc_client_channel_test.go
@@ -364,7 +364,7 @@ func TestWebRTCClientChannelResetStream(t *testing.T) {
 						Data: someStatusMd,
 						Eom:  true,
 					},
-					Eos: true,
+					Eos: false,
 				},
 			},
 		},
@@ -407,7 +407,10 @@ func TestWebRTCClientChannelResetStream(t *testing.T) {
 	expectedMessagesMu.Unlock()
 
 	var respStatus pbstatus.Status
-	err = clientCh.Invoke(ctx, "thing", someStatus.Proto(), &respStatus)
+	clientStream, err := clientCh.NewStream(ctx, &grpc.StreamDesc{ClientStreams: true}, "thing")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, clientStream.SendMsg(someStatus.Proto()), test.ShouldBeNil)
+	err = clientStream.RecvMsg(&respStatus)
 	test.That(t, err, test.ShouldBeError, context.Canceled)
 	test.That(t, &respStatus, test.ShouldResemble, &pbstatus.Status{})
 

--- a/rpc/wrtc_server_channel.go
+++ b/rpc/wrtc_server_channel.go
@@ -106,14 +106,14 @@ func (ch *webrtcServerChannel) onChannelMessage(msg webrtc.DataChannelMessage) {
 	serverStream, ok := ch.streams[id]
 	if !ok {
 		if len(ch.streams) == WebRTCMaxStreamCount {
-			ch.webrtcBaseChannel.logger.Error(errWebRTCMaxStreams)
+			logger.Error(errWebRTCMaxStreams)
 			ch.mu.Unlock()
 			return
 		}
 		// peek headers for timeout
 		headers, ok := req.Type.(*webrtcpb.Request_Headers)
 		if !ok || headers.Headers == nil {
-			ch.webrtcBaseChannel.logger.Debugf("expected headers as first message but got %T, discard request", req.Type)
+			logger.Debugf("expected headers as first message but got %T, discard request", req.Type)
 			ch.mu.Unlock()
 			return
 		}

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sync/atomic"
 
 	"github.com/edaniels/golog"
 	protov1 "github.com/golang/protobuf/proto" //nolint:staticcheck
@@ -33,10 +34,11 @@ type webrtcServerStream struct {
 	*webrtcBaseStream
 	ch              *webrtcServerChannel
 	method          string
-	headersWritten  bool
+	headersWritten  atomic.Bool
 	headersReceived bool
 	header          metadata.MD
 	trailer         metadata.MD
+	sendClosed      atomic.Bool
 }
 
 // newWebRTCServerStream creates a gRPC stream from the given server channel with a
@@ -75,7 +77,7 @@ func (s *webrtcServerStream) SetHeader(header metadata.MD) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.headersWritten {
+	if s.headersWritten.Load() {
 		return errors.WithStack(ErrIllegalHeaderWrite)
 	}
 	if s.header == nil {
@@ -162,9 +164,16 @@ func init() {
 // untimely stream closure may result in lost messages.
 //
 // It is safe to have a goroutine calling SendMsg and another goroutine
-// calling RecvMsg on the same stream at the same time, but it is not safe
+// calling RecvMsg on the same stream at the same time, but it is undefined behavior
 // to call SendMsg on the same stream in different goroutines.
 func (s *webrtcServerStream) SendMsg(m interface{}) (err error) {
+	s.webrtcBaseStream.mu.RLock()
+	defer s.webrtcBaseStream.mu.RUnlock()
+	if s.sendClosed.Load() {
+		s.webrtcBaseStream.mu.RUnlock()
+		return io.ErrClosedPipe
+	}
+
 	defer func() {
 		if err != nil {
 			err = multierr.Combine(err, s.closeWithSendError(err))
@@ -299,16 +308,13 @@ func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 }
 
 func (s *webrtcServerStream) processMessage(msg *webrtcpb.RequestMessage) {
-	s.webrtcBaseStream.mu.Lock()
-	if s.recvClosed {
-		s.webrtcBaseStream.mu.Unlock()
+	if s.recvClosed.Load() {
 		s.logger.Error("message received after EOS")
 		return
 	}
-	s.webrtcBaseStream.mu.Unlock()
 	if msg.HasMessage {
 		if msg.PacketMessage == nil {
-			s.closeRecvWithError(errors.New("expected RequestMessage.PacketMessgae to not be nil but it was"))
+			s.closeWithError(errors.New("expected RequestMessage.PacketMessgae to not be nil but it was"))
 			return
 		}
 		data, eop := s.webrtcBaseStream.processMessage(msg.PacketMessage)
@@ -316,7 +322,7 @@ func (s *webrtcServerStream) processMessage(msg *webrtcpb.RequestMessage) {
 			return
 		}
 		s.webrtcBaseStream.mu.Lock()
-		if s.recvClosed {
+		if s.recvClosed.Load() {
 			s.webrtcBaseStream.mu.Unlock()
 			return
 		}
@@ -339,6 +345,9 @@ func (s *webrtcServerStream) processMessage(msg *webrtcpb.RequestMessage) {
 }
 
 func (s *webrtcServerStream) closeWithSendError(err error) (writeErr error) {
+	if !s.sendClosed.CompareAndSwap(false, true) {
+		return nil
+	}
 	defer func() {
 		if writeErr == nil || errors.Is(writeErr, sctp.ErrStreamClosed) {
 			writeErr = nil
@@ -372,17 +381,13 @@ func (s *webrtcServerStream) closeWithSendError(err error) (writeErr error) {
 }
 
 func (s *webrtcServerStream) writeHeaders() error {
-	s.webrtcBaseStream.mu.Lock()
-	if !s.headersWritten {
-		s.headersWritten = true
-		protoHeaders := metadataToProto(s.header)
-		s.webrtcBaseStream.mu.Unlock()
-		return s.ch.writeHeaders(s.stream, &webrtcpb.ResponseHeaders{
-			Metadata: protoHeaders,
-		})
+	if !s.headersWritten.CompareAndSwap(false, true) {
+		return nil
 	}
-	s.webrtcBaseStream.mu.Unlock()
-	return nil
+	protoHeaders := metadataToProto(s.header)
+	return s.ch.writeHeaders(s.stream, &webrtcpb.ResponseHeaders{
+		Metadata: protoHeaders,
+	})
 }
 
 // ErrorToStatus converts an error to a gRPC status. A nil


### PR DESCRIPTION
This also makes sure we serialize writes coming in more clearly