### PR TITLE
limit cipher suits

### DIFF
--- a/http2.go
+++ b/http2.go
@@ -31,7 +31,7 @@ func NewPossiblySecureHTTPServer(handler http.Handler, opts HTTPServerOptions) (
 			MaxHeaderBytes: opts.MaxHeaderBytes,
 			Handler:        handler,
 		}
-
+		// TlS settings configured using https://ssl-config.mozilla.org/
 		if opts.TLSAuth {
 			httpServer.TLSConfig = &tls.Config{
 				MinVersion: tls.VersionTLS12,

--- a/http2.go
+++ b/http2.go
@@ -35,6 +35,14 @@ func NewPossiblySecureHTTPServer(handler http.Handler, opts HTTPServerOptions) (
 		if opts.TLSAuth {
 			httpServer.TLSConfig = &tls.Config{
 				MinVersion: tls.VersionTLS12,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				},
 				ClientAuth: tls.VerifyClientCertIfGiven,
 			}
 		}


### PR DESCRIPTION
We currently allow for weak ciphers in tls 1.2. This limits the ciphers to only the strong ones.