### PR TITLE
RSDK-4447: Allow dial timeout to be configurable

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -28,10 +28,10 @@ func Dial(ctx context.Context, address string, logger golog.Logger, opts ...Dial
 		logger = zap.NewNop().Sugar()
 	}
 
-	if (dOpts.timeout == 0) {
+	if dOpts.timeout == 0 {
 		dOpts.timeout = 20 // default to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go
 	}
-	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Duration(dOpts.timeout * float64(time.Second)))
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Duration(dOpts.timeout*float64(time.Second)))
 	defer timeoutCancel()
 	return dialInner(timeoutCtx, address, logger, &dOpts)
 }

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -28,7 +28,12 @@ func Dial(ctx context.Context, address string, logger golog.Logger, opts ...Dial
 		logger = zap.NewNop().Sugar()
 	}
 
-	return dialInner(ctx, address, logger, &dOpts)
+	if (dOpts.timeout == 0) {
+		dOpts.timeout = 20 // default to 20sec to match _defaultOfferDeadline in goutils/rpc/wrtc_call_queue.go
+	}
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Duration(dOpts.timeout * float64(time.Second)))
+	defer timeoutCancel()
+	return dialInner(timeoutCtx, address, logger, &dOpts)
 }
 
 func dialInner(

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -64,6 +64,8 @@ type dialOptions struct {
 	// interceptors
 	unaryInterceptor  grpc.UnaryClientInterceptor
 	streamInterceptor grpc.StreamClientInterceptor
+
+	timeout float64
 }
 
 // DialMulticastDNSOptions dictate any special settings to apply while dialing via mDNS.


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-4447

Changes in Goutils:

- [x] Add DialOptions float attribute for seconds of timeout
- [x] Add handling of timeout in Dial with new context and a default of 20sec
- [ ] Test using local RDK deployment with throttling