### PR TITLE
RSDK-5906: Upload CI test.json file as a github artifact.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,14 @@ jobs:
         export ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS=`pwd`/artifact_google_creds.json
         sudo -u testbot --preserve-env=ARTIFACT_GOOGLE_APPLICATION_CREDENTIALS,TEST_MONGODB_URI,MONGODB_TEST_OUTPUT_URI,GITHUB_SHA,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_RUN_ATTEMPT,GITHUB_X_PR_BASE_SHA,GITHUB_X_PR_BASE_REF,GITHUB_X_HEAD_REF,GITHUB_X_HEAD_SHA,GITHUB_REPOSITORY bash -lc 'make cover'
 
+    - name: Upload test.json
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: test.json
+        path: json.log
+        retention-days: 30
+
     # this one runs as root for CAP_SETUID
     - name: test run-as-user
       env:


### PR DESCRIPTION
Cribbed from [the rdk](https://github.com/viamrobotics/rdk/blob/e92959d049e72b0ed57c1dcb9a2328ee5160d802/.github/workflows/test.yml#L84-L90).

Claim that `test.json` is the file to upload:
* The [test command](https://github.com/viamrobotics/goutils/blob/39728ac2cfd339fc555eb547ca71e4ab59bf05bb/.github/workflows/test.yml#L77-L84) calls `make cover`
* [`make cover` calls `etc/test.bash`](https://github.com/viamrobotics/goutils/blob/39728ac2cfd339fc555eb547ca71e4ab59bf05bb/Makefile#L59-L60)
* [`test.bash` calls `gotestsum` with `--jsonfile json.log`](https://github.com/viamrobotics/goutils/blob/39728ac2cfd339fc555eb547ca71e4ab59bf05bb/etc/test.bash#L12)