### PR TITLE
Add struct to structpb method that ignores omit empty tags

### DIFF
--- a/protoutils/protoutils.go
+++ b/protoutils/protoutils.go
@@ -13,7 +13,7 @@ import (
 // InterfaceToMap attempts to coerce an interface into a form acceptable by structpb.NewStruct.
 // Expects a struct or a map-like object.
 func InterfaceToMap(data interface{}) (map[string]interface{}, error) {
-	return interfaceToMapHelper(data, true)
+	return interfaceToMapHelper(data, false)
 }
 
 func interfaceToMapHelper(data interface{}, ignoreOmitEmpty bool) (map[string]interface{}, error) {
@@ -66,7 +66,7 @@ func StructToStructPb(i interface{}) (*structpb.Struct, error) {
 // StructToStructPbIgnoreOmitEmpty converts an arbitrary Go struct to a *structpb.Struct. Only exported fields are included in the
 // returned proto and any omitempty tag is ignored.
 func StructToStructPbIgnoreOmitEmpty(i interface{}) (*structpb.Struct, error) {
-	encoded, err := interfaceToMapHelper(i, false)
+	encoded, err := interfaceToMapHelper(i, true)
 	if err != nil {
 		return nil, errors.Wrapf(err,
 			"unable to convert interface %v to a form acceptable to structpb.NewStruct", i)
@@ -185,8 +185,8 @@ func structToMap(data interface{}, ignoreOmitEmpty bool) (map[string]interface{}
 
 		field := value.Field(i).Interface()
 
-		// If "omitempty" is specified in the tag, it ignores empty values.
-		if ignoreOmitEmpty && strings.Contains(tag, "omitempty") && isEmptyValue(reflect.ValueOf(field)) {
+		// If "omitempty" is specified in the tag and ignoreOmitEmpty is false, it ignores empty values.
+		if !ignoreOmitEmpty && strings.Contains(tag, "omitempty") && isEmptyValue(reflect.ValueOf(field)) {
 			continue
 		}
 

--- a/protoutils/protoutils.go
+++ b/protoutils/protoutils.go
@@ -92,7 +92,7 @@ func StructToStructPb(i interface{}) (*structpb.Struct, error) {
 	return ret, nil
 }
 
-// StructToStructPb converts an arbitrary Go struct to a *structpb.Struct. Only exported fields are included in the
+// StructToStructPbIgnoreOmitEmpty converts an arbitrary Go struct to a *structpb.Struct. Only exported fields are included in the
 // returned proto and any omitempty tag is ignored.
 func StructToStructPbIgnoreOmitEmpty(i interface{}) (*structpb.Struct, error) {
 	encoded, err := interfaceToMapKeepEmpty(i)

--- a/protoutils/protoutils.go
+++ b/protoutils/protoutils.go
@@ -44,6 +44,7 @@ func InterfaceToMap(data interface{}) (map[string]interface{}, error) {
 	return res, nil
 }
 
+//nolint:dupl
 func interfaceToMapKeepEmpty(data interface{}) (map[string]interface{}, error) {
 	if data == nil {
 		return nil, errors.New("no data passed in")
@@ -177,7 +178,7 @@ func isEmptyValue(v reflect.Value) bool {
 
 // structToMap attempts to coerce a struct into a form acceptable by grpc.
 // shouldOmit specifies whether to ignore empty values if they are tagged omit empty or
-// keep all values
+// keep all values.
 func structToMap(data interface{}, shouldOmitEmpty bool) (map[string]interface{}, error) {
 	t := reflect.TypeOf(data)
 	if t.Kind() == reflect.Ptr {

--- a/protoutils/protoutils.go
+++ b/protoutils/protoutils.go
@@ -12,8 +12,6 @@ import (
 
 // InterfaceToMap attempts to coerce an interface into a form acceptable by structpb.NewStruct.
 // Expects a struct or a map-like object.
-//
-
 func InterfaceToMap(data interface{}) (map[string]interface{}, error) {
 	return interfaceToMapHelper(data, true)
 }

--- a/protoutils/protoutils.go
+++ b/protoutils/protoutils.go
@@ -12,6 +12,8 @@ import (
 
 // InterfaceToMap attempts to coerce an interface into a form acceptable by structpb.NewStruct.
 // Expects a struct or a map-like object.
+//
+//nolint:dupl
 func InterfaceToMap(data interface{}) (map[string]interface{}, error) {
 	if data == nil {
 		return nil, errors.New("no data passed in")

--- a/protoutils/protoutils_test.go
+++ b/protoutils/protoutils_test.go
@@ -182,24 +182,24 @@ func TestInterfaceToMap(t *testing.T) {
 
 func TestMarshalMap(t *testing.T) {
 	t.Run("not a valid map", func(t *testing.T) {
-		_, err := marshalMap(simpleStruct)
+		_, err := marshalMap(simpleStruct, true)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type protoutils.SimpleStruct is not a map"))
 
-		_, err = marshalMap("1")
+		_, err = marshalMap("1", true)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type string is not a map"))
 
-		_, err = marshalMap([]string{"1"})
+		_, err = marshalMap([]string{"1"}, true)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type []string is not a map"))
 
-		_, err = marshalMap(map[int]string{1: "1"})
+		_, err = marshalMap(map[int]string{1: "1"}, true)
 		test.That(t, err, test.ShouldBeError, errors.New("map keys of type int are not strings and do not implement String"))
 
-		_, err = marshalMap(map[interface{}]string{"1": "1"})
+		_, err = marshalMap(map[interface{}]string{"1": "1"}, true)
 		test.That(t, err, test.ShouldBeError, errors.New("map keys of type interface are not strings and do not implement String"))
 	})
 
 	for _, tc := range mapTests {
-		map1, err := marshalMap(tc.Data)
+		map1, err := marshalMap(tc.Data, true)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, map1, test.ShouldResemble, tc.Expected)
 
@@ -211,19 +211,19 @@ func TestMarshalMap(t *testing.T) {
 
 func TestStructToMap(t *testing.T) {
 	t.Run("not a struct", func(t *testing.T) {
-		_, err := structToMap(map[string]interface{}{"exists": true})
+		_, err := structToMap(map[string]interface{}{"exists": true}, true)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type map[string]interface {} is not a struct"))
 
-		_, err = structToMap(1)
+		_, err = structToMap(1, true)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type int is not a struct"))
 
-		_, err = structToMap([]string{"1"})
+		_, err = structToMap([]string{"1"}, true)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type []string is not a struct"))
 	})
 
 	//nolint:dupl
 	for _, tc := range structTests {
-		map1, err := structToMap(tc.Data)
+		map1, err := structToMap(tc.Data, true)
 		test.That(t, err, test.ShouldBeNil)
 		switch tc.TestName {
 		case "struct with uint":
@@ -256,7 +256,7 @@ func TestStructToMap(t *testing.T) {
 
 func TestMarshalSlice(t *testing.T) {
 	t.Run("not a list", func(t *testing.T) {
-		_, err := marshalSlice(1)
+		_, err := marshalSlice(1, true)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type int is not a slice"))
 	})
 
@@ -304,7 +304,7 @@ func TestMarshalSlice(t *testing.T) {
 		},
 	} {
 		t.Run(tc.TestName, func(t *testing.T) {
-			marshalled, err := marshalSlice(tc.Data)
+			marshalled, err := marshalSlice(tc.Data, true)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, len(marshalled), test.ShouldEqual, tc.Length)
 			test.That(t, marshalled, test.ShouldResemble, tc.Expected)
@@ -332,24 +332,33 @@ func TestStructToStructPb(t *testing.T) {
 	}
 }
 
+func TestStructToStructPbOmitEmpty(t *testing.T) {
+	expected := map[string]interface{}{"x": 0.0, "y": 0.0}
+	t.Run("StructToStructPBIgnoreOmitEmpty includes all values", func(t *testing.T) {
+		data, err := StructToStructPbIgnoreOmitEmpty(OmitStruct{})
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, data.AsMap(), test.ShouldResemble, expected)
+	})
+}
+
 func TestToInterfaceWeirdBugUint(t *testing.T) {
 	a := uint(5)
-	x, err := toInterface(a)
+	x, err := toInterface(a, true)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 
-	x, err = toInterface(&a)
+	x, err = toInterface(&a, true)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 }
 
 func TestToInterfaceWeirdBugUint8(t *testing.T) {
 	a := uint8(5)
-	x, err := toInterface(a)
+	x, err := toInterface(a, true)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 
-	x, err = toInterface(&a)
+	x, err = toInterface(&a, true)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 }

--- a/protoutils/protoutils_test.go
+++ b/protoutils/protoutils_test.go
@@ -72,7 +72,7 @@ var (
 	structTests = []structTest{
 		{"simple struct", simpleStruct, map[string]interface{}{"x": 1.1, "y": 2.2, "z": 3.3}, SimpleStruct{}},
 		{"typed string struct", typedStringStruct, map[string]interface{}{"typed_string": "hello"}, TypedStringStruct{}},
-		{"omit struct", OmitStruct{}, map[string]interface{}{}, OmitStruct{}},
+		{"omit struct", OmitStruct{}, map[string]interface{}{"x": 0.0}, OmitStruct{}},
 		{"ignore struct", IgnoreStruct{X: 1}, map[string]interface{}{}, IgnoreStruct{X: 1}},
 		{"slice struct", sliceStruct, map[string]interface{}{"degrees": []interface{}{1.1, 2.2, 3.3}}, SliceStruct{}},
 		{"map struct", mapStruct, map[string]interface{}{"status": map[string]interface{}{"foo": "bar"}}, MapStruct{}},
@@ -379,7 +379,7 @@ type (
 )
 
 type OmitStruct struct {
-	X float64 `json:"x,omitempty"`
+	X float64 `json:"x"`
 	Y float64 `json:"y,omitempty"`
 }
 type IgnoreStruct struct {

--- a/protoutils/protoutils_test.go
+++ b/protoutils/protoutils_test.go
@@ -334,11 +334,9 @@ func TestStructToStructPb(t *testing.T) {
 
 func TestStructToStructPbOmitEmpty(t *testing.T) {
 	expected := map[string]interface{}{"x": 0.0, "y": 0.0}
-	t.Run("StructToStructPBIgnoreOmitEmpty includes all values", func(t *testing.T) {
-		data, err := StructToStructPbIgnoreOmitEmpty(OmitStruct{})
-		test.That(t, err, test.ShouldBeNil)
-		test.That(t, data.AsMap(), test.ShouldResemble, expected)
-	})
+	data, err := StructToStructPbIgnoreOmitEmpty(OmitStruct{})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, data.AsMap(), test.ShouldResemble, expected)
 }
 
 func TestToInterfaceWeirdBugUint(t *testing.T) {

--- a/protoutils/protoutils_test.go
+++ b/protoutils/protoutils_test.go
@@ -220,7 +220,6 @@ func TestStructToMap(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, errors.New("data of type []string is not a struct"))
 	})
 
-	
 	for _, tc := range structTests {
 		map1, err := structToMap(tc.Data, true)
 		test.That(t, err, test.ShouldBeNil)

--- a/protoutils/protoutils_test.go
+++ b/protoutils/protoutils_test.go
@@ -16,7 +16,7 @@ type mapTest struct {
 	Expected map[string]interface{}
 }
 
-const shouldOmitEmpty = true
+const ignoreOmitEmpty = false
 
 var (
 	myUUIDString = "c0ab974c-f32c-11ed-a05b-0242ac120003"
@@ -183,24 +183,24 @@ func TestInterfaceToMap(t *testing.T) {
 
 func TestMarshalMap(t *testing.T) {
 	t.Run("not a valid map", func(t *testing.T) {
-		_, err := marshalMap(simpleStruct, shouldOmitEmpty)
+		_, err := marshalMap(simpleStruct, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type protoutils.SimpleStruct is not a map"))
 
-		_, err = marshalMap("1", shouldOmitEmpty)
+		_, err = marshalMap("1", ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type string is not a map"))
 
-		_, err = marshalMap([]string{"1"}, shouldOmitEmpty)
+		_, err = marshalMap([]string{"1"}, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type []string is not a map"))
 
-		_, err = marshalMap(map[int]string{1: "1"}, shouldOmitEmpty)
+		_, err = marshalMap(map[int]string{1: "1"}, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("map keys of type int are not strings and do not implement String"))
 
-		_, err = marshalMap(map[interface{}]string{"1": "1"}, shouldOmitEmpty)
+		_, err = marshalMap(map[interface{}]string{"1": "1"}, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("map keys of type interface are not strings and do not implement String"))
 	})
 
 	for _, tc := range mapTests {
-		map1, err := marshalMap(tc.Data, shouldOmitEmpty)
+		map1, err := marshalMap(tc.Data, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, map1, test.ShouldResemble, tc.Expected)
 
@@ -212,18 +212,18 @@ func TestMarshalMap(t *testing.T) {
 
 func TestStructToMap(t *testing.T) {
 	t.Run("not a struct", func(t *testing.T) {
-		_, err := structToMap(map[string]interface{}{"exists": true}, shouldOmitEmpty)
+		_, err := structToMap(map[string]interface{}{"exists": true}, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type map[string]interface {} is not a struct"))
 
-		_, err = structToMap(1, shouldOmitEmpty)
+		_, err = structToMap(1, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type int is not a struct"))
 
-		_, err = structToMap([]string{"1"}, shouldOmitEmpty)
+		_, err = structToMap([]string{"1"}, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type []string is not a struct"))
 	})
 
 	for _, tc := range structTests {
-		map1, err := structToMap(tc.Data, shouldOmitEmpty)
+		map1, err := structToMap(tc.Data, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeNil)
 		switch tc.TestName {
 		case "struct with uint":
@@ -256,7 +256,7 @@ func TestStructToMap(t *testing.T) {
 
 func TestMarshalSlice(t *testing.T) {
 	t.Run("not a list", func(t *testing.T) {
-		_, err := marshalSlice(1, shouldOmitEmpty)
+		_, err := marshalSlice(1, ignoreOmitEmpty)
 		test.That(t, err, test.ShouldBeError, errors.New("data of type int is not a slice"))
 	})
 
@@ -304,7 +304,7 @@ func TestMarshalSlice(t *testing.T) {
 		},
 	} {
 		t.Run(tc.TestName, func(t *testing.T) {
-			marshalled, err := marshalSlice(tc.Data, shouldOmitEmpty)
+			marshalled, err := marshalSlice(tc.Data, ignoreOmitEmpty)
 			test.That(t, err, test.ShouldBeNil)
 			test.That(t, len(marshalled), test.ShouldEqual, tc.Length)
 			test.That(t, marshalled, test.ShouldResemble, tc.Expected)
@@ -341,22 +341,22 @@ func TestStructToStructPbOmitEmpty(t *testing.T) {
 
 func TestToInterfaceWeirdBugUint(t *testing.T) {
 	a := uint(5)
-	x, err := toInterface(a, shouldOmitEmpty)
+	x, err := toInterface(a, ignoreOmitEmpty)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 
-	x, err = toInterface(&a, shouldOmitEmpty)
+	x, err = toInterface(&a, ignoreOmitEmpty)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 }
 
 func TestToInterfaceWeirdBugUint8(t *testing.T) {
 	a := uint8(5)
-	x, err := toInterface(a, shouldOmitEmpty)
+	x, err := toInterface(a, ignoreOmitEmpty)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 
-	x, err = toInterface(&a, shouldOmitEmpty)
+	x, err = toInterface(&a, ignoreOmitEmpty)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, x, test.ShouldEqual, a)
 }

--- a/protoutils/protoutils_test.go
+++ b/protoutils/protoutils_test.go
@@ -147,7 +147,6 @@ func TestInterfaceToMap(t *testing.T) {
 		test.That(t, newStruct.AsMap(), test.ShouldResemble, tc.Expected)
 	}
 
-	//nolint:dupl
 	for _, tc := range structTests {
 		map1, err := InterfaceToMap(tc.Data)
 		test.That(t, err, test.ShouldBeNil)
@@ -221,7 +220,7 @@ func TestStructToMap(t *testing.T) {
 		test.That(t, err, test.ShouldBeError, errors.New("data of type []string is not a struct"))
 	})
 
-	//nolint:dupl
+	
 	for _, tc := range structTests {
 		map1, err := structToMap(tc.Data, true)
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
Hey yall, as part of queryable sensor data , we would like users to be able to see all fields of their data regardless of it is an "empty value". If a boolean is false, it can be dropped from the collector which is not ideal. The testing for the new method is fairly barebones as its fundamentally the same method, just added a case where it shouldn't be dropping a variable. I'm happy to add more if required. 