### PR TITLE
[RSDK-3286] Fix go routine leak in wrtc ice candidate function

### DIFF
--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -237,6 +237,9 @@ func dialWebRTC(
 			}
 			// must spin off to unblock the ICE gatherer
 			utils.PanicCapturingGo(func() {
+				if i != nil {
+					defer callFlowWG.Done()
+				}
 				select {
 				case <-remoteDescSet:
 				case <-exchangeCtx.Done():
@@ -249,7 +252,6 @@ func dialWebRTC(
 					}
 					return
 				}
-				defer callFlowWG.Done()
 				iProto := iceCandidateToProto(i)
 				if _, err := signalingClient.CallUpdate(exchangeCtx, &webrtcpb.CallUpdateRequest{
 					Uuid: uuid,


### PR DESCRIPTION
After staring at this code for far too long, I think the only way the leak shown in RSDK-3286 could have happened was by this function returning via the select because of a race with other instances of itself. @edaniels Please take a look though, as I'm not 100% certain how this waitgroup pattern is supposed to function (deferring in a later anonymous function feels odd.)