### PR TITLE
RSDK-3441 Lock usage of Start and Stop for signaling answerer

### DIFF
--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -24,7 +24,7 @@ import (
 // directly connected to a Server that will handle the actual calls/connections over WebRTC
 // data channels.
 type webrtcSignalingAnswerer struct {
-	mu sync.Mutex // mu guards the Start and Stop methods so they do not happen concurrently.
+	startStopMu sync.Mutex // startStopMu guards the Start and Stop methods so they do not happen concurrently.
 
 	address                 string
 	hosts                   []string
@@ -73,8 +73,8 @@ const (
 // Start connects to the signaling service and listens forever until instructed to stop
 // via Stop.
 func (ans *webrtcSignalingAnswerer) Start() {
-	ans.mu.Lock()
-	defer ans.mu.Unlock()
+	ans.startStopMu.Lock()
+	defer ans.startStopMu.Unlock()
 
 	for i := 0; i < defaultMaxAnswerers; i++ {
 		ans.startAnswerer()
@@ -195,8 +195,8 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 
 // Stop waits for the answer to stop listening and return.
 func (ans *webrtcSignalingAnswerer) Stop() {
-	ans.mu.Lock()
-	defer ans.mu.Unlock()
+	ans.startStopMu.Lock()
+	defer ans.startStopMu.Unlock()
 
 	ans.cancelBackgroundWorkers()
 	ans.activeBackgroundWorkers.Wait()

--- a/testutils/env.go
+++ b/testutils/env.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ func SkipUnlessInternet(tb testing.TB) {
 	tb.Helper()
 	if internetConnected == nil {
 		var connected bool
-		conn, err := net.Dial("tcp", "mozilla.org:80")
+		conn, err := net.DialTimeout("tcp", "mozilla.org:80", 5*time.Second)
 		if err == nil {
 			test.That(tb, conn.Close(), test.ShouldBeNil)
 			connected = true


### PR DESCRIPTION
[RSDK-3441](https://viam.atlassian.net/browse/RSDK-3441)

Adds a mutex to keep `Start` and `Stop` exclusive for the signaling answerer. Adds a test to ensure `Start` and `Stop` do not race.

[TestWebStreamImmediateClose](https://github.com/viamrobotics/rdk/blob/main/robot/web/web_test.go#L789) is an rdk test I wrote that starts and immediately stops the web service to ensure there are no races/deadlocks. It occasionally (once every ~50 times) causes a [data race](https://github.com/viamrobotics/rdk/actions/runs/5180043576/jobs/9333712461) in goutils. The [signaling answerer’s](https://github.com/viamrobotics/rdk/blob/main/robot/web/web_test.go#L789) `Stop` method had a race with the signaling answerer’s `Start` method. The former tried to `Wait` for background workers and the latter tried to `Add` a new one with no locking.

[RSDK-3441]: https://viam.atlassian.net/browse/RSDK-3441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ