### PR TITLE
APP-2028: Add get last login method

### DIFF
--- a/web/user.go
+++ b/web/user.go
@@ -57,6 +57,8 @@ func (u *UserInfo) GetBool(name string) bool {
 }
 
 // GetLastLogin gets the user last login time.
+// Updated_at is a timestamp indicating when the user's profile was last updated/modified.
+// Changes to last_login are considered updates, so most of the time, updated_at will match last_login.
 func (u *UserInfo) GetLastLogin() string {
 	if u.Properties == nil {
 		return ""

--- a/web/user.go
+++ b/web/user.go
@@ -56,19 +56,17 @@ func (u *UserInfo) GetBool(name string) bool {
 	return b
 }
 
-// GetLastLogin gets the user last login time.
-// Updated_at is a timestamp indicating when the user's profile was last updated/modified.
-// Changes to last_login are considered updates, so most of the time, updated_at will match last_login.
-func (u *UserInfo) GetLastLogin() string {
+// GetUpdatedAt gets the timestamp indicating when the user's auth0 profile was last updated/modified.
+func (u *UserInfo) GetUpdatedAt() string {
 	if u.Properties == nil {
 		return ""
 	}
 
-	lastLogin, ok := u.Properties["updated_at"].(string)
+	updatedAt, ok := u.Properties["updated_at"].(string)
 	if !ok {
 		return ""
 	}
-	return lastLogin
+	return updatedAt
 }
 
 // GetLoggedInUserInfo figures out if the session is associated with a user.

--- a/web/user.go
+++ b/web/user.go
@@ -62,11 +62,11 @@ func (u *UserInfo) GetLastLogin() string {
 		return ""
 	}
 
-	ll, ok := u.Properties["updated_at"].(string)
+	lastLogin, ok := u.Properties["updated_at"].(string)
 	if !ok {
 		return ""
 	}
-	return ll
+	return lastLogin
 }
 
 // GetLoggedInUserInfo figures out if the session is associated with a user.

--- a/web/user.go
+++ b/web/user.go
@@ -56,6 +56,19 @@ func (u *UserInfo) GetBool(name string) bool {
 	return b
 }
 
+// GetLastLogin gets the user last login time.
+func (u *UserInfo) GetLastLogin() string {
+	if u.Properties == nil {
+		return ""
+	}
+
+	ll, ok := u.Properties["updated_at"].(string)
+	if !ok {
+		return ""
+	}
+	return ll
+}
+
 // GetLoggedInUserInfo figures out if the session is associated with a user.
 func GetLoggedInUserInfo(sessions *SessionManager, r *http.Request) (UserInfo, error) {
 	ui := UserInfo{LoggedIn: false, Properties: map[string]interface{}{"email": ""}}


### PR DESCRIPTION
**20230625_APP-2028: Add get last login method**

- Extends the “UserInfo” struct with a new method, GetLastLogin.
- GetLastLogin is needed to help provide last login time of users for display in the members table of the org settings page.

Figma: https://www.figma.com/file/2hs9zGWN9nTLqcm8pR38ip/Management?type=design&node-id=3039-21808
