### PR TITLE
RSDK-3026 Ignore and log user-initiated abort chunk

### DIFF
--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -207,8 +207,6 @@ func newPeerConnectionForServer(
 	if err != nil {
 		return pc, dataChannel, err
 	}
-	defer utils.UncheckedError(negotiationChannel.Close())
-
 	negotiationChannel.OnError(initialDataChannelOnError(pc, logger))
 
 	negotiationChannel.OnOpen(func() {


### PR DESCRIPTION
[RSDK-3026](https://viam.atlassian.net/browse/RSDK-3026)

Ignores and debug-logs `User Initiated Abort: Close called` errors. Also ignores `dtls.ConnIsClosed` errors that occur when the peer connection has already been closed by the other side.

Certain browsers close RTC peer connections through an ["upper-layer request"](https://www.tech-invite.com/y45/tinv-ietf-rfc-4960-3.html#e-3-3-10-12) that sends an abort chunk error that, [as of relatively recently](https://github.com/pion/sctp/commit/e4e606d1fff223734f7aa74c50eb82d50932b3f4), is correctly packaged by the underlying `sctp` library and handed to goutils. That abort chunk error was being unnecessarily logged by both the data channel and negotiation channel.

[RSDK-3026]: https://viam.atlassian.net/browse/RSDK-3026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ