### PR TITLE
RSDK-5350 - Update goutils to support passing environment variables to managed processes

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -50,7 +50,7 @@ func NewManagedProcess(config ProcessConfig, logger golog.Logger) ManagedProcess
 	//  If Env contains duplicate environment keys, only the last
 	//  value in the slice for each duplicate key is used.
 	env := os.Environ()
-	for key, value := range config.EnvironmentVariables {
+	for key, value := range config.Environment {
 		env = append(env, fmt.Sprintf("%s=%s", key, value))
 	}
 

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -46,13 +46,22 @@ func NewManagedProcess(config ProcessConfig, logger golog.Logger) ManagedProcess
 		config.StopTimeout = defaultStopTimeout
 	}
 
+	// From os/exec/exec.go:
+	//  If Env contains duplicate environment keys, only the last
+	//  value in the slice for each duplicate key is used.
+	env := os.Environ()
+	for key, value := range config.EnvironmentVariables {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+
 	return &managedProcess{
 		id:               config.ID,
 		name:             config.Name,
 		args:             config.Args,
 		cwd:              config.CWD,
-		username:         config.Username,
 		oneShot:          config.OneShot,
+		username:         config.Username,
+		env:              env,
 		shouldLog:        config.Log,
 		onUnexpectedExit: config.OnUnexpectedExit,
 		managingCh:       make(chan struct{}),
@@ -73,6 +82,7 @@ type managedProcess struct {
 	cwd       string
 	oneShot   bool
 	username  string
+	env       []string
 	shouldLog bool
 	cmd       *exec.Cmd
 
@@ -120,6 +130,7 @@ func (p *managedProcess) Start(ctx context.Context) error {
 		if cmd.SysProcAttr, err = p.sysProcAttr(); err != nil {
 			return err
 		}
+		cmd.Env = p.env
 		cmd.Dir = p.cwd
 		var runErr error
 		if p.shouldLog || p.logWriter != nil {
@@ -154,6 +165,7 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	if cmd.SysProcAttr, err = p.sysProcAttr(); err != nil {
 		return err
 	}
+	cmd.Env = p.env
 	cmd.Dir = p.cwd
 
 	var stdOut, stdErr io.ReadCloser

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -583,7 +583,7 @@ done`, tempFile.Name()))
 }
 
 func TestManagedProcessEnvironmentVariables(t *testing.T) {
-	t.Run("Set an environment variable", func(t *testing.T) {
+	t.Run("set an environment variable", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 		output := new(bytes.Buffer)
 		proc := NewManagedProcess(ProcessConfig{
@@ -597,7 +597,7 @@ func TestManagedProcessEnvironmentVariables(t *testing.T) {
 		test.That(t, output.String(), test.ShouldEqual, "/opt/viam")
 	})
 
-	t.Run("Overwrite an environment variable", func(t *testing.T) {
+	t.Run("overwrite an environment variable", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 		// test that the variable already exists
 		test.That(t, os.Getenv("HOME"), test.ShouldNotBeEmpty)

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -583,15 +583,15 @@ done`, tempFile.Name()))
 }
 
 func TestManagedProcessEnvironmentVariables(t *testing.T) {
-	t.Run("set an environment variable on one shot process", func(t *testing.T) {
+	t.Run("set an environment variable on one-shot process", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 		output := new(bytes.Buffer)
 		proc := NewManagedProcess(ProcessConfig{
-			Name:                 "bash",
-			Args:                 []string{"-c", "printenv VIAM_HOME"},
-			EnvironmentVariables: map[string]string{"VIAM_HOME": "/opt/viam"},
-			OneShot:              true,
-			LogWriter:            output,
+			Name:        "bash",
+			Args:        []string{"-c", "printenv VIAM_HOME"},
+			Environment: map[string]string{"VIAM_HOME": "/opt/viam"},
+			OneShot:     true,
+			LogWriter:   output,
 		}, logger)
 		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 		test.That(t, output.String(), test.ShouldEqual, "/opt/viam\n")
@@ -601,10 +601,10 @@ func TestManagedProcessEnvironmentVariables(t *testing.T) {
 		logReader, logWriter := io.Pipe()
 		logger := golog.NewTestLogger(t)
 		proc := NewManagedProcess(ProcessConfig{
-			Name:                 "bash",
-			Args:                 []string{"-c", "printenv VIAM_HOME"},
-			EnvironmentVariables: map[string]string{"VIAM_HOME": "/opt/viam"},
-			LogWriter:            logWriter,
+			Name:        "bash",
+			Args:        []string{"-c", "printenv VIAM_HOME"},
+			Environment: map[string]string{"VIAM_HOME": "/opt/viam"},
+			LogWriter:   logWriter,
 		}, logger)
 		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 		bufferedLogReader := bufio.NewReader(logReader)
@@ -620,11 +620,11 @@ func TestManagedProcessEnvironmentVariables(t *testing.T) {
 		test.That(t, os.Getenv("HOME"), test.ShouldNotBeEmpty)
 		output := new(bytes.Buffer)
 		proc := NewManagedProcess(ProcessConfig{
-			Name:                 "bash",
-			Args:                 []string{"-c", "printenv HOME"},
-			EnvironmentVariables: map[string]string{"HOME": "/some/dir"},
-			OneShot:              true,
-			LogWriter:            output,
+			Name:        "bash",
+			Args:        []string{"-c", "printenv HOME"},
+			Environment: map[string]string{"HOME": "/some/dir"},
+			OneShot:     true,
+			LogWriter:   output,
 		}, logger)
 		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 		test.That(t, output.String(), test.ShouldEqual, "/some/dir\n")

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -29,11 +29,13 @@ type ProcessConfig struct {
 	OneShot bool
 	// Optional. When present, we will try to look up the Uid of the named user
 	// and run the process as that user.
-	Username    string
-	Log         bool
-	LogWriter   io.Writer
-	StopSignal  syscall.Signal
-	StopTimeout time.Duration
+	Username string
+	// Additional environment variables to pass through to the process.
+	EnvironmentVariables map[string]string
+	Log                  bool
+	LogWriter            io.Writer
+	StopSignal           syscall.Signal
+	StopTimeout          time.Duration
 	// OnUnexpectedExit will be called when the manage goroutine detects an
 	// unexpected exit of the process. The exit code of the crashed process will
 	// be passed in. If the returned bool is true, the manage goroutine will
@@ -73,15 +75,16 @@ func (config *ProcessConfig) validate(path string) error {
 
 // Note: keep this in sync with json-supported fields in ProcessConfig.
 type configData struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Args        []string `json:"args"`
-	CWD         string   `json:"cwd"`
-	OneShot     bool     `json:"one_shot"`
-	Username    string   `json:"username"`
-	Log         bool     `json:"log"`
-	StopSignal  string   `json:"stop_signal,omitempty"`
-	StopTimeout string   `json:"stop_timeout,omitempty"`
+	ID                   string            `json:"id"`
+	Name                 string            `json:"name"`
+	Args                 []string          `json:"args"`
+	CWD                  string            `json:"cwd"`
+	OneShot              bool              `json:"one_shot"`
+	Username             string            `json:"username"`
+	EnvironmentVariables map[string]string `json:"environment_variables"`
+	Log                  bool              `json:"log"`
+	StopSignal           string            `json:"stop_signal,omitempty"`
+	StopTimeout          string            `json:"stop_timeout,omitempty"`
 }
 
 // UnmarshalJSON parses incoming json.
@@ -92,13 +95,14 @@ func (config *ProcessConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	*config = ProcessConfig{
-		ID:       temp.ID,
-		Name:     temp.Name,
-		Args:     temp.Args,
-		CWD:      temp.CWD,
-		OneShot:  temp.OneShot,
-		Username: temp.Username,
-		Log:      temp.Log,
+		ID:                   temp.ID,
+		Name:                 temp.Name,
+		Args:                 temp.Args,
+		CWD:                  temp.CWD,
+		OneShot:              temp.OneShot,
+		Username:             temp.Username,
+		EnvironmentVariables: temp.EnvironmentVariables,
+		Log:                  temp.Log,
 		// OnUnexpectedExit cannot be specified in JSON.
 	}
 
@@ -126,15 +130,16 @@ func (config ProcessConfig) MarshalJSON() ([]byte, error) {
 		stopSig = config.StopSignal.String()
 	}
 	temp := configData{
-		ID:          config.ID,
-		Name:        config.Name,
-		Args:        config.Args,
-		CWD:         config.CWD,
-		OneShot:     config.OneShot,
-		Username:    config.Username,
-		Log:         config.Log,
-		StopSignal:  stopSig,
-		StopTimeout: config.StopTimeout.String(),
+		ID:                   config.ID,
+		Name:                 config.Name,
+		Args:                 config.Args,
+		CWD:                  config.CWD,
+		OneShot:              config.OneShot,
+		Username:             config.Username,
+		EnvironmentVariables: config.EnvironmentVariables,
+		Log:                  config.Log,
+		StopSignal:           stopSig,
+		StopTimeout:          config.StopTimeout.String(),
 		// OnUnexpectedExit cannot be converted to JSON.
 	}
 	return json.Marshal(temp)

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -30,13 +30,13 @@ type ProcessConfig struct {
 	// Optional. When present, we will try to look up the Uid of the named user
 	// and run the process as that user.
 	Username string
-	// Additional environment variables to pass through to the process.
+	// Environment variables to pass through to the process.
 	// Will overwrite existing environment variables.
-	EnvironmentVariables map[string]string
-	Log                  bool
-	LogWriter            io.Writer
-	StopSignal           syscall.Signal
-	StopTimeout          time.Duration
+	Environment map[string]string
+	Log         bool
+	LogWriter   io.Writer
+	StopSignal  syscall.Signal
+	StopTimeout time.Duration
 	// OnUnexpectedExit will be called when the manage goroutine detects an
 	// unexpected exit of the process. The exit code of the crashed process will
 	// be passed in. If the returned bool is true, the manage goroutine will
@@ -76,16 +76,16 @@ func (config *ProcessConfig) validate(path string) error {
 
 // Note: keep this in sync with json-supported fields in ProcessConfig.
 type configData struct {
-	ID                   string            `json:"id"`
-	Name                 string            `json:"name"`
-	Args                 []string          `json:"args"`
-	CWD                  string            `json:"cwd"`
-	OneShot              bool              `json:"one_shot"`
-	Username             string            `json:"username"`
-	EnvironmentVariables map[string]string `json:"environment_variables"`
-	Log                  bool              `json:"log"`
-	StopSignal           string            `json:"stop_signal,omitempty"`
-	StopTimeout          string            `json:"stop_timeout,omitempty"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Args        []string          `json:"args"`
+	CWD         string            `json:"cwd"`
+	OneShot     bool              `json:"one_shot"`
+	Username    string            `json:"username"`
+	Environment map[string]string `json:"env"`
+	Log         bool              `json:"log"`
+	StopSignal  string            `json:"stop_signal,omitempty"`
+	StopTimeout string            `json:"stop_timeout,omitempty"`
 }
 
 // UnmarshalJSON parses incoming json.
@@ -96,14 +96,14 @@ func (config *ProcessConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	*config = ProcessConfig{
-		ID:                   temp.ID,
-		Name:                 temp.Name,
-		Args:                 temp.Args,
-		CWD:                  temp.CWD,
-		OneShot:              temp.OneShot,
-		Username:             temp.Username,
-		EnvironmentVariables: temp.EnvironmentVariables,
-		Log:                  temp.Log,
+		ID:          temp.ID,
+		Name:        temp.Name,
+		Args:        temp.Args,
+		CWD:         temp.CWD,
+		OneShot:     temp.OneShot,
+		Username:    temp.Username,
+		Environment: temp.Environment,
+		Log:         temp.Log,
 		// OnUnexpectedExit cannot be specified in JSON.
 	}
 
@@ -131,16 +131,16 @@ func (config ProcessConfig) MarshalJSON() ([]byte, error) {
 		stopSig = config.StopSignal.String()
 	}
 	temp := configData{
-		ID:                   config.ID,
-		Name:                 config.Name,
-		Args:                 config.Args,
-		CWD:                  config.CWD,
-		OneShot:              config.OneShot,
-		Username:             config.Username,
-		EnvironmentVariables: config.EnvironmentVariables,
-		Log:                  config.Log,
-		StopSignal:           stopSig,
-		StopTimeout:          config.StopTimeout.String(),
+		ID:          config.ID,
+		Name:        config.Name,
+		Args:        config.Args,
+		CWD:         config.CWD,
+		OneShot:     config.OneShot,
+		Username:    config.Username,
+		Environment: config.Environment,
+		Log:         config.Log,
+		StopSignal:  stopSig,
+		StopTimeout: config.StopTimeout.String(),
 		// OnUnexpectedExit cannot be converted to JSON.
 	}
 	return json.Marshal(temp)

--- a/pexec/process.go
+++ b/pexec/process.go
@@ -31,6 +31,7 @@ type ProcessConfig struct {
 	// and run the process as that user.
 	Username string
 	// Additional environment variables to pass through to the process.
+	// Will overwrite existing environment variables.
 	EnvironmentVariables map[string]string
 	Log                  bool
 	LogWriter            io.Writer


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-5350


Blocks: https://github.com/viamrobotics/rdk/pull/3062

Hoping to get this into the release tomorrow morning. However, if that is not possible, that is okay.


Main question is whether this will work on windows. I haven't done any PRs to this repo yet so not sure if we have a good way to test that.