### PR TITLE
RSDK-4281: Shutting down viam-server causes intel realsense module to seg-fault

### DIFF
--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -106,12 +106,14 @@ func (p *managedProcess) kill() (bool, error) {
 	return forceKilled, nil
 }
 
-func isWaitErrUnknown(err string, forceKilled bool) bool {
-	// This can easily happen if the process does not handle interrupts gracefully
-	// and it won't provide us any exit code info.
+func isWaitErrUnknown(err string, _ bool) bool {
+	// TODO: ensure processes handle interrupts gracefully.
+	//  For now, ignore signals caused by improper handling of interrupts since they provide no exit code, exception, or
+	//  other status information.
 	switch err {
-	case "signal: interrupt", "signal: terminated", "signal: killed":
+	case "signal: interrupt", "signal: terminated", "signal: killed", "signal: segmentation fault":
 		return true
+	default:
+		return false
 	}
-	return false
 }


### PR DESCRIPTION
I've manually tested that this fixes the errors referenced in the ticket. I've also confirmed that the module returns an exit code of 0 and throws no exceptions when this happens with something like
```
int main(int argc, char* argv[]) try {
    return ... // always zero
} catch (const std::exception& e) {
         // no exceptions caught
}

```

This error message should also be ignored since the module does not provide an exit code, exception, or any other status information. The problem is likely at the boundary between the module and the C++ SDK miscommunicating what it means to "[shut] down gracefully" on [close](https://github.com/viamrobotics/viam-cpp-sdk/blob/816344a7932260307fbcfe0255a0c08afeb448f6/src/viam/sdk/module/service.cpp#L223). 

Debugging the C++ SDK along with process signals is way out of the scope of this ticket. I'll create a new ticket and link it in the TODO here if this gets approved, but I think this represents a larger issue of how we shut down processes.
