### PR TITLE
DATA-2031 windows-specific build

### DIFF
--- a/etc/.golangci.yaml
+++ b/etc/.golangci.yaml
@@ -76,6 +76,9 @@ linters-settings:
       - shadow
   lll:
     line-length: 140
+  revive:
+    disable:
+    - package-comments
 issues:
   exclude:
     - composites

--- a/runtime.go
+++ b/runtime.go
@@ -43,7 +43,7 @@ func contextualMain(main func(ctx context.Context, args []string, logger golog.L
 		ctx = ContextWithQuitSignal(ctx, quitC)
 	}
 	usr1C := make(chan os.Signal, 1)
-	signal.Notify(usr1C, syscall.SIGUSR1)
+	notifySignals(usr1C)
 
 	var signalWatcher sync.WaitGroup
 	signalWatcher.Add(1)

--- a/runtime_posix.go
+++ b/runtime_posix.go
@@ -1,10 +1,11 @@
 //go:build !windows
+
 package utils
 
 import (
-	"syscall"
 	"os"
 	"os/signal"
+	"syscall"
 )
 
 func notifySignals(channel chan os.Signal) {

--- a/runtime_posix.go
+++ b/runtime_posix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+package utils
+
+import (
+	"syscall"
+	"os"
+	"os/signal"
+)
+
+func notifySignals(channel chan os.Signal) {
+	signal.Notify(channel, syscall.SIGUSR1)
+}

--- a/runtime_windows.go
+++ b/runtime_windows.go
@@ -1,0 +1,7 @@
+package utils
+
+import "os"
+
+func notifySignals(channel chan os.Signal) {
+	println("skipping notifySignals on windows platform")
+}


### PR DESCRIPTION
## What
- move signal registration for ContextualMain to architecture-specific file
- note: I'm not sure what this is used for and it's possible ContextualMain won't work correctly on windows (but seems like SIGTERM will still support some use cases)
- this is for CLI, which doesn't use ContextualMain. another option here would be to move the entire ContextualMain logic to runtime_posix.go
## Why
- this is to allow a windows-specific build of the CLI in rdk repo