### PR TITLE
RSDK-3600: Avoid double locking when SendMsg encounters an error.

### DIFF
--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -212,7 +212,14 @@ func (srv *webrtcServer) unaryHandler(ss interface{}, handler methodHandler) han
 		if err != nil {
 			return s.closeWithSendError(err)
 		}
-		return s.closeWithSendError(s.SendMsg(response))
+
+		err = s.SendMsg(response)
+		if err != nil {
+			// `ServerStream.SendMsg` closes itself on error.
+			return err
+		}
+
+		return s.closeWithSendError(nil)
 	}
 }
 


### PR DESCRIPTION
Additionally, change the server's unaryHandler from repeating a call to `closeWithSendError`. Due to `closeWithSendError`s implementation, that change is inconsequential. But I think the explicit handling adds clarity.