### PR TITLE
RSDK-4293 wait for answerer to finish completely

### DIFF
--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	t.Setenv("TEST_DELAY_FINISH_NEGOTIATION", "t")
+	t.Setenv(testDelayNegotiationVar, "t")
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	t.Setenv(testDelayNegotiationVar, "t")
+	t.Setenv(testDelayAnswererNegotiationVar, "t")
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	t.Setenv("TEST_DELAY_FINISH_NEGOTIATION", "t")
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -329,10 +329,6 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 					return
 				}
 				if icecandidate == nil {
-					// TODO(mp): remove this sleep! it's there to repro a flaky test
-					// failure:
-					// https://viam.atlassian.net/browse/RSDK-4293?focusedCommentId=20176
-					time.Sleep(2 * time.Second)
 					callFlowWG.Wait()
 					if err := sendDone(); err != nil {
 						sendErr(err)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -326,6 +326,7 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 					return
 				}
 				if i == nil {
+					time.Sleep(2 * time.Second)
 					callFlowWG.Wait()
 					if err := sendDone(); err != nil {
 						sendErr(err)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -320,6 +320,9 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 			}
 			// must spin off to unblock the ICE gatherer
 			utils.PanicCapturingGo(func() {
+				ans.activeBackgroundWorkers.Add(1)
+				defer ans.activeBackgroundWorkers.Done()
+
 				select {
 				case <-initSent:
 				case <-exchangeCtx.Done():

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -321,8 +321,8 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 			}
 			// must spin off to unblock the ICE gatherer
 			utils.PanicCapturingGo(func() {
-				// ans.activeBackgroundWorkers.Add(1)
-				// defer ans.activeBackgroundWorkers.Done()
+				ans.activeBackgroundWorkers.Add(1)
+				defer ans.activeBackgroundWorkers.Done()
 
 				select {
 				case <-initSent:

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -322,8 +322,8 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 				}
 			}
 			// must spin off to unblock the ICE gatherer
+			ans.activeBackgroundWorkers.Add(1)
 			utils.PanicCapturingGo(func() {
-				ans.activeBackgroundWorkers.Add(1)
 				defer ans.activeBackgroundWorkers.Done()
 
 				if icecandidate != nil {

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -21,6 +21,8 @@ import (
 	webrtcpb "go.viam.com/utils/proto/rpc/webrtc/v1"
 )
 
+const testDelayNegotiationVar = "TEST_DELAY_FINISH_NEGOTIATION"
+
 // A webrtcSignalingAnswerer listens for and answers calls with a given signaling service. It is
 // directly connected to a Server that will handle the actual calls/connections over WebRTC
 // data channels.
@@ -331,7 +333,9 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 				}
 				// there are no more candidates coming during this negotiation
 				if icecandidate == nil {
-					if _, ok := os.LookupEnv("TEST_DELAY_FINISH_NEGOTIATION"); ok {
+					if _, ok := os.LookupEnv(testDelayNegotiationVar); ok {
+						// RSDK-4293: Introducing a sleep here replicates the conditions
+						// for a prior goroutine leak.
 						ans.logger.Debug("Sleeping to delay the end of the negotiation")
 						time.Sleep(1 * time.Second)
 					}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -326,6 +326,10 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 				ans.activeBackgroundWorkers.Add(1)
 				defer ans.activeBackgroundWorkers.Done()
 
+				if icecandidate != nil {
+					defer callFlowWG.Done()
+				}
+
 				select {
 				case <-initSent:
 				case <-exchangeCtx.Done():
@@ -345,7 +349,6 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 					}
 					return
 				}
-				defer callFlowWG.Done()
 				iProto := iceCandidateToProto(icecandidate)
 				if err := client.Send(&webrtcpb.AnswerResponse{
 					Uuid: uuid,

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -21,7 +21,7 @@ import (
 	webrtcpb "go.viam.com/utils/proto/rpc/webrtc/v1"
 )
 
-const testDelayNegotiationVar = "TEST_DELAY_FINISH_NEGOTIATION"
+const testDelayAnswererNegotiationVar = "TEST_DELAY_ANSWERER_NEGOTIATION"
 
 // A webrtcSignalingAnswerer listens for and answers calls with a given signaling service. It is
 // directly connected to a Server that will handle the actual calls/connections over WebRTC
@@ -337,7 +337,7 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 				}
 				// there are no more candidates coming during this negotiation
 				if icecandidate == nil {
-					if _, ok := os.LookupEnv(testDelayNegotiationVar); ok {
+					if _, ok := os.LookupEnv(testDelayAnswererNegotiationVar); ok {
 						// RSDK-4293: Introducing a sleep here replicates the conditions
 						// for a prior goroutine leak.
 						ans.logger.Debug("Sleeping to delay the end of the negotiation")


### PR DESCRIPTION
Wait on all goroutines related to ice candidate negotiation to complete before closing the server.

Testing
- goleak reproduced in [this commit](https://github.com/viamrobotics/goutils/pull/211/commits/9e03120cf4087b105d7d62ae022c5a24a6a3cf0e)