### PR TITLE
APP-2534: Create a TTL index on the web.sessions collection

### DIFF
--- a/web/sessions.go
+++ b/web/sessions.go
@@ -4,16 +4,28 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/edaniels/golog"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.opencensus.io/trace"
+	mongoutils "go.viam.com/utils/mongo"
+)
+
+var (
+	webSessionsIndex = []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "lastUpdated", Value: 1},
+			},
+			Options: options.Index().SetExpireAfterSeconds(30 * 24 * 3600),
+		},
+	}
 )
 
 // SessionManager handles working with sessions from http.
@@ -150,8 +162,12 @@ func (s *Session) Save(ctx context.Context, r *http.Request, w http.ResponseWrit
 // -----
 
 // NewMongoDBSessionStore new MongoDB backed store.
-func NewMongoDBSessionStore(coll *mongo.Collection) Store {
-	return &mongoDBSessionStore{collection: coll}
+func NewMongoDBSessionStore(ctx context.Context,coll *mongo.Collection) (Store, error) {
+	if err := mongoutils.EnsureIndexes(ctx, coll, webSessionsIndex...); err != nil {
+		return nil, errors.Wrap(err, "Failed to create indexes for webSessionsCollection")
+	}
+
+	return &mongoDBSessionStore{collection: coll}, nil
 }
 
 type mongoDBSessionStore struct {

--- a/web/sessions.go
+++ b/web/sessions.go
@@ -8,25 +8,25 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/edaniels/golog"
+	"github.com/edaniels/golog"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.opencensus.io/trace"
+
 	mongoutils "go.viam.com/utils/mongo"
 )
 
-var (
-	webSessionsIndex = []mongo.IndexModel{
-		{
-			Keys: bson.D{
-				{Key: "lastUpdated", Value: 1},
-			},
-			Options: options.Index().SetExpireAfterSeconds(30 * 24 * 3600),
+var webSessionsIndex = []mongo.IndexModel{
+	{
+		Keys: bson.D{
+			{Key: "lastUpdated", Value: 1},
 		},
-	}
-)
+		Options: options.Index().SetExpireAfterSeconds(30 * 24 * 3600),
+	},
+}
 
 // SessionManager handles working with sessions from http.
 type SessionManager struct {
@@ -162,7 +162,7 @@ func (s *Session) Save(ctx context.Context, r *http.Request, w http.ResponseWrit
 // -----
 
 // NewMongoDBSessionStore new MongoDB backed store.
-func NewMongoDBSessionStore(ctx context.Context,coll *mongo.Collection) (Store, error) {
+func NewMongoDBSessionStore(ctx context.Context, coll *mongo.Collection) (Store, error) {
 	if err := mongoutils.EnsureIndexes(ctx, coll, webSessionsIndex...); err != nil {
 		return nil, errors.Wrap(err, "Failed to create indexes for webSessionsCollection")
 	}

--- a/web/sessions.go
+++ b/web/sessions.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
-	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"


### PR DESCRIPTION
This is required for: [Create TTL index on web.sessions in app.viam](https://viam.atlassian.net/browse/APP-2535)

In this PR, I added code to ensure that a TTL index is created on the `web.sessions` collections as this helps me close out work on the `app.viam` on creating a TTL index that removes sessions documents that are over 30 days old.