### PR TITLE
APP-2890: Refactor to make EnsureAuth Public

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -100,7 +100,7 @@ type Server interface {
 	// limitations of normal gRPC being served from a non-root path.
 	http.Handler
 
-	EnsureAuthed (ctx context.Context) (context.Context, error)
+	EnsureAuthed(ctx context.Context) (context.Context, error)
 }
 
 type simpleServer struct {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -99,6 +99,8 @@ type Server interface {
 	// This is useful in a scenario where all gRPC is served from the root path due to
 	// limitations of normal gRPC being served from a non-root path.
 	http.Handler
+
+	EnsureAuthed (ctx context.Context) (context.Context, error)
 }
 
 type simpleServer struct {
@@ -662,6 +664,10 @@ func (ss *simpleServer) GRPCHandler() http.Handler {
 			w.WriteHeader(http.StatusBadRequest)
 		}
 	})
+}
+
+func (ss *simpleServer) EnsureAuthed(ctx context.Context) (context.Context, error) {
+	return ss.ensureAuthed(ctx)
 }
 
 // ServeHTTP is an all-in-one handler for any kind of gRPC traffic. This is useful

--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -30,8 +30,8 @@ func (ss *simpleServer) authHandlers(forType CredentialsType) (credAuthHandlers,
 }
 
 const (
-	metadataFieldAuthorization     = "authorization"
-	authorizationValuePrefixBearer = "Bearer "
+	MetadataFieldAuthorization     = "authorization"
+	AuthorizationValuePrefixBearer = "Bearer "
 )
 
 // JWTClaims extends jwt.RegisteredClaims with information about the credentials as well
@@ -72,7 +72,7 @@ func (ss *simpleServer) Authenticate(ctx context.Context, req *rpcpb.Authenticat
 	if !ok {
 		return nil, errors.New("expected metadata")
 	}
-	if len(md[metadataFieldAuthorization]) != 0 {
+	if len(md[MetadataFieldAuthorization]) != 0 {
 		return nil, status.Error(codes.InvalidArgument, "already authenticated; cannot re-authenticate")
 	}
 	if req.Credentials == nil {
@@ -241,14 +241,14 @@ func tokenFromContext(ctx context.Context) (string, error) {
 	if !ok {
 		return "", status.Error(codes.Unauthenticated, "authentication required no md")
 	}
-	authHeader := md.Get(metadataFieldAuthorization)
+	authHeader := md.Get(MetadataFieldAuthorization)
 	if len(authHeader) != 1 {
 		return "", status.Error(codes.Unauthenticated, "authentication required")
 	}
-	if !strings.HasPrefix(authHeader[0], authorizationValuePrefixBearer) {
-		return "", status.Errorf(codes.Unauthenticated, "expected Authorization: %s", authorizationValuePrefixBearer)
+	if !strings.HasPrefix(authHeader[0], AuthorizationValuePrefixBearer) {
+		return "", status.Errorf(codes.Unauthenticated, "expected Authorization: %s", AuthorizationValuePrefixBearer)
 	}
-	return strings.TrimPrefix(authHeader[0], authorizationValuePrefixBearer), nil
+	return strings.TrimPrefix(authHeader[0], AuthorizationValuePrefixBearer), nil
 }
 
 var errNotTLSAuthed = errors.New("not authenticated via TLS")
@@ -283,7 +283,6 @@ func (ss *simpleServer) tryAuth(ctx context.Context) (context.Context, error) {
 
 func (ss *simpleServer) ensureAuthed(ctx context.Context) (context.Context, error) {
 	tokenString, err := tokenFromContext(ctx)
-	//return nil, errors.New(fmt.Sprintf("ctx %s", t))
 	if err != nil {
 		// check TLS state
 		if ss.tlsAuthHandler == nil {

--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -239,7 +239,7 @@ func (wrapped ctxWrappedServerStream) Context() context.Context {
 func tokenFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", status.Error(codes.Unauthenticated, "authentication required")
+		return "", status.Error(codes.Unauthenticated, "authentication required no md")
 	}
 	authHeader := md.Get(metadataFieldAuthorization)
 	if len(authHeader) != 1 {
@@ -283,6 +283,7 @@ func (ss *simpleServer) tryAuth(ctx context.Context) (context.Context, error) {
 
 func (ss *simpleServer) ensureAuthed(ctx context.Context) (context.Context, error) {
 	tokenString, err := tokenFromContext(ctx)
+	//return nil, errors.New(fmt.Sprintf("ctx %s", t))
 	if err != nil {
 		// check TLS state
 		if ss.tlsAuthHandler == nil {

--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -30,7 +30,9 @@ func (ss *simpleServer) authHandlers(forType CredentialsType) (credAuthHandlers,
 }
 
 const (
-	MetadataFieldAuthorization     = "authorization"
+	// MetadataFieldAuthorization is a constant for the authorization header key.
+	MetadataFieldAuthorization = "authorization"
+	// AuthorizationValuePrefixBearer is a constant for the Bearer token prefix.
 	AuthorizationValuePrefixBearer = "Bearer "
 )
 

--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -241,14 +241,14 @@ func (wrapped ctxWrappedServerStream) Context() context.Context {
 func tokenFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", status.Error(codes.Unauthenticated, "authentication required no md")
+		return "", status.Error(codes.Unauthenticated, "authentication required")
 	}
 	authHeader := md.Get(MetadataFieldAuthorization)
 	if len(authHeader) != 1 {
 		return "", status.Error(codes.Unauthenticated, "authentication required")
 	}
 	if !strings.HasPrefix(authHeader[0], AuthorizationValuePrefixBearer) {
-		return "", status.Errorf(codes.Unauthenticated, "expected Authorization: %s", AuthorizationValuePrefixBearer)
+		return "", status.Errorf(codes.Unauthenticated, "expected authorization header with prefix: %s", AuthorizationValuePrefixBearer)
 	}
 	return strings.TrimPrefix(authHeader[0], AuthorizationValuePrefixBearer), nil
 }

--- a/rpc/server_auth_test.go
+++ b/rpc/server_auth_test.go
@@ -118,7 +118,7 @@ func TestServerAuth(t *testing.T) {
 		gStatus, ok = status.FromError(err)
 		test.That(t, ok, test.ShouldBeTrue)
 		test.That(t, gStatus.Code(), test.ShouldEqual, codes.Unauthenticated)
-		test.That(t, gStatus.Message(), test.ShouldContainSubstring, "expected Authorization")
+		test.That(t, gStatus.Message(), test.ShouldContainSubstring, "expected authorization header with prefix")
 
 		md = make(metadata.MD)
 		md.Set("authorization", "Bearer ")
@@ -203,7 +203,7 @@ func TestServerAuth(t *testing.T) {
 		test.That(t, httpResp2.StatusCode, test.ShouldEqual, 200)
 		rd, err = io.ReadAll(httpResp2.Body)
 		test.That(t, err, test.ShouldBeNil)
-		test.That(t, httpResp2.Header["Grpc-Message"], test.ShouldResemble, []string{"expected Authorization: Bearer"})
+		test.That(t, httpResp2.Header["Grpc-Message"], test.ShouldResemble, []string{"expected authorization header with prefix: Bearer"})
 		test.That(t, string(rd), test.ShouldResemble, "")
 
 		req, err = http.NewRequest(http.MethodPost, httpURL, strings.NewReader(grpcWebReq))


### PR DESCRIPTION
Allows the ability for usages of goutils to call EnsureAuth whenever auth checks are needed that don't follow the convention of RPC Credential Type (For example checks outside of gRPC calls).