### PR TITLE
APP-2592:  Goutils: implement auth handler that supports (id, key) pairs

### DIFF
--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -225,8 +225,10 @@ func MakeSimpleMultiAuthPairHandler(forEntities, expectedPayloads []map[string]s
 			return nil, err
 		}
 
-		// Find the key that maps to the current payload which is a keyID
+		// set the keyID to the current payload
 		payloadKeyID := []byte(payload)
+
+		// Find the key that maps to the current payload
 		var payloadKey string
 		for _, pk := range expectedPayloads {
 			for key, value := range pk {

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -251,11 +251,6 @@ func MakeSimpleMultiAuthPairHandler(forEntities, expectedPayloads []map[string]s
 		}
 		return nil, errInvalidCredentials
 	})
-	// We are given a keyID and a key by the user
-	// Perform a lookup of the keyID in the list of pre-populated keyIDs
-	// If the keyID is found, lookup the corresponding key to the ID found in the list of keyIDs
-	// Compare that that key is the same as the key passed in the request
-	// Done
 }
 
 // MakeEntitiesChecker checks a list of entities against a given one for use in an auth handler.

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -224,12 +224,12 @@ func MakeSimpleMultiAuthPairHandler(forEntities, expectedPayloads []map[string]s
 			}
 			return nil, err
 		}
-		payloadKeyID := []byte(payload)
 
 		// Find the key that maps to the current payload which is a keyID
+		payloadKeyID := []byte(payload)
 		var payloadKey string
-		for _, entity := range forEntities {
-			for key, value := range entity {
+		for _, pk := range expectedPayloads {
+			for key, value := range pk {
 				if subtle.ConstantTimeCompare([]byte(key), payloadKeyID) == 1 {
 					payloadKey = value
 				}

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -203,7 +203,6 @@ func MakeSimpleMultiAuthHandler(forEntities, expectedPayloads []string) AuthHand
 // MakeSimpleMultiAuthPairHandler works similarly to MakeSimpleMultiAuthHandler with the addition of
 // supporting a key, id pair used to ensure that a key that maps to the id matches the key passed
 // during the function call.
-
 func MakeSimpleMultiAuthPairHandler(expectedPayloads map[string]string) AuthHandler {
 	if len(expectedPayloads) == 0 {
 		panic("expected at least one payload")

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -249,7 +249,6 @@ func MakeSimpleMultiAuthPairHandler(forEntities, expectedPayloads []map[string]s
 					}
 				}
 			}
-
 		}
 		return nil, errInvalidCredentials
 	})

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -137,6 +137,14 @@ func TestMakeSimpleMultiAuthHandler(t *testing.T) {
 	})
 }
 
+func TestMakeSimpleMultiAuthPairHandler(t *testing.T) {
+	test.That(t, func() {
+		MakeSimpleMultiAuthPairHandler([]string{"hey"}, nil)
+	}, test.ShouldPanicWith, "expected at least one payload")
+
+
+}
+
 func TestTokenVerificationKeyProviderFunc(t *testing.T) {
 	err1 := errors.New("whoops")
 	capCtx := make(chan struct{})

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -150,7 +150,7 @@ func TestMakeSimpleMultiAuthPairHandler(t *testing.T) {
 		test.That(t, err, test.ShouldNotBeNil)
 	})
 
-	t.Run("should validate entities and key", func(t *testing.T) {
+	t.Run("should validate entities and (keyID, key) mappings", func(t *testing.T) {
 		expectedEntitiesMap := []map[string]string{{"one": "1"}, {"two": "2"}, {"three": "3"}}
 		expectedKeysMap := []map[string]string{{"myKeyID": "someKey"}, {"somethingElseKeyID": "someOtherKeyID"}}
 		handler := MakeSimpleMultiAuthPairHandler(expectedEntitiesMap, expectedKeysMap)

--- a/rpc/auth_test.go
+++ b/rpc/auth_test.go
@@ -139,45 +139,21 @@ func TestMakeSimpleMultiAuthHandler(t *testing.T) {
 
 func TestMakeSimpleMultiAuthPairHandler(t *testing.T) {
 	test.That(t, func() {
-		MakeSimpleMultiAuthPairHandler([]map[string]string{{"one": "1"}}, nil)
+		MakeSimpleMultiAuthPairHandler(map[string]string{})
 	}, test.ShouldPanicWith, "expected at least one payload")
 
-	t.Run("with no entities should always fail", func(t *testing.T) {
-		handler := MakeSimpleMultiAuthPairHandler(nil, []map[string]string{{"something": "nothing"}})
-		_, err := handler.Authenticate(context.Background(), "", "something")
-		test.That(t, err, test.ShouldNotBeNil)
-		_, err = handler.Authenticate(context.Background(), "entity", "something")
-		test.That(t, err, test.ShouldNotBeNil)
-	})
+	t.Run("should validate (keyID, key) mappings", func(t *testing.T) {
+		expectedKeysMap := map[string]string{"myKeyID": "someKey", "somethingElseKeyID": "someOtherKeyID"}
+		handler := MakeSimpleMultiAuthPairHandler(expectedKeysMap)
 
-	t.Run("should validate entities and (keyID, key) mappings", func(t *testing.T) {
-		expectedEntitiesMap := []map[string]string{{"one": "1"}, {"two": "2"}, {"three": "3"}}
-		expectedKeysMap := []map[string]string{{"myKeyID": "someKey"}, {"somethingElseKeyID": "someOtherKeyID"}}
-		handler := MakeSimpleMultiAuthPairHandler(expectedEntitiesMap, expectedKeysMap)
+		for key, value := range expectedKeysMap {
+			t.Run(key, func(t *testing.T) {
+				_, err := handler.Authenticate(context.Background(), key, value)
+				test.That(t, err, test.ShouldBeNil)
+				_, err = handler.Authenticate(context.Background(), key, value+"1")
+				test.That(t, err, test.ShouldEqual, errInvalidCredentials)
 
-		var expectedKeys []string
-		for _, ek := range expectedKeysMap {
-			for key := range ek {
-				expectedKeys = append(expectedKeys, key)
-			}
-		}
-
-		var expectedEntities []string
-		for _, en := range expectedEntitiesMap {
-			for key := range en {
-				expectedEntities = append(expectedEntities, key)
-			}
-		}
-
-		for _, expectedKey := range expectedKeys {
-			t.Run(expectedKey, func(t *testing.T) {
-				for _, ent := range expectedEntities {
-					_, err := handler.Authenticate(context.Background(), ent, expectedKey)
-					test.That(t, err, test.ShouldBeNil)
-					_, err = handler.Authenticate(context.Background(), ent, expectedKey+"1")
-					test.That(t, err, test.ShouldEqual, errInvalidCredentials)
-				}
-				_, err := handler.Authenticate(context.Background(), "notent", expectedKey)
+				_, err = handler.Authenticate(context.Background(), "notent", key)
 				test.That(t, err, test.ShouldBeError, errInvalidCredentials)
 			})
 		}

--- a/web/api.go
+++ b/web/api.go
@@ -115,7 +115,7 @@ func (am *APIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	marshaler := protojson.Marshaler{am.MarshalingOptions}
+	marshaler := protojson.Marshaler{Opts: am.MarshalingOptions}
 	js, err := marshaler.Marshal(data)
 	if handleAPIError(w, err, am.Logger, nil) {
 		return

--- a/web/api.go
+++ b/web/api.go
@@ -115,7 +115,7 @@ func (am *APIMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	marshaler := protojson.Marshaler{Opts: am.MarshalingOptions}
+	marshaler := protojson.Marshaler{am.MarshalingOptions}
 	js, err := marshaler.Marshal(data)
 	if handleAPIError(w, err, am.Logger, nil) {
 		return


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/APP-2592)

## Description:
The goal of this PR is to add the `MakeSimpleMultiAuthPairHandler` which implements an auth handler for an api key and api key id pair. The goal is described more in-depth [here](https://docs.google.com/document/d/1o1Eq0bQBun4LADDaOWGjUTI9dfOnI4wenTe6JtChe3Y/edit#bookmark=id.ff76wzf60oxk)

## Testing:
- [x] Added unit test to test proper software behavior.