### PR TITLE
sync/atomic alignment fix

### DIFF
--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -32,7 +32,7 @@ var (
 // A webrtcClientChannel reflects the client end of a gRPC connection serviced over
 // a WebRTC data channel.
 type webrtcClientChannel struct {
-	streamIDCounter   uint64
+	streamIDCounter uint64
 	*webrtcBaseChannel
 	mu                sync.Mutex
 	streams           map[uint64]activeWebRTCClientStream

--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -32,9 +32,9 @@ var (
 // A webrtcClientChannel reflects the client end of a gRPC connection serviced over
 // a WebRTC data channel.
 type webrtcClientChannel struct {
+	streamIDCounter   uint64
 	*webrtcBaseChannel
 	mu                sync.Mutex
-	streamIDCounter   uint64
 	streams           map[uint64]activeWebRTCClientStream
 	unaryInterceptor  grpc.UnaryClientInterceptor
 	streamInterceptor grpc.StreamClientInterceptor


### PR DESCRIPTION
## What changed
- This changes the position of streamIDCounter so it has a 64-bit offset
## Why
- On 32-bit arm systems, sync/atomic will panic on this field
## Lint failure
These only show up when you run the linter on 32-bit arm hardware, but the message looks like this:
```log
rpc/wrtc_client_channel.go:241:7: SA1027: address of non 64-bit aligned field streamIDCounter passed to sync/atomic.AddUint64 (staticcheck)
                Id: atomic.AddUint64(&ch.streamIDCounter, 1),
                    ^
```
The rdk repo will soon check all of its dependencies for these lint failures.