### PR TITLE
RandomAlphaString fix for 32-bit

### DIFF
--- a/string.go
+++ b/string.go
@@ -11,7 +11,7 @@ const alphaLowers string = "abcdefghijklmnopqrstuvwxyz"
 
 var (
 	alphaUppers     = strings.ToUpper(alphaLowers)
-	maxIntBig       = big.NewInt(math.MaxInt64)
+	maxInt32        = big.NewInt(math.MaxInt32)
 	fiftyFityChance = big.NewInt(2)
 )
 
@@ -24,20 +24,20 @@ func RandomAlphaString(size int) string {
 	}
 	chars := make([]byte, 0, size)
 	for i := 0; i < size; i++ {
-		valBig, err := rand.Int(rand.Reader, maxIntBig)
+		valBig, err := rand.Int(rand.Reader, maxInt32)
 		if err != nil {
 			panic(err)
 		}
-		val := valBig.Int64()
+		val := int(valBig.Int64())
 		chance, err := rand.Int(rand.Reader, fiftyFityChance)
 		if err != nil {
 			panic(err)
 		}
 		switch chance.Int64() {
 		case 0:
-			chars = append(chars, alphaLowers[val%int64(len(alphaLowers))])
+			chars = append(chars, alphaLowers[val%len(alphaLowers)])
 		case 1:
-			chars = append(chars, alphaUppers[val%int64(len(alphaUppers))])
+			chars = append(chars, alphaUppers[val%len(alphaUppers)])
 		}
 	}
 	return string(chars)

--- a/string.go
+++ b/string.go
@@ -28,16 +28,16 @@ func RandomAlphaString(size int) string {
 		if err != nil {
 			panic(err)
 		}
-		val := int(valBig.Int64())
+		val := valBig.Int64()
 		chance, err := rand.Int(rand.Reader, fiftyFityChance)
 		if err != nil {
 			panic(err)
 		}
 		switch chance.Int64() {
 		case 0:
-			chars = append(chars, alphaLowers[val%len(alphaLowers)])
+			chars = append(chars, alphaLowers[val%int64(len(alphaLowers))])
 		case 1:
-			chars = append(chars, alphaUppers[val%len(alphaUppers)])
+			chars = append(chars, alphaUppers[val%int64(len(alphaUppers))])
 		}
 	}
 	return string(chars)


### PR DESCRIPTION
In 32-bit builds, RandomAlphaString can crash with 'index out of range'

Note: golang won't let you compile a simple `array[-1]` because it knows negative numbers shouldn't be array indices, but this sample will repro if you want to see the failure:
```go
package main
import "math"
import "math/big"
import "crypto/rand"
func main() {
	arr := []int{1,2,3}
	for i := 0; i < 20; i++ {
		val, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
		index := int(val.Int64()) % len(arr)
		println("index", index, "val", arr[index])
	}
}
```
Then
```sh
GOARCH=386 go build main.go && main
```
(if you're on M1 mac, do GOARCH=arm)