### PR TITLE
RSDK-4447: Allow dial timeout to be configurable

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -70,7 +70,6 @@ func dialInner(
 			conn, _, err := dial(ctx, address, address, logger, dOpts, true)
 			return conn, err
 		})
-
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +212,8 @@ func dialMulticastDNS(
 		defer resolver.Shutdown()
 		for _, candidate := range candidates {
 			entries := make(chan *zeroconf.ServiceEntry)
-			var lookupCtx context.Context; var cancel context.CancelFunc
+			var lookupCtx context.Context
+			var cancel context.CancelFunc
 			if _, ok := ctx.Deadline(); ok {
 				lookupCtx, cancel = context.WithCancel(ctx)
 			} else {


### PR DESCRIPTION
### Summary

https://viam.atlassian.net/browse/RSDK-4447

`lookupCtx` blocks the dial webrtc process from being longer than 12 seconds. Added conditional logic that respects user set custom deadlines, allowing >12 second context duration

### Test procedure
1. Setup basic go sdk client
```
func main() {
  logger := golog.NewDevelopmentLogger("client")
  ctx := context.Background()
  timeoutContext, cancel := context.WithTimeout(ctx, 30*time.Second)
  defer cancel()
  startTime := time.Now()
  robot, err := client.New(
      timeoutContext,
      "go-sdk-test-main.yznpnnv7bl.viam.cloud",
      logger,
      client.WithDialOptions(rpc.WithCredentials(rpc.Credentials{
          Type:    utils.CredentialsTypeRobotLocationSecret,
          Payload: "tveba0mvmygaae8hnz4rhybwf1bsijv4gby6s266ntvcg5yl",
      })),
  )
  if err != nil {
    logger.Warn(time.Since(startTime))
    deadline, ok := timeoutContext.Deadline()
    if ok {
        logger.Warnf("%v", time.Until(deadline).Seconds())
    } else {
        logger.Warn("context not ok")
    }
    logger.Fatal(err)
  }
  defer robot.Close(context.Background())
  logger.Info("Resources:")
  logger.Info(robot.ResourceNames())
}
```
2. Make it to connect to a non-existent robot
3. Logged execution times and errors (tracking whether or not they came from context deadlines or other sources)
4. Found chokepoint at lookupCtx

After adding the conditional logic, both a 1-min and 3-min timeout context passed in from the client timed out (deadline exceeded error) as expected