### PR TITLE
RSDK-3382 Remove "suppressing" logs from error callbacks

### DIFF
--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -193,7 +193,6 @@ func isUserInitiatedAbortChunkErr(err error) bool {
 func (ch *webrtcBaseChannel) onChannelError(err error) {
 	if errors.Is(err, sctp.ErrResetPacketInStateNotExist) ||
 		isUserInitiatedAbortChunkErr(err) {
-		ch.logger.Debugw("suppressing error from sctp", "error", err)
 		return
 	}
 	ch.logger.Errorw("channel error", "error", err)

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -354,7 +354,6 @@ func initialDataChannelOnError(pc io.Closer, logger golog.Logger) func(err error
 	return func(err error) {
 		if errors.Is(err, sctp.ErrResetPacketInStateNotExist) ||
 			isUserInitiatedAbortChunkErr(err) {
-			logger.Debugw("suppressing error from sctp", "error", err)
 			return
 		}
 		logger.Errorw("premature data channel error before WebRTC channel association", "error", err)


### PR DESCRIPTION
[RDSK-3382](https://viam.atlassian.net/browse/RSDK-3382)

Removes `suppressing error from sctp` logs in both error callbacks (added in this [commit](https://github.com/viamrobotics/goutils/commit/f353bc8a72266afd24807a72d8470a92c8548fb8)).

The `DataChannel`'s `OnError` callbacks (like the `OnClose` callbacks) are [called](https://github.com/pion/webrtc/blob/c05e366e6677576c979a92d14d3cdeff660e34ab/datachannel.go#L346) asynchronously. This means they sometimes run while the channel is being closed or even slightly after. In our tests, this means they sometimes run while the testing object is being [marked](https://github.com/golang/go/blob/release-branch.go1.19/src/testing/testing.go#L1433) "done" and try to log something through the test logger, which [reads](https://github.com/golang/go/blob/release-branch.go1.19/src/testing/testing.go#L883) the done value. The offending log message is always something like:
```
suppressing error from sctp {"ch": 0, "error": "sending reset packet in non-established state: state=Closed"}
```
from any of the server channel, client channel, or peer data channel's error callbacks. After discussing a bit with @dgottlieb (thank you for all the advice), I'm not sure it's paramount that we _ensure_ error callbacks run strictly before channel close; I also sense that would require a change to the `pion` library that is not particularly straightforward nor obviously to spec. It may be easier to just remove these "suppressing" logs for now, which has the added effect of removing noise in tests (given the determined triviality of these logs).