### PR TITLE
RSDK-4473 Make stream message reception sensitive to peer finishing

### DIFF
--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -64,6 +64,10 @@ func newBaseChannel(
 	var connIDMu sync.Mutex
 	var peerDoneOnce bool
 	doPeerDone := func() {
+		// Cancel base channel context so streams on the channel will stop trying
+		// to receive messages when the peer is done.
+		ch.cancel()
+
 		if !peerDoneOnce && onPeerDone != nil {
 			peerDoneOnce = true
 			onPeerDone()

--- a/rpc/wrtc_client_channel_test.go
+++ b/rpc/wrtc_client_channel_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -576,14 +577,24 @@ func TestWebRTCClientChannelCanStopStreamRecvMsg(t *testing.T) {
 		&grpc.StreamDesc{ClientStreams: true}, "thing")
 	test.That(t, err, test.ShouldBeNil)
 
+	// Send a message to the server and delay slightly to allow server to receive
+	// the message and close serverFinished.
 	test.That(t, clientStream.SendMsg(someStatus.Proto()), test.ShouldBeNil)
+	time.Sleep(50 * time.Millisecond)
 
 	// Close client peer connection before receiving a client message. Assert
 	// that RecvMsg does not hang.
 	test.That(t, pc1.Close(), test.ShouldBeNil)
 	var respStatus pbstatus.Status
 	err = clientStream.RecvMsg(&respStatus)
-	test.That(t, err, test.ShouldBeError, context.Canceled)
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// The error returned from RecvMsg can be either a context canceled error
+	// or an EOF error. The former is returned when RecvMsg catches the context
+	// error first and reports it. The latter is returned when the goroutine
+	// created in newWebRTCClientStream catches the context error first and
+	// attempts to reset the stream.
+	test.That(t, err.Error(), test.ShouldBeIn, context.Canceled.Error(), io.EOF.Error())
 	test.That(t, &respStatus, test.ShouldResemble, &pbstatus.Status{})
 
 	<-serverFinished

--- a/rpc/wrtc_client_stream.go
+++ b/rpc/wrtc_client_stream.go
@@ -45,7 +45,7 @@ func newWebRTCClientStream(
 	logger golog.Logger,
 ) *webrtcClientStream {
 	ctx, cancel := context.WithCancel(ctx)
-	bs := newWebRTCBaseStream(ctx, cancel, stream, onDone, logger)
+	bs := newWebRTCBaseStream(ctx, cancel, channel.ctx, stream, onDone, logger)
 	s := &webrtcClientStream{
 		webrtcBaseStream: bs,
 		ctx:              ctx,

--- a/rpc/wrtc_client_stream.go
+++ b/rpc/wrtc_client_stream.go
@@ -44,8 +44,8 @@ func newWebRTCClientStream(
 	onDone func(id uint64),
 	logger golog.Logger,
 ) *webrtcClientStream {
-	ctx, cancel := context.WithCancel(ctx)
-	bs := newWebRTCBaseStream(ctx, cancel, channel.ctx, stream, onDone, logger)
+	ctx, cancel := utils.MergeContext(channel.ctx, ctx)
+	bs := newWebRTCBaseStream(ctx, cancel, stream, onDone, logger)
 	s := &webrtcClientStream{
 		webrtcBaseStream: bs,
 		ctx:              ctx,

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -53,7 +53,7 @@ func newWebRTCServerStream(
 	onDone func(id uint64),
 	logger golog.Logger,
 ) *webrtcServerStream {
-	bs := newWebRTCBaseStream(ctx, cancelCtx, stream, onDone, logger)
+	bs := newWebRTCBaseStream(ctx, cancelCtx, channel.ctx, stream, onDone, logger)
 	s := &webrtcServerStream{
 		webrtcBaseStream: bs,
 		ch:               channel,

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -53,7 +53,7 @@ func newWebRTCServerStream(
 	onDone func(id uint64),
 	logger golog.Logger,
 ) *webrtcServerStream {
-	bs := newWebRTCBaseStream(ctx, cancelCtx, channel.ctx, stream, onDone, logger)
+	bs := newWebRTCBaseStream(ctx, cancelCtx, stream, onDone, logger)
 	s := &webrtcServerStream{
 		webrtcBaseStream: bs,
 		ch:               channel,


### PR DESCRIPTION
Could be related to https://viam.atlassian.net/browse/RSDK-5235 and/or https://viam.atlassian.net/browse/RSDK-4473.

Cancels channel context when peer has finished (connection was closed, or connection state moved to disconnected, failed or closed). Respects channel context in base stream `RecvMsg`, so streams 
(both client and server) will not hang if connection gets closed mid-operation-invocation.