### PR TITLE
RSDK-2796 Allow map keys to be non-strings that implement String

### DIFF
--- a/protoutils/protoutils.go
+++ b/protoutils/protoutils.go
@@ -192,11 +192,16 @@ func marshalMap(data interface{}) (map[string]interface{}, error) {
 	var err error
 	for iter.Next() {
 		k := iter.Key()
+		key := k.String()
 		if k.Kind() != reflect.String {
-			return nil, errors.Errorf("map keys of type %v are not strings", k.Kind())
+			kstringer, ok := k.Interface().(fmt.Stringer)
+			if !ok {
+				return nil, errors.Errorf("map keys of type %v are not strings and do not implement String", k.Kind())
+			}
+			key = kstringer.String()
 		}
 		v := iter.Value().Interface()
-		result[k.String()], err = toInterface(v)
+		result[key], err = toInterface(v)
 		if err != nil {
 			return nil, err
 		}

--- a/protoutils/protoutils_test.go
+++ b/protoutils/protoutils_test.go
@@ -192,10 +192,10 @@ func TestMarshalMap(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, errors.New("data of type []string is not a map"))
 
 		_, err = marshalMap(map[int]string{1: "1"})
-		test.That(t, err, test.ShouldBeError, errors.New("map keys of type int are not strings"))
+		test.That(t, err, test.ShouldBeError, errors.New("map keys of type int are not strings and do not implement String"))
 
 		_, err = marshalMap(map[interface{}]string{"1": "1"})
-		test.That(t, err, test.ShouldBeError, errors.New("map keys of type interface are not strings"))
+		test.That(t, err, test.ShouldBeError, errors.New("map keys of type interface are not strings and do not implement String"))
 	})
 
 	for _, tc := range mapTests {
@@ -207,15 +207,6 @@ func TestMarshalMap(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, newStruct.AsMap(), test.ShouldResemble, tc.Expected)
 	}
-}
-
-func TestNonStringMapKey(t *testing.T) {
-	// Regression test for RSDK-2796 (ensure map keys cannot be non-strings that
-	// do not implement fmt.Stringer)
-
-	_, err := marshalMap(map[int]int{1: 1})
-	test.That(t, err, test.ShouldBeError,
-		errors.New("map keys of type int are not strings and do not implement String"))
 }
 
 func TestStructToMap(t *testing.T) {


### PR DESCRIPTION
[RSDK-2796](https://viam.atlassian.net/browse/RSDK-2796)

Allows map keys to be non-strings that implement [`fmt.Stringer`](https://pkg.go.dev/fmt#Stringer). Adds tests that those maps can be marshaled and maps with non-string types that do not implement `Stringer` still cannot be.

[RSDK-2796]: https://viam.atlassian.net/browse/RSDK-2796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ