### PR TITLE
RSDK-4952 - pass priority attribute

### DIFF
--- a/rpc/examples/echo/frontend/package-lock.json
+++ b/rpc/examples/echo/frontend/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../../../js": {
       "name": "@viamrobotics/rpc",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package-lock.json
+++ b/rpc/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/rpc",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package.json
+++ b/rpc/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "Apache-2.0",
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/src/dial.d.ts
+++ b/rpc/js/src/dial.d.ts
@@ -15,7 +15,7 @@ export interface DialWebRTCOptions {
   signalingExternalAuthToEntity?: string;
   signalingCredentials?: Credentials;
   signalingAccessToken?: string;
-  priority?: number;
+  additionalSdpFields?: object;
 }
 export interface Credentials {
   type: string;

--- a/rpc/js/src/dial.d.ts
+++ b/rpc/js/src/dial.d.ts
@@ -15,6 +15,7 @@ export interface DialWebRTCOptions {
   signalingExternalAuthToEntity?: string;
   signalingCredentials?: Credentials;
   signalingAccessToken?: string;
+  priority?: number;
 }
 export interface Credentials {
   type: string;

--- a/rpc/js/src/dial.d.ts
+++ b/rpc/js/src/dial.d.ts
@@ -15,7 +15,7 @@ export interface DialWebRTCOptions {
   signalingExternalAuthToEntity?: string;
   signalingCredentials?: Credentials;
   signalingAccessToken?: string;
-  additionalSdpFields?: object;
+  additionalSdpFields?: Record<string, string | number>;
 }
 export interface Credentials {
   type: string;

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -26,7 +26,7 @@ import {
   OptionalWebRTCConfigResponse,
 } from "./gen/proto/rpc/webrtc/v1/signaling_pb";
 import { SignalingService } from "./gen/proto/rpc/webrtc/v1/signaling_pb_service";
-import { addCustomSdpFields, newPeerConnectionForClient } from "./peer";
+import { addSdpFields, newPeerConnectionForClient } from "./peer";
 
 export interface DialOptions {
   authEntity?: string;
@@ -569,7 +569,7 @@ export async function dialWebRTC(
     client.start({ "rpc-host": host });
 
     const callRequest = new CallRequest();
-    const description = addCustomSdpFields(
+    const description = addSdpFields(
       pc.localDescription,
       opts.webrtcOptions?.additionalSdpFields
     );

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -74,6 +74,10 @@ export interface DialWebRTCOptions {
   //
   // If enabled, other auth options have no affect. Eg. authEntity, credentials, signalingAuthEntity, signalingCredentials.
   signalingAccessToken?: string;
+
+  // `priority` is the priority of the current WebRTC connection. If only one WebRTC
+  // connection is allowed and another peer with a higher priority attempts to connect,
+  // the higher priority connection will unseat the lower priority connection.
   priority?: number;
 }
 

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -74,6 +74,7 @@ export interface DialWebRTCOptions {
   //
   // If enabled, other auth options have no affect. Eg. authEntity, credentials, signalingAuthEntity, signalingCredentials.
   signalingAccessToken?: string;
+  priority?: number;
 }
 
 export interface Credentials {
@@ -565,7 +566,15 @@ export async function dialWebRTC(
     client.start({ "rpc-host": host });
 
     const callRequest = new CallRequest();
-    const encodedSDP = btoa(JSON.stringify(pc.localDescription));
+    let description = {
+      sdp: pc.localDescription?.sdp,
+      type: pc.localDescription?.type,
+    };
+    if (opts.webrtcOptions?.priority) {
+      description.sdp =
+        description.sdp + `a=x-priority:${opts.webrtcOptions?.priority}\r\n`;
+    }
+    const encodedSDP = btoa(JSON.stringify(description));
     callRequest.setSdp(encodedSDP);
     if (webrtcOpts && webrtcOpts.disableTrickleICE) {
       callRequest.setDisableTrickle(webrtcOpts.disableTrickleICE);

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -75,8 +75,8 @@ export interface DialWebRTCOptions {
   // If enabled, other auth options have no affect. Eg. authEntity, credentials, signalingAuthEntity, signalingCredentials.
   signalingAccessToken?: string;
 
-  // `additionalSDPValues` is an object of additional SDP values that we want to pass into the connection's call request.
-  additionalSdpFields?: object;
+  // `additionalSDPValues` is a collection of additional SDP values that we want to pass into the connection's call request.
+  additionalSdpFields?: Record<string, string | number>;
 }
 
 export interface Credentials {
@@ -570,8 +570,8 @@ export async function dialWebRTC(
 
     const callRequest = new CallRequest();
     const description = addCustomSdpFields(
-      opts.webrtcOptions?.additionalSdpFields,
-      pc.localDescription
+      pc.localDescription,
+      opts.webrtcOptions?.additionalSdpFields
     );
     const encodedSDP = btoa(JSON.stringify(description));
     callRequest.setSdp(encodedSDP);

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -576,8 +576,7 @@ export async function dialWebRTC(
       type: pc.localDescription?.type,
     };
     if (opts.webrtcOptions?.priority) {
-      description.sdp =
-        description.sdp + `a=x-priority:${opts.webrtcOptions?.priority}\r\n`;
+      description.sdp = [description.sdp, `a=x-priority:${opts.webrtcOptions?.priority}\r\n`].join("");
     }
     const encodedSDP = btoa(JSON.stringify(description));
     callRequest.setSdp(encodedSDP);

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -356,7 +356,8 @@ export async function dialWebRTC(
 
   const { pc, dc } = await newPeerConnectionForClient(
     webrtcOpts !== undefined && webrtcOpts.disableTrickleICE,
-    webrtcOpts?.rtcConfig
+    webrtcOpts?.rtcConfig,
+    webrtcOpts.priority
   );
   let successful = false;
 

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -355,7 +355,7 @@ export async function dialWebRTC(
   const { pc, dc } = await newPeerConnectionForClient(
     webrtcOpts !== undefined && webrtcOpts.disableTrickleICE,
     webrtcOpts?.rtcConfig,
-    webrtcOpts.additionalSdpFields
+    webrtcOpts?.additionalSdpFields
   );
   let successful = false;
 

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -576,7 +576,10 @@ export async function dialWebRTC(
       type: pc.localDescription?.type,
     };
     if (opts.webrtcOptions?.priority) {
-      description.sdp = [description.sdp, `a=x-priority:${opts.webrtcOptions?.priority}\r\n`].join("");
+      description.sdp = [
+        description.sdp,
+        `a=x-priority:${opts.webrtcOptions?.priority}\r\n`,
+      ].join("");
     }
     const encodedSDP = btoa(JSON.stringify(description));
     callRequest.setSdp(encodedSDP);

--- a/rpc/js/src/peer.d.ts
+++ b/rpc/js/src/peer.d.ts
@@ -3,8 +3,8 @@ interface ReadyPeer {
   dc: RTCDataChannel;
 }
 export declare function addCustomSdpFields(
-  sdpFields?: object,
-  localDescription?: RTCSessionDescription | null
+  localDescription?: RTCSessionDescription | null,
+  sdpFields?: Record<string, string | number>
 ): {
   sdp: string | undefined;
   type: RTCSdpType | undefined;
@@ -12,6 +12,6 @@ export declare function addCustomSdpFields(
 export declare function newPeerConnectionForClient(
   disableTrickle: boolean,
   rtcConfig?: RTCConfiguration,
-  additionalSdpFields?: object
+  additionalSdpFields?: Record<string, string | number>
 ): Promise<ReadyPeer>;
 export {};

--- a/rpc/js/src/peer.d.ts
+++ b/rpc/js/src/peer.d.ts
@@ -2,9 +2,16 @@ interface ReadyPeer {
   pc: RTCPeerConnection;
   dc: RTCDataChannel;
 }
+export declare function addCustomSdpFields(
+  sdpFields?: object,
+  localDescription?: RTCSessionDescription | null
+): {
+  sdp: string | undefined;
+  type: RTCSdpType | undefined;
+};
 export declare function newPeerConnectionForClient(
   disableTrickle: boolean,
   rtcConfig?: RTCConfiguration,
-  priority?: number
+  additionalSdpFields?: object
 ): Promise<ReadyPeer>;
 export {};

--- a/rpc/js/src/peer.d.ts
+++ b/rpc/js/src/peer.d.ts
@@ -4,6 +4,7 @@ interface ReadyPeer {
 }
 export declare function newPeerConnectionForClient(
   disableTrickle: boolean,
-  rtcConfig?: RTCConfiguration
+  rtcConfig?: RTCConfiguration,
+  priority?: number
 ): Promise<ReadyPeer>;
 export {};

--- a/rpc/js/src/peer.d.ts
+++ b/rpc/js/src/peer.d.ts
@@ -2,7 +2,7 @@ interface ReadyPeer {
   pc: RTCPeerConnection;
   dc: RTCDataChannel;
 }
-export declare function addCustomSdpFields(
+export declare function addSdpFields(
   localDescription?: RTCSessionDescription | null,
   sdpFields?: Record<string, string | number>
 ): {

--- a/rpc/js/src/peer.ts
+++ b/rpc/js/src/peer.ts
@@ -66,7 +66,7 @@ export async function newPeerConnectionForClient(
           type: peerConnection.localDescription?.type,
         };
         if (priority) {
-          description.sdp = description.sdp + `a=x-priority:${priority}\r\n`;
+          description.sdp = [description.sdp, `a=x-priority:${opts.webrtcOptions?.priority}\r\n`].join("");
         }
         negotiationChannel.send(btoa(JSON.stringify(description)));
       }
@@ -86,7 +86,7 @@ export async function newPeerConnectionForClient(
         type: peerConnection.localDescription?.type,
       };
       if (priority) {
-        description.sdp = description.sdp + `a=x-priority:${priority}\r\n`;
+        description.sdp = [description.sdp, `a=x-priority:${opts.webrtcOptions?.priority}\r\n`].join("");
       }
       negotiationChannel.send(btoa(JSON.stringify(description)));
     } catch (e) {

--- a/rpc/js/src/peer.ts
+++ b/rpc/js/src/peer.ts
@@ -5,7 +5,8 @@ interface ReadyPeer {
 
 export async function newPeerConnectionForClient(
   disableTrickle: boolean,
-  rtcConfig?: RTCConfiguration
+  rtcConfig?: RTCConfiguration,
+  priority?: number
 ): Promise<ReadyPeer> {
   if (!rtcConfig) {
     rtcConfig = {
@@ -60,9 +61,14 @@ export async function newPeerConnectionForClient(
 
       if (description.type === "offer") {
         await peerConnection.setLocalDescription();
-        negotiationChannel.send(
-          btoa(JSON.stringify(peerConnection.localDescription))
-        );
+        let description = {
+          sdp: peerConnection.localDescription?.sdp,
+          type: peerConnection.localDescription?.type,
+        };
+        if (priority) {
+          description.sdp = description.sdp + `a=x-priority:${priority}\r\n`;
+        }
+        negotiationChannel.send(btoa(JSON.stringify(description)));
       }
     } catch (e) {
       console.error(e);
@@ -75,9 +81,14 @@ export async function newPeerConnectionForClient(
     }
     try {
       await peerConnection.setLocalDescription();
-      negotiationChannel.send(
-        btoa(JSON.stringify(peerConnection.localDescription))
-      );
+      let description = {
+        sdp: peerConnection.localDescription?.sdp,
+        type: peerConnection.localDescription?.type,
+      };
+      if (priority) {
+        description.sdp = description.sdp + `a=x-priority:${priority}\r\n`;
+      }
+      negotiationChannel.send(btoa(JSON.stringify(description)));
     } catch (e) {
       console.error(e);
     }

--- a/rpc/js/src/peer.ts
+++ b/rpc/js/src/peer.ts
@@ -66,7 +66,10 @@ export async function newPeerConnectionForClient(
           type: peerConnection.localDescription?.type,
         };
         if (priority) {
-          description.sdp = [description.sdp, `a=x-priority:${opts.webrtcOptions?.priority}\r\n`].join("");
+          description.sdp = [
+            description.sdp,
+            `a=x-priority:${priority}\r\n`,
+          ].join("");
         }
         negotiationChannel.send(btoa(JSON.stringify(description)));
       }
@@ -86,7 +89,10 @@ export async function newPeerConnectionForClient(
         type: peerConnection.localDescription?.type,
       };
       if (priority) {
-        description.sdp = [description.sdp, `a=x-priority:${opts.webrtcOptions?.priority}\r\n`].join("");
+        description.sdp = [
+          description.sdp,
+          `a=x-priority:${priority}\r\n`,
+        ].join("");
       }
       negotiationChannel.send(btoa(JSON.stringify(description)));
     } catch (e) {

--- a/rpc/js/src/peer.ts
+++ b/rpc/js/src/peer.ts
@@ -3,7 +3,7 @@ interface ReadyPeer {
   dc: RTCDataChannel;
 }
 
-export function addCustomSdpFields(
+export function addSdpFields(
   localDescription?: RTCSessionDescription | null,
   sdpFields?: Record<string, string | number>
 ) {
@@ -15,7 +15,7 @@ export function addCustomSdpFields(
     Object.keys(sdpFields).forEach((key) => {
       description.sdp = [
         description.sdp,
-        `a=x-${key}:${sdpFields[key as keyof typeof sdpFields]}\r\n`,
+        `a=${key}:${sdpFields[key as keyof typeof sdpFields]}\r\n`,
       ].join("");
     });
   }
@@ -80,7 +80,7 @@ export async function newPeerConnectionForClient(
 
       if (description.type === "offer") {
         await peerConnection.setLocalDescription();
-        const newDescription = addCustomSdpFields(
+        const newDescription = addSdpFields(
           peerConnection.localDescription,
           additionalSdpFields
         );
@@ -97,7 +97,7 @@ export async function newPeerConnectionForClient(
     }
     try {
       await peerConnection.setLocalDescription();
-      const newDescription = addCustomSdpFields(
+      const newDescription = addSdpFields(
         peerConnection.localDescription,
         additionalSdpFields
       );

--- a/rpc/js/src/peer.ts
+++ b/rpc/js/src/peer.ts
@@ -4,8 +4,8 @@ interface ReadyPeer {
 }
 
 export function addCustomSdpFields(
-  sdpFields?: object,
-  localDescription?: RTCSessionDescription | null
+  localDescription?: RTCSessionDescription | null,
+  sdpFields?: Record<string, string | number>
 ) {
   let description = {
     sdp: localDescription?.sdp,
@@ -25,7 +25,7 @@ export function addCustomSdpFields(
 export async function newPeerConnectionForClient(
   disableTrickle: boolean,
   rtcConfig?: RTCConfiguration,
-  additionalSdpFields?: object
+  additionalSdpFields?: Record<string, string | number>
 ): Promise<ReadyPeer> {
   if (!rtcConfig) {
     rtcConfig = {
@@ -81,8 +81,8 @@ export async function newPeerConnectionForClient(
       if (description.type === "offer") {
         await peerConnection.setLocalDescription();
         const newDescription = addCustomSdpFields(
-          additionalSdpFields,
-          peerConnection.localDescription
+          peerConnection.localDescription,
+          additionalSdpFields
         );
         negotiationChannel.send(btoa(JSON.stringify(newDescription)));
       }
@@ -98,8 +98,8 @@ export async function newPeerConnectionForClient(
     try {
       await peerConnection.setLocalDescription();
       const newDescription = addCustomSdpFields(
-        additionalSdpFields,
-        peerConnection.localDescription
+        peerConnection.localDescription,
+        additionalSdpFields
       );
       negotiationChannel.send(btoa(JSON.stringify(newDescription)));
     } catch (e) {


### PR DESCRIPTION
[Related TS SDK change](https://github.com/viamrobotics/viam-typescript-sdk/pull/181)
[Jira ticket](https://viam.atlassian.net/browse/RSDK-5228)

Allowing for a custom priority attribute to be pushed in.

Tested with a board running the MicroRDK to confirm default and customized priority works as expected. Also tested with a robot running the regular RDK (with and without a priority attribute) to confirm everything else still works. The echo example was also run to confirm it ran smoothly.