### PR TITLE
Bump @viamrobotics/rpc to 0.1.39

### DIFF
--- a/rpc/examples/echo/frontend/package-lock.json
+++ b/rpc/examples/echo/frontend/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../../../js": {
       "name": "@viamrobotics/rpc",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package-lock.json
+++ b/rpc/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/rpc",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package.json
+++ b/rpc/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "license": "Apache-2.0",
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",


### PR DESCRIPTION
Bumping the version here so we can get the typings issues that were fixed as a transient dependency in `@viamrobotics/sdk` and ultimately `app`.

See my PR for the downstream issue: https://github.com/viamrobotics/app/actions/runs/6895151896/job/18758485918?pr=2866