### PR TITLE
RSDK-906: Upload test result and coverage data into a MDB backend.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       options: --platform linux/amd64
     timeout-minutes: 20
     if: |
-      github.event_name == 'workflow_dispatch' || github.event_name == 'push' || 
+      github.event_name == 'workflow_dispatch' || github.event_name == 'push' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe to test' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
 
     steps:
@@ -64,20 +64,7 @@ jobs:
       run: |
         sudo -u testbot bash -lc 'echo "${{ secrets.ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > artifact_google_creds.json'
         export ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS=`pwd`/artifact_google_creds.json
-        sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI bash -lc 'make cover'
-
-    - name: Code Coverage Summary Report
-      uses: edaniels/CodeCoverageSummary@v1.2.3
-      with:
-        filename: coverage.xml
-        badge: true
-        fail_below_min: false
-        format: markdown
-        hide_branch_rate: true
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '50 70'
+        sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI,MONGODB_TEST_OUTPUT_URI bash -lc 'make cover'
 
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2.2.0
@@ -86,4 +73,3 @@ jobs:
         recreate: true
         path: code-coverage-results.md
         GITHUB_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
-

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ docs/
 # Test data
 coverage.txt
 coverage.xml
+code-coverage-results.md
+json.log
 
 *~
 *#

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ tool-install:
 		github.com/edaniels/golinters/cmd/combined \
 		github.com/golangci/golangci-lint/cmd/golangci-lint \
 		github.com/AlekSi/gocov-xml \
-		github.com/axw/gocov/gocov
+		github.com/axw/gocov/gocov \
+		gotest.tools/gotestsum
 
 buf: buf-go buf-web
 
@@ -55,12 +56,11 @@ lint-go: tool-install
 	export pkgs="`go list -f '{{.Dir}}' ./... | grep -v /proto/`" && echo "$$pkgs" | xargs go vet -vettool=$(TOOL_BIN)/combined
 	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
 
-cover:
-	go test -tags=no_skip -race -coverprofile=coverage.txt ./...
-	PATH=$(PATH_WITH_TOOLS) gocov convert coverage.txt | PATH=$(PATH_WITH_TOOLS) gocov-xml > coverage.xml
+cover: tool-install
+	PATH=$(PATH_WITH_TOOLS) ./etc/test.bash cover
 
-test:
-	go test -tags=no_skip -race ./...
+test: tool-install
+	PATH=$(PATH_WITH_TOOLS) ./etc/test.bash
 
 # examples
 

--- a/etc/analyzecoverage/main.go
+++ b/etc/analyzecoverage/main.go
@@ -1,0 +1,661 @@
+// Package main is a go test analyzer that publishes results to a MongoDB database.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/edaniels/golog"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.uber.org/multierr"
+	"go.viam.com/utils"
+	"golang.org/x/tools/cover"
+)
+
+var logger = golog.NewDebugLogger("analyzetests")
+
+func main() {
+	utils.ContextualMain(mainWithArgs, logger)
+}
+
+func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error {
+	profileDataAll, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+	profileDatas := bytes.Split(profileDataAll, []byte("mode: "))
+
+	gitSHA, _ := os.LookupEnv("GITHUB_X_HEAD_SHA")
+	repository, _ := os.LookupEnv("GITHUB_REPOSITORY")
+	var gitHubRunID, gitHubRunNumber, gitHubRunAttempt int64
+	gitHubRunIDStr, ok := os.LookupEnv("GITHUB_RUN_ID")
+	if ok {
+		var err error
+		gitHubRunID, err = strconv.ParseInt(gitHubRunIDStr, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+	gitHubRunNumberStr, ok := os.LookupEnv("GITHUB_RUN_NUMBER")
+	if ok {
+		var err error
+		gitHubRunNumber, err = strconv.ParseInt(gitHubRunNumberStr, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+	gitHubRunAttemptStr, ok := os.LookupEnv("GITHUB_RUN_ATTEMPT")
+	if ok {
+		var err error
+		gitHubRunAttempt, err = strconv.ParseInt(gitHubRunAttemptStr, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	baseRef, ok := os.LookupEnv("GITHUB_X_PR_BASE_REF")
+	isPullRequest := ok && baseRef != ""
+	baseSha, _ := os.LookupEnv("GITHUB_X_PR_BASE_SHA")
+
+	branchName, _ := os.LookupEnv("GITHUB_X_HEAD_REF")
+
+	mongoURI, ok := os.LookupEnv("MONGODB_TEST_OUTPUT_URI")
+	if !ok || mongoURI == "" {
+		logger.Warn("no MongoDB URI found; skipping")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	client, err := mongo.NewClient(options.Client().ApplyURI(mongoURI))
+	if err != nil {
+		return err
+	}
+	if err := client.Connect(ctx); err != nil {
+		return err
+	}
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return multierr.Combine(err, client.Disconnect(ctx))
+	}
+	defer func() {
+		utils.UncheckedError(client.Disconnect(ctx))
+	}()
+
+	coll := client.Database("coverage").Collection("results")
+
+	var closestPastResults *closetMergeBaseResults
+	var closestPastResultsErr error
+	if isPullRequest {
+		closestPastResults, closestPastResultsErr = findClosestMergeBaseResults(
+			ctx, coll, branchName, gitSHA, baseRef, baseSha)
+	}
+
+	createdAt := time.Now()
+
+	covResults := map[string]coverageResult{}
+	rawResults := map[string]*funcOutputResult{}
+	for _, data := range profileDatas[1:] {
+		newData := append([]byte("mode: "), data...)
+		results, err := funcOutput(bytes.NewReader(newData))
+		if err != nil {
+			return err
+		}
+		for pkgName, result := range results {
+			pctCovered := percent(result.covered, result.total)
+			if _, ok := covResults[pkgName]; ok {
+				newPct := pctCovered
+				if pctCovered < covResults[pkgName].LineCoveragePct {
+					newPct = covResults[pkgName].LineCoveragePct
+				} else if pctCovered == covResults[pkgName].LineCoveragePct {
+					continue
+				}
+				logger.Infow(
+					"multiple coverage profiles for package; taking higher...",
+					"package", pkgName,
+					"prev", covResults[pkgName].LineCoveragePct,
+					"new_entry", pctCovered,
+					"new", newPct,
+				)
+				pctCovered = newPct
+			}
+			covResults[pkgName] = coverageResult{
+				CreatedAt:           createdAt,
+				GitSHA:              gitSHA,
+				GitBranch:           branchName,
+				GitHubRepository:    repository,
+				GitHubRunID:         gitHubRunID,
+				GitHubRunNumber:     gitHubRunNumber,
+				GitHubRunAttempt:    gitHubRunAttempt,
+				GitHubIsPullRequest: isPullRequest,
+				Package:             pkgName,
+				LineCoveragePct:     pctCovered,
+				LinesCovered:        result.covered,
+				LinesTotal:          result.total,
+			}
+			resultCopy := *result
+			rawResults[pkgName] = &resultCopy
+		}
+	}
+
+	if len(covResults) == 0 {
+		return nil
+	}
+
+	resultsIfc := make([]interface{}, 0, len(covResults))
+	for _, res := range covResults {
+		resultsIfc = append(resultsIfc, res)
+	}
+
+	var totalCovered, totalLines int64
+	for _, rawResult := range rawResults {
+		totalCovered += rawResult.covered
+		totalLines += rawResult.total
+	}
+	summaryResult := coverageResult{
+		CreatedAt:           createdAt,
+		GitSHA:              gitSHA,
+		GitBranch:           branchName,
+		GitHubRepository:    repository,
+		GitHubRunID:         gitHubRunID,
+		GitHubRunNumber:     gitHubRunNumber,
+		GitHubRunAttempt:    gitHubRunAttempt,
+		GitHubIsPullRequest: isPullRequest,
+		LineCoveragePct:     percent(totalCovered, totalLines),
+		LinesCovered:        totalCovered,
+		LinesTotal:          totalLines,
+	}
+	resultsIfc = append(resultsIfc, summaryResult)
+
+	if _, err := coll.InsertMany(ctx, resultsIfc); err != nil {
+		logger.Errorw("error storing coverage results", "error", err)
+	}
+
+	mdOutput := generateMarkdownOutput(
+		overallResults{covResults, summaryResult},
+		generateBadge(summaryResult),
+		closestPastResults,
+		closestPastResultsErr,
+	)
+	//nolint:gosec
+	return os.WriteFile("code-coverage-results.md", []byte(mdOutput), 0o644)
+}
+
+func generateBadge(summary coverageResult) string {
+	var color string
+	switch {
+	case summary.LineCoveragePct < lowerThreshold:
+		color = "critical"
+	case summary.LineCoveragePct < upperThreshold:
+		color = "yellow"
+	default:
+		color = "success"
+	}
+	return fmt.Sprintf("https://img.shields.io/badge/Code%%20Coverage-%.0f%%25-%s?style=flat", summary.LineCoveragePct, color)
+}
+
+const (
+	lowerThreshold = 50
+	upperThreshold = 70
+)
+
+func generateHealthIndicator(rate float64) string {
+	switch {
+	case rate < lowerThreshold:
+		return "❌"
+	case rate < upperThreshold:
+		return "➖"
+	default:
+		return "✅"
+	}
+}
+
+// based off of https://github.com/irongut/CodeCoverageSummary
+func generateMarkdownOutput(
+	results overallResults,
+	badgeURL string,
+	closestPastResults *closetMergeBaseResults,
+	closestPastResultsErr error,
+) string {
+	var builder strings.Builder
+
+	builder.WriteString(fmt.Sprintf("![Code Coverage](%s)\n\n", badgeURL))
+
+	if closestPastResultsErr != nil {
+		builder.WriteString(fmt.Sprintf("**Note: %s**\n", closestPastResultsErr))
+	}
+	var canDelta bool
+	if closestPastResults != nil {
+		canDelta = len(closestPastResults.results.packages) != 0
+		if !canDelta {
+			builder.WriteString("**Note: no suitable past coverage found to compare against**\n")
+		}
+	}
+
+	builder.WriteString("Package | Line Rate")
+	if canDelta {
+		builder.WriteString(" | Delta")
+	}
+	builder.WriteString(" | Health\n")
+	builder.WriteString("-------- | ---------")
+	if canDelta {
+		builder.WriteString(" | ------")
+	}
+	builder.WriteString(" | ------\n")
+
+	pkgNames := make([]string, 0, len(results.packages))
+	for pkgName := range results.packages {
+		pkgNames = append(pkgNames, pkgName)
+	}
+	sort.Strings(pkgNames)
+
+	getDelta := func(now, past coverageResult) string {
+		delta := now.LineCoveragePct - past.LineCoveragePct
+		if math.Abs(delta) < 1e-2 {
+			delta = 0
+		}
+		var deltaSign string
+		if !(delta == 0 || math.Signbit(delta)) {
+			deltaSign = "+"
+		}
+		deltaStr := fmt.Sprintf("%s%.2f%%", deltaSign, delta)
+		if math.Abs(delta) > 5 {
+			deltaStr = fmt.Sprintf("**%s**", deltaStr)
+		}
+		return deltaStr
+	}
+	for _, pkgName := range pkgNames {
+		result := results.packages[pkgName]
+		builder.WriteString(fmt.Sprintf("%s | %.0f%%", pkgName, result.LineCoveragePct))
+		if canDelta {
+			if pastResult, ok := closestPastResults.results.packages[pkgName]; ok {
+				builder.WriteString(fmt.Sprintf(" | %s", getDelta(result, pastResult)))
+			} else {
+				builder.WriteString(" | N/A")
+			}
+		}
+		builder.WriteString(fmt.Sprintf(" | %s\n", generateHealthIndicator(result.LineCoveragePct)))
+	}
+
+	builder.WriteString(fmt.Sprintf(
+		"**Summary** | **%.0f%%** (%d / %d)",
+		results.summary.LineCoveragePct,
+		results.summary.LinesCovered,
+		results.summary.LinesTotal))
+	if canDelta {
+		builder.WriteString(fmt.Sprintf(" | %s", getDelta(results.summary, closestPastResults.results.summary)))
+	}
+	builder.WriteString(fmt.Sprintf(" | %s\n", generateHealthIndicator(results.summary.LineCoveragePct)))
+
+	return builder.String()
+}
+
+type funcOutputResult struct {
+	covered int64
+	total   int64
+}
+
+// *heavily* borrowed from https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/cmd/cover/func.go
+
+func funcOutput(profileData io.Reader) (map[string]*funcOutputResult, error) {
+	profiles, err := cover.ParseProfilesFromReader(profileData)
+	if err != nil {
+		return nil, err
+	}
+
+	dirs, err := findPkgs(profiles)
+	if err != nil {
+		return nil, err
+	}
+
+	results := map[string]*funcOutputResult{}
+	for _, profile := range profiles {
+		fn := profile.FileName
+		file, err := findFile(dirs, fn)
+		if err != nil {
+			return nil, err
+		}
+		funcs, err := findFuncs(file)
+		if err != nil {
+			return nil, err
+		}
+		// Now match up functions and profile blocks.
+		for _, f := range funcs {
+			c, t := f.coverage(profile)
+			pkgName := dirs[path.Dir(fn)].ImportPath
+			if results[pkgName] == nil {
+				results[pkgName] = &funcOutputResult{}
+			}
+			results[pkgName].total += t
+			results[pkgName].covered += c
+		}
+	}
+
+	return results, nil
+}
+
+// findFuncs parses the file and returns a slice of FuncExtent descriptors.
+func findFuncs(name string) ([]*FuncExtent, error) {
+	fset := token.NewFileSet()
+	parsedFile, err := parser.ParseFile(fset, name, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	visitor := &FuncVisitor{
+		fset:    fset,
+		name:    name,
+		astFile: parsedFile,
+	}
+	ast.Walk(visitor, visitor.astFile)
+	return visitor.funcs, nil
+}
+
+// FuncExtent describes a function's extent in the source by file and position.
+type FuncExtent struct {
+	name      string
+	startLine int
+	startCol  int
+	endLine   int
+	endCol    int
+}
+
+// FuncVisitor implements the visitor that builds the function position list for a file.
+type FuncVisitor struct {
+	fset    *token.FileSet
+	name    string // Name of file.
+	astFile *ast.File
+	funcs   []*FuncExtent
+}
+
+// Visit implements the ast.Visitor interface.
+func (v *FuncVisitor) Visit(node ast.Node) ast.Visitor {
+	switch n := node.(type) {
+	case *ast.FuncDecl:
+		if n.Body == nil {
+			// Do not count declarations of assembly functions.
+			break
+		}
+		start := v.fset.Position(n.Pos())
+		end := v.fset.Position(n.End())
+		fe := &FuncExtent{
+			name:      n.Name.Name,
+			startLine: start.Line,
+			startCol:  start.Column,
+			endLine:   end.Line,
+			endCol:    end.Column,
+		}
+		v.funcs = append(v.funcs, fe)
+	}
+	return v
+}
+
+// coverage returns the fraction of the statements in the function that were covered, as a numerator and denominator.
+func (f *FuncExtent) coverage(profile *cover.Profile) (num, den int64) {
+	// We could avoid making this n^2 overall by doing a single scan and annotating the functions,
+	// but the sizes of the data structures is never very large and the scan is almost instantaneous.
+	var covered, total int64
+	// The blocks are sorted, so we can stop counting as soon as we reach the end of the relevant block.
+	for _, b := range profile.Blocks {
+		if b.StartLine > f.endLine || (b.StartLine == f.endLine && b.StartCol >= f.endCol) {
+			// Past the end of the function.
+			break
+		}
+		if b.EndLine < f.startLine || (b.EndLine == f.startLine && b.EndCol <= f.startCol) {
+			// Before the beginning of the function
+			continue
+		}
+		total += int64(b.NumStmt)
+		if b.Count > 0 {
+			covered += int64(b.NumStmt)
+		}
+	}
+	return covered, total
+}
+
+// Pkg describes a single package, compatible with the JSON output from 'go list'; see 'go help list'.
+type Pkg struct {
+	ImportPath string
+	Dir        string
+	Error      *struct {
+		Err string
+	}
+}
+
+func findPkgs(profiles []*cover.Profile) (map[string]*Pkg, error) {
+	// Run go list to find the location of every package we care about.
+	pkgs := make(map[string]*Pkg)
+	var list []string
+	for _, profile := range profiles {
+		if strings.HasPrefix(profile.FileName, ".") || filepath.IsAbs(profile.FileName) {
+			// Relative or absolute path.
+			continue
+		}
+		pkg := path.Dir(profile.FileName)
+		if _, ok := pkgs[pkg]; !ok {
+			pkgs[pkg] = nil
+			list = append(list, pkg)
+		}
+	}
+
+	if len(list) == 0 {
+		return pkgs, nil
+	}
+
+	// Note: usually run as "go tool cover" in which case $GOROOT is set,
+	// in which case runtime.GOROOT() does exactly what we want.
+	goTool := filepath.Join(runtime.GOROOT(), "bin/go")
+	//nolint:gosec
+	cmd := exec.Command(goTool, append([]string{"list", "-e", "-json"}, list...)...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("cannot run go list: %w\n%s", err, stderr.Bytes())
+	}
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+	for {
+		var pkg Pkg
+		err := dec.Decode(&pkg)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decoding go list json: %w", err)
+		}
+		pkgs[pkg.ImportPath] = &pkg
+	}
+	return pkgs, nil
+}
+
+// findFile finds the location of the named file in GOROOT, GOPATH etc.
+func findFile(pkgs map[string]*Pkg, file string) (string, error) {
+	if strings.HasPrefix(file, ".") || filepath.IsAbs(file) {
+		// Relative or absolute path.
+		return file, nil
+	}
+	pkg := pkgs[path.Dir(file)]
+	if pkg != nil {
+		if pkg.Dir != "" {
+			return filepath.Join(pkg.Dir, path.Base(file)), nil
+		}
+		if pkg.Error != nil {
+			return "", errors.New(pkg.Error.Err)
+		}
+	}
+	return "", fmt.Errorf("did not find package for %s in go list output", file)
+}
+
+func percent(covered, total int64) float64 {
+	if total == 0 {
+		total = 1 // Avoid zero denominator.
+	}
+	return 100.0 * float64(covered) / float64(total)
+}
+
+type coverageResult struct {
+	CreatedAt           time.Time `bson:"created_at"`
+	GitSHA              string    `bson:"git_sha,omitempty"`
+	GitBranch           string    `bson:"git_branch"`
+	GitHubRepository    string    `bson:"github_repository"`
+	GitHubRunID         int64     `bson:"github_run_id,omitempty"`
+	GitHubRunNumber     int64     `bson:"github_run_number,omitempty"`
+	GitHubRunAttempt    int64     `bson:"github_run_attempt,omitempty"`
+	GitHubIsPullRequest bool      `bson:"github_is_pull_request"`
+	LineCoveragePct     float64   `bson:"line_coverage_pct"`
+	LinesCovered        int64     `bson:"lines_covered"`
+	LinesTotal          int64     `bson:"lines_total"`
+	Package             string    `bson:"package,omitempty"`
+}
+
+type overallResults struct {
+	packages map[string]coverageResult
+	summary  coverageResult
+}
+
+type closetMergeBaseResults struct {
+	base    string
+	results overallResults
+}
+
+func checkForResults(ctx context.Context, coll *mongo.Collection, gitSha string) []coverageResult {
+	resultCount, err := coll.CountDocuments(ctx, bson.D{
+		{"git_sha", gitSha},
+	})
+	if err != nil {
+		logger.Errorw("failed to find coverage for merge base", "git_sha", gitSha, "error", err)
+	}
+	if resultCount == 0 {
+		return nil
+	}
+
+	cur, err := coll.Find(ctx, bson.D{
+		{"git_sha", gitSha},
+	})
+	if err != nil {
+		logger.Errorw("failed to find coverage for merge base", "git_sha", gitSha, "error", err)
+	}
+	var results []coverageResult
+	if err := cur.All(ctx, &results); err != nil {
+		logger.Errorw("failed to find coverage for merge base", "git_sha", gitSha, "error", err)
+	}
+	return results
+}
+
+func findClosestMergeBaseResults(
+	ctx context.Context,
+	coll *mongo.Collection,
+	branchName string,
+	branchSha string,
+	baseRef string,
+	baseSha string,
+) (*closetMergeBaseResults, error) {
+	revParse := func(base string, back int) (string, error) {
+		checkRef := fmt.Sprintf("%s~%d", base, back)
+		//nolint:gosec
+		cmd := exec.Command("git", "rev-parse", checkRef)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			if len(out) != 0 {
+				return "", fmt.Errorf("error running git rev-parse %s: %s", checkRef, string(out))
+			}
+			return "", err
+		}
+		return strings.TrimSuffix(string(out), "\n"), nil
+	}
+
+	// look back for results
+	cmd := exec.Command("git", "merge-base", branchSha, baseSha)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if len(out) != 0 {
+			return nil, fmt.Errorf(
+				"error running git merge-base %s(%s) %s(%s): %s",
+				branchName,
+				branchSha,
+				baseRef,
+				baseSha,
+				string(out),
+			)
+		}
+		return nil, err
+	}
+	possibleMergeBaseRoot := strings.TrimSuffix(string(out), "\n")
+	possibleMergeBaseCurr := possibleMergeBaseRoot
+
+	var mergeBase string
+	var mergeBaseResults []coverageResult
+	mergeBaseCovResults := map[string]coverageResult{}
+	var mergeBaseSummaryResult coverageResult
+
+	var mergeBaseErr error
+	for i := 0; i < 5; i++ {
+		if i != 0 {
+			var err error
+			possibleMergeBaseCurr, err = revParse(possibleMergeBaseRoot, i)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		mergeBaseResults = checkForResults(ctx, coll, possibleMergeBaseCurr)
+		if len(mergeBaseResults) == 0 {
+			continue
+		}
+		mergeBase = possibleMergeBaseCurr
+		if i != 0 {
+			mergeBaseErr = fmt.Errorf(
+				"merge base coverage results not available, comparing against closest %s~%d=(%s) instead",
+				possibleMergeBaseRoot, i, mergeBase)
+		}
+		break
+	}
+
+	if mergeBase == "" {
+		// last resort, try the HEAD at this point in time of base ref
+		mergeBaseResults = checkForResults(ctx, coll, baseSha)
+		if len(mergeBaseResults) != 0 {
+			mergeBase = baseSha
+			mergeBaseErr = fmt.Errorf(
+				"merge base coverage results not available, using HEAD(%s)=%s as no other closest candidate was found",
+				baseRef, baseSha)
+		} else {
+			return nil, errors.New("failed to find any suitable merge base to compare against")
+		}
+	}
+
+	// dedupe
+	for _, result := range mergeBaseResults {
+		resultCopy := result
+		if result.Package == "" {
+			mergeBaseSummaryResult = resultCopy
+			continue
+		}
+		mergeBaseCovResults[result.Package] = resultCopy
+	}
+	return &closetMergeBaseResults{
+		base: mergeBase,
+		results: overallResults{
+			packages: mergeBaseCovResults,
+			summary:  mergeBaseSummaryResult,
+		},
+	}, mergeBaseErr
+}

--- a/etc/analyzecoverage/main.go
+++ b/etc/analyzecoverage/main.go
@@ -28,8 +28,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.uber.org/multierr"
-	"go.viam.com/utils"
 	"golang.org/x/tools/cover"
+
+	"go.viam.com/utils"
 )
 
 var logger = golog.NewDebugLogger("analyzetests")

--- a/etc/analyzetests/main.go
+++ b/etc/analyzetests/main.go
@@ -1,0 +1,154 @@
+// Package main is a go test analyzer that publishes results to a MongoDB database.
+package main
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/edaniels/golog"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.uber.org/multierr"
+	"go.viam.com/utils"
+	"gotest.tools/gotestsum/testjson"
+)
+
+var logger = golog.NewDebugLogger("analyzetests")
+
+func main() {
+	utils.ContextualMain(mainWithArgs, logger)
+}
+
+func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error {
+	exec, err := testjson.ScanTestOutput(testjson.ScanConfig{
+		Stdout: os.Stdin,
+	})
+	if err != nil {
+		return err
+	}
+
+	mongoURI, ok := os.LookupEnv("MONGODB_TEST_OUTPUT_URI")
+	if !ok || mongoURI == "" {
+		logger.Warn("no MongoDB URI found; skipping")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, err := mongo.NewClient(options.Client().ApplyURI(mongoURI))
+	if err != nil {
+		return err
+	}
+	if err := client.Connect(ctx); err != nil {
+		return err
+	}
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		return multierr.Combine(err, client.Disconnect(ctx))
+	}
+	defer func() {
+		utils.UncheckedError(client.Disconnect(ctx))
+	}()
+
+	gitSHA, _ := os.LookupEnv("GITHUB_X_HEAD_SHA")
+	repository, _ := os.LookupEnv("GITHUB_REPOSITORY")
+	var gitHubRunID, gitHubRunNumber, gitHubRunAttempt int64
+	gitHubRunIDStr, ok := os.LookupEnv("GITHUB_RUN_ID")
+	if ok {
+		var err error
+		gitHubRunID, err = strconv.ParseInt(gitHubRunIDStr, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+	gitHubRunNumberStr, ok := os.LookupEnv("GITHUB_RUN_NUMBER")
+	if ok {
+		var err error
+		gitHubRunNumber, err = strconv.ParseInt(gitHubRunNumberStr, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+	gitHubRunAttemptStr, ok := os.LookupEnv("GITHUB_RUN_ATTEMPT")
+	if ok {
+		var err error
+		gitHubRunAttempt, err = strconv.ParseInt(gitHubRunAttemptStr, 10, 64)
+		if err != nil {
+			return err
+		}
+	}
+
+	baseRef, ok := os.LookupEnv("GITHUB_X_PR_BASE_REF")
+	isPullRequest := ok && baseRef != ""
+
+	branchName, _ := os.LookupEnv("GITHUB_X_HEAD_REF")
+
+	createdAt := time.Now()
+	parseTest := func(status string, tc testjson.TestCase) testResult {
+		root, sub := tc.Test.Split()
+		return testResult{
+			CreatedAt:           createdAt,
+			GitSHA:              gitSHA,
+			GitBranch:           branchName,
+			GitHubRepository:    repository,
+			GitHubRunID:         gitHubRunID,
+			GitHubRunNumber:     gitHubRunNumber,
+			GitHubRunAttempt:    gitHubRunAttempt,
+			GitHubIsPullRequest: isPullRequest,
+			Status:              status,
+			Package:             tc.Package,
+			Test:                tc.Test.Name(),
+			RootTest:            root,
+			SubTest:             sub,
+			Elapsed:             tc.Elapsed.Milliseconds(),
+		}
+	}
+	parseTests := func(status string, tcs []testjson.TestCase) []testResult {
+		var results []testResult
+		results = make([]testResult, 0, len(tcs))
+		for _, tc := range tcs {
+			results = append(results, parseTest(status, tc))
+		}
+		return results
+	}
+
+	var results []testResult
+	for _, pkgName := range exec.Packages() {
+		pkg := exec.Package(pkgName)
+		results = append(results, parseTests("passed", pkg.Passed)...)
+		results = append(results, parseTests("skipped", pkg.Skipped)...)
+		results = append(results, parseTests("failed", testjson.FilterFailedUnique(pkg.Failed))...)
+	}
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	resultsIfc := make([]interface{}, 0, len(results))
+	for _, res := range results {
+		resultsIfc = append(resultsIfc, res)
+	}
+
+	coll := client.Database("tests").Collection("results")
+	_, err = coll.InsertMany(context.Background(), resultsIfc)
+	return err
+}
+
+type testResult struct {
+	CreatedAt           time.Time `bson:"created_at"`
+	GitSHA              string    `bson:"git_sha,omitempty"`
+	GitBranch           string    `bson:"git_branch"`
+	GitHubRepository    string    `bson:"github_repository"`
+	GitHubRunID         int64     `bson:"github_run_id,omitempty"`
+	GitHubRunNumber     int64     `bson:"github_run_number,omitempty"`
+	GitHubRunAttempt    int64     `bson:"github_run_attempt,omitempty"`
+	GitHubIsPullRequest bool      `bson:"github_is_pull_request"`
+	Status              string    `bson:"status"`
+	Package             string    `bson:"package"`
+	Test                string    `bson:"test"`
+	RootTest            string    `bson:"root_test"`
+	SubTest             string    `bson:"sub_test,omitempty"`
+	Elapsed             int64     `bson:"elapsed,omitempty"`
+}

--- a/etc/analyzetests/main.go
+++ b/etc/analyzetests/main.go
@@ -12,8 +12,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.uber.org/multierr"
-	"go.viam.com/utils"
 	"gotest.tools/gotestsum/testjson"
+
+	"go.viam.com/utils"
 )
 
 var logger = golog.NewDebugLogger("analyzetests")
@@ -36,16 +37,16 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	connectCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoURI))
 	if err != nil {
 		return err
 	}
-	if err := client.Connect(ctx); err != nil {
+	if err := client.Connect(connectCtx); err != nil {
 		return err
 	}
-	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+	if err := client.Ping(connectCtx, readpref.Primary()); err != nil {
 		return multierr.Combine(err, client.Disconnect(ctx))
 	}
 	defer func() {
@@ -132,7 +133,7 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error
 	}
 
 	coll := client.Database("tests").Collection("results")
-	_, err = coll.InsertMany(context.Background(), resultsIfc)
+	_, err = coll.InsertMany(ctx, resultsIfc)
 	return err
 }
 

--- a/etc/test.bash
+++ b/etc/test.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$DIR/../"
+cd $ROOT_DIR
+
+if [[ "$1" == "cover" ]]; then
+	COVER=-coverprofile=coverage.txt
+fi
+
+# race isn't supported on the pi or jetson (and possibly other arm boards)
+# https://github.com/golang/go/issues/29948
+if [ "$(uname -m)" != "aarch64" ] || [ "$(uname)" != "Linux" ]; then
+	RACE=-race
+fi
+
+gotestsum --format standard-verbose --jsonfile json.log -- -tags=no_skip $RACE $COVER ./...
+PID=$!
+
+trap "kill -9 $PID" INT
+
+FAIL=0
+wait $PID || let "FAIL+=1"
+
+cat json.log | go run ./etc/analyzetests/main.go
+
+if [ "$FAIL" != "0" ]; then
+	exit $FAIL
+fi
+
+cat coverage.txt | go run ./etc/analyzecoverage/main.go
+
+if [[ "$1" == "cover" ]]; then
+	gocov convert coverage.txt | gocov-xml > coverage.xml
+fi

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/bufbuild/buf v1.1.0
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/edaniels/golinters v0.0.5-0.20210512224240-495d3b8eed19
-	github.com/edaniels/golog v0.0.0-20220930140416-6e52e83a97fc
+	github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0
 	github.com/edaniels/zeroconf v1.0.9
 	github.com/fatih/color v1.14.1
 	github.com/fsnotify/fsnotify v1.5.4
@@ -47,11 +47,13 @@ require (
 	goji.io v2.0.2+incompatible
 	golang.org/x/net v0.9.0
 	golang.org/x/oauth2 v0.4.0
+	golang.org/x/tools v0.6.0
 	google.golang.org/api v0.103.0
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
 	google.golang.org/grpc v1.54.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.28.1
+	gotest.tools/gotestsum v1.10.0
 	howett.net/plist v1.0.0
 )
 
@@ -99,6 +101,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
+	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/envoyproxy/go-control-plane v0.10.3 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.9.1 // indirect
 	github.com/esimonov/ifshort v1.0.4 // indirect
@@ -135,6 +138,7 @@ require (
 	github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6 // indirect
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20230107090616-13ace0543b28 // indirect
@@ -279,7 +283,6 @@ require (
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
-	golang.org/x/tools v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mz
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
+github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/edaniels/golinters v0.0.4/go.mod h1:KzjC7OrCrRlFxufhH+kQ1Sdyzuj2eanHHzPaWxD3lgk=
@@ -290,6 +292,8 @@ github.com/edaniels/golinters v0.0.5-0.20210512224240-495d3b8eed19 h1:H1ItaK5N1m
 github.com/edaniels/golinters v0.0.5-0.20210512224240-495d3b8eed19/go.mod h1:i/zcokIKs893VZA41BS8jTOHW23PlqiiZEa7Y+4Nujk=
 github.com/edaniels/golog v0.0.0-20220930140416-6e52e83a97fc h1:x43xs2HSLmj8OGqiVyefDyDgC0W1B8mbX1cfvkDjqqM=
 github.com/edaniels/golog v0.0.0-20220930140416-6e52e83a97fc/go.mod h1:Ms3gOPiAEPRrgN3kBOF8YIkT2JEXxPFk/HBx/FAkmgA=
+github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0 h1:nNKMo+7J87eEtmp/tdmaORLS+u6mmcmW/ZpxJCQ+Mu8=
+github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0/go.mod h1:+Fw6jgiaW75M1z173j7FFZB2Ug5SccFxroA/eM2YFaM=
 github.com/edaniels/zeroconf v1.0.9 h1:QFEH3ISQ+MSXWVSAIY7zwPiZb69PhjPbULAdhrGJHg8=
 github.com/edaniels/zeroconf v1.0.9/go.mod h1:22UUi3EGu1VSKYpObTSRkMvN9ENVT20KgHJbDISznEk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -551,6 +555,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.0.0-20191226140753-aa36bfddb3a0/go.mod h1:RaTPr0KUf2K7fnZYLNDrr8rxAamWs3iNywJLtQ2AzBg=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/trillian v1.3.11/go.mod h1:0tPraVHrSDkA3BO6vKX67zgLXs6SsOAbHEivX+9mPgw=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1538,6 +1544,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1652,6 +1659,7 @@ golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
@@ -2022,6 +2030,10 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/gotestsum v1.10.0 h1:lVO4uQJoxdsJb7jgmr1fg8QW7zGQ/tuqvsq5fHKyoHQ=
+gotest.tools/gotestsum v1.10.0/go.mod h1:6JHCiN6TEjA7Kaz23q1bH0e2Dc3YJjDUZ0DmctFZf+w=
+gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
+gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -19,4 +19,5 @@ import (
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "gotest.tools/gotestsum"
 )


### PR DESCRIPTION
The goutils repository can currently output code coverage data into a file that is slurped into a Github PR comment. This patch moves that code into test executaion rather than being contained as a github action. That change will result in an additional coverage file, `code-coverage-results.md` (gitignored) to be created in the goutils repo root when running `make cover`.