### PR TITLE
add ProcessConfig.Username field

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Check out main branch code
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
       uses: actions/checkout@v3
       with:
         fetch-depth: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,13 @@ jobs:
         export ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS=`pwd`/artifact_google_creds.json
         sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI,MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY bash -lc 'make cover'
 
+    # this one runs as root for CAP_SETUID
+    - name: test run-as-user
+      env:
+        TEST_SUBPROC_USER: testbot
+      run: |
+        sudo go test -v ./pexec -run TestManagedProcessStart
+
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2.2.0
       if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-  pull_request: # pull_request_target:
-    # branches: [ main ]
-    # types: [ labeled ]
+  pull_request_target:
+    branches: [ main ]
+    types: [ labeled ]
 
 jobs:
   test_passing:
@@ -22,7 +22,7 @@ jobs:
 
   build_and_test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: [x64, qemu-host]
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
       options: --platform linux/amd64
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Check out main branch code
-      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'pull_request'
+      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
       uses: actions/checkout@v3
       with:
         fetch-depth: 2
@@ -61,32 +61,33 @@ jobs:
         echo "GITHUB_X_PR_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
         echo "GITHUB_X_PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
 
-    # - name: Verify no uncommitted changes from "make build lint"
-    #   run: |
-    #     git init
-    #     git add .
-    #     chown -R testbot .
-    #     sudo -u testbot bash -lc 'make build lint'
-    #     GEN_DIFF=$(git status -s)
-    #     if [ -n "$GEN_DIFF" ]; then
-    #         echo '"make build lint" resulted in changes not in git' 1>&2
-    #         git status
-    #         exit 1
-    #     fi
+    - name: Verify no uncommitted changes from "make build lint"
+      run: |
+        git init
+        git add .
+        chown -R testbot .
+        sudo -u testbot bash -lc 'make build lint'
+        GEN_DIFF=$(git status -s)
+        if [ -n "$GEN_DIFF" ]; then
+            echo '"make build lint" resulted in changes not in git' 1>&2
+            git status
+            exit 1
+        fi
 
-    # - name: Test
-    #   env:
-    #     TEST_MONGODB_URI: ${{ secrets.TEST_MONGODB_URI }}
-    #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
-    #   run: |
-    #     sudo -u testbot bash -lc 'echo "${{ secrets.ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > artifact_google_creds.json'
-    #     export ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS=`pwd`/artifact_google_creds.json
-    #     sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI,MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY bash -lc 'make cover'
+    - name: Test
+      env:
+        TEST_MONGODB_URI: ${{ secrets.TEST_MONGODB_URI }}
+        MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+      run: |
+        sudo -u testbot bash -lc 'echo "${{ secrets.ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > artifact_google_creds.json'
+        export ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS=`pwd`/artifact_google_creds.json
+        sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI,MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY bash -lc 'make cover'
 
     # this one runs as root for CAP_SETUID
     - name: test run-as-user
-      run: |
-        sudo sh -c "TEST_SUBPROC_USER=testbot go test -v ./pexec -run TestManagedProcessStart"
+      env:
+        TEST_SUBPROC_USER: testbot
+      run: go test -v ./pexec -run TestManagedProcessStart
 
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-  pull_request_target:
-    branches: [ main ]
-    types: [ labeled ]
+  pull_request: # pull_request_target:
+    # branches: [ main ]
+    # types: [ labeled ]
 
 jobs:
   test_passing:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,34 +61,32 @@ jobs:
         echo "GITHUB_X_PR_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
         echo "GITHUB_X_PR_BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
 
-    - name: Verify no uncommitted changes from "make build lint"
-      run: |
-        git init
-        git add .
-        chown -R testbot .
-        sudo -u testbot bash -lc 'make build lint'
-        GEN_DIFF=$(git status -s)
-        if [ -n "$GEN_DIFF" ]; then
-            echo '"make build lint" resulted in changes not in git' 1>&2
-            git status
-            exit 1
-        fi
+    # - name: Verify no uncommitted changes from "make build lint"
+    #   run: |
+    #     git init
+    #     git add .
+    #     chown -R testbot .
+    #     sudo -u testbot bash -lc 'make build lint'
+    #     GEN_DIFF=$(git status -s)
+    #     if [ -n "$GEN_DIFF" ]; then
+    #         echo '"make build lint" resulted in changes not in git' 1>&2
+    #         git status
+    #         exit 1
+    #     fi
 
-    - name: Test
-      env:
-        TEST_MONGODB_URI: ${{ secrets.TEST_MONGODB_URI }}
-        MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
-      run: |
-        sudo -u testbot bash -lc 'echo "${{ secrets.ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > artifact_google_creds.json'
-        export ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS=`pwd`/artifact_google_creds.json
-        sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI,MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY bash -lc 'make cover'
+    # - name: Test
+    #   env:
+    #     TEST_MONGODB_URI: ${{ secrets.TEST_MONGODB_URI }}
+    #     MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+    #   run: |
+    #     sudo -u testbot bash -lc 'echo "${{ secrets.ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > artifact_google_creds.json'
+    #     export ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS=`pwd`/artifact_google_creds.json
+    #     sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI,MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY bash -lc 'make cover'
 
     # this one runs as root for CAP_SETUID
     - name: test run-as-user
-      env:
-        TEST_SUBPROC_USER: testbot
       run: |
-        sudo go test -v ./pexec -run TestManagedProcessStart
+        sudo sh -c "TEST_SUBPROC_USER=testbot go test -v ./pexec -run TestManagedProcessStart"
 
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
   build_and_test:
     name: Build and Test
-    runs-on: [x64, qemu-host]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
       options: --platform linux/amd64

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -51,6 +51,7 @@ func NewManagedProcess(config ProcessConfig, logger golog.Logger) ManagedProcess
 		name:             config.Name,
 		args:             config.Args,
 		cwd:              config.CWD,
+		username:         config.Username,
 		oneShot:          config.OneShot,
 		shouldLog:        config.Log,
 		onUnexpectedExit: config.OnUnexpectedExit,
@@ -71,6 +72,7 @@ type managedProcess struct {
 	args      []string
 	cwd       string
 	oneShot   bool
+	username  string
 	shouldLog bool
 	cmd       *exec.Cmd
 

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -116,7 +116,10 @@ func (p *managedProcess) Start(ctx context.Context) error {
 		// to finish running.
 		//nolint:gosec
 		cmd := exec.CommandContext(ctx, p.name, p.args...)
-		cmd.SysProcAttr = sysProcAttr()
+		var err error
+		if cmd.SysProcAttr, err = p.sysProcAttr(); err != nil {
+			return err
+		}
 		cmd.Dir = p.cwd
 		var runErr error
 		if p.shouldLog || p.logWriter != nil {
@@ -147,7 +150,10 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	// use the CommandContext variant.
 	//nolint:gosec
 	cmd := exec.Command(p.name, p.args...)
-	cmd.SysProcAttr = sysProcAttr()
+	var err error
+	if cmd.SysProcAttr, err = p.sysProcAttr(); err != nil {
+		return err
+	}
 	cmd.Dir = p.cwd
 
 	var stdOut, stdErr io.ReadCloser

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -212,8 +212,8 @@ func TestManagedProcessStart(t *testing.T) {
 				Log:      true,
 			}, golog.NewTestLogger(t))
 			test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
-			detectedUid, _ := exec.Command("ps", "--no-headers", "-o", "uid", "-p", strconv.Itoa(proc.(*managedProcess).cmd.Process.Pid)).Output()
-			test.That(t, asUser.Uid, test.ShouldEqual, strings.Trim(string(detectedUid), " \n\r"))
+			detectedUID, _ := exec.Command("ps", "--no-headers", "-o", "uid", "-p", strconv.Itoa(proc.(*managedProcess).cmd.Process.Pid)).Output()
+			test.That(t, asUser.Uid, test.ShouldEqual, strings.Trim(string(detectedUID), " \n\r"))
 			test.That(t, proc.Stop(), test.ShouldBeNil)
 		})
 	})

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -28,8 +28,10 @@ import (
 func subprocUser() *user.User {
 	var userInfo *user.User
 	var err error
+	println("getenv", os.Getenv("TEST_SUBPROC_USER"))
 	if usernameFromEnv := os.Getenv("TEST_SUBPROC_USER"); len(usernameFromEnv) > 0 {
 		userInfo, err = user.Lookup(usernameFromEnv)
+		println("running as", userInfo.Name, userInfo.Uid)
 	} else {
 		userInfo, err = user.Current()
 	}
@@ -211,6 +213,8 @@ func TestManagedProcessStart(t *testing.T) {
 			}, golog.NewTestLogger(t))
 			test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 			contents, _ := os.ReadFile(fmt.Sprintf("/proc/%d/loginuid", proc.(*managedProcess).cmd.Process.Pid))
+			println("temp contents", contents) // deleteme
+			println("comparing", strings.Trim(string(contents), " \n\r"), "---", asUser.Uid)
 			test.That(t, asUser.Uid, test.ShouldEqual, strings.Trim(string(contents), " \n\r"))
 			test.That(t, proc.Stop(), test.ShouldBeNil)
 		})

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -66,7 +66,6 @@ func parseSignal(sigStr, name string) (syscall.Signal, error) {
 }
 
 func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
-	// todo reviewer: should I wrap these errors for clarity?
 	attrs := &syscall.SysProcAttr{Setpgid: true}
 	if len(p.username) > 0 {
 		user, err := user.Lookup(p.username)
@@ -77,6 +76,7 @@ func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
 		if err != nil {
 			return nil, err
 		}
+		attrs.Credential = &syscall.Credential{}
 		attrs.Credential.Uid = uint32(val)
 		val, err = strconv.ParseUint(user.Gid, 10, 32)
 		if err != nil {

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -4,6 +4,8 @@ package pexec
 
 import (
 	"os"
+	"os/user"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -63,8 +65,26 @@ func parseSignal(sigStr, name string) (syscall.Signal, error) {
 	}
 }
 
-func sysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{Setpgid: true}
+func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
+	// todo reviewer: should I wrap these errors for clarity?
+	attrs := &syscall.SysProcAttr{Setpgid: true}
+	if len(p.username) > 0 {
+		user, err := user.Lookup(p.username)
+		if err != nil {
+			return nil, err
+		}
+		val, err := strconv.ParseUint(user.Uid, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		attrs.Credential.Uid = uint32(val)
+		val, err = strconv.ParseUint(user.Gid, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		attrs.Credential.Gid = uint32(val)
+	}
+	return attrs, nil
 }
 
 func (p *managedProcess) kill() (bool, error) {

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -25,10 +25,14 @@ func parseSignal(sigStr, name string) (syscall.Signal, error) {
 	return 0, errors.New("signals not supported on Windows")
 }
 
-func sysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{
+func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
+	ret := &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
+	if len(p.username) > 0 {
+		return nil, errors.Errorf("can't run as user %s, not supported yet on windows", p.username)
+	}
+	return ret, nil
 }
 
 func (p *managedProcess) kill() (bool, error) {

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -22,11 +22,14 @@ const defaultStopTimeout = time.Second * 10
 
 // A ProcessConfig describes how to manage a system process.
 type ProcessConfig struct {
-	ID          string
-	Name        string
-	Args        []string
-	CWD         string
-	OneShot     bool
+	ID      string
+	Name    string
+	Args    []string
+	CWD     string
+	OneShot bool
+	// Optional. When present, we will try to look up the Uid of the named user
+	// and run the process as that user.
+	Username    string
 	Log         bool
 	LogWriter   io.Writer
 	StopSignal  syscall.Signal
@@ -75,6 +78,7 @@ type configData struct {
 	Args        []string `json:"args"`
 	CWD         string   `json:"cwd"`
 	OneShot     bool     `json:"one_shot"`
+	Username    string   `json:"username"`
 	Log         bool     `json:"log"`
 	StopSignal  string   `json:"stop_signal,omitempty"`
 	StopTimeout string   `json:"stop_timeout,omitempty"`
@@ -88,12 +92,13 @@ func (config *ProcessConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	*config = ProcessConfig{
-		ID:      temp.ID,
-		Name:    temp.Name,
-		Args:    temp.Args,
-		CWD:     temp.CWD,
-		OneShot: temp.OneShot,
-		Log:     temp.Log,
+		ID:       temp.ID,
+		Name:     temp.Name,
+		Args:     temp.Args,
+		CWD:      temp.CWD,
+		OneShot:  temp.OneShot,
+		Username: temp.Username,
+		Log:      temp.Log,
 		// OnUnexpectedExit cannot be specified in JSON.
 	}
 
@@ -126,6 +131,7 @@ func (config ProcessConfig) MarshalJSON() ([]byte, error) {
 		Args:        config.Args,
 		CWD:         config.CWD,
 		OneShot:     config.OneShot,
+		Username:    config.Username,
 		Log:         config.Log,
 		StopSignal:  stopSig,
 		StopTimeout: config.StopTimeout.String(),


### PR DESCRIPTION
## What
- add Username in managedProcess + ProcessConfig
- when this field is present, managedProcess looks up the user and runs as them
- add a new CI step to test this (because it needs to run with setuid capability)
## Why
- to support running non-privileged subprocess (if necessary in the future)