### PR TITLE
RSDK-6097 increase analyzetests connection timeout

### DIFF
--- a/etc/analyzetests/main.go
+++ b/etc/analyzetests/main.go
@@ -37,7 +37,7 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error
 		return nil
 	}
 
-	connectCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	client, err := mongo.NewClient(options.Client().ApplyURI(mongoURI))
 	if err != nil {


### PR DESCRIPTION
## What changed
- increase connection timeout from 5 seconds to 10 seconds
## Why
Intermittent failures like this one:

https://github.com/viamrobotics/app/actions/runs/7024504474/job/19113759522?pr=3012#step:6:7464
> 2023-11-28T21:20:07.524Z	FATAL	analyzetests	utils@v0.1.52/runtime.go:78	timed out while checking out a connection from connection pool: context deadline exceeded; maxPoolSize: 100, connections in use by cursors: 0, connections in use by transactions: 0, connections in use by other operations: 1