### PR TITLE
RSDK-5407: fix RPC web build and add missing public exports

### DIFF
--- a/rpc/examples/echo/frontend/package-lock.json
+++ b/rpc/examples/echo/frontend/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../../../js": {
       "name": "@viamrobotics/rpc",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package-lock.json
+++ b/rpc/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/rpc",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package.json
+++ b/rpc/js/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint '**/*.{ts,js,cjs}' --quiet",
     "format": "prettier --write '**/*.{ts,js,cjs}'",
-    "build": "vite build",
+    "build": "vite build && tsc --project tsconfig.build.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/rpc/js/package.json
+++ b/rpc/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -249,7 +249,7 @@ class authenticatedTransport implements grpc.Transport {
   }
 }
 
-interface WebRTCConnection {
+export interface WebRTCConnection {
   transportFactory: grpc.TransportFactory;
   peerConnection: RTCPeerConnection;
 }

--- a/rpc/js/src/main.ts
+++ b/rpc/js/src/main.ts
@@ -1,2 +1,10 @@
-export { dialDirect, dialWebRTC, type Credentials } from './dial';
+export {
+  dialDirect,
+  dialWebRTC,
+  type Credentials,
+  type DialOptions,
+  type DialWebRTCOptions,
+  type WebRTCConnection,
+} from './dial';
+
 export { ConnectionClosedError, GRPCError } from './errors';


### PR DESCRIPTION
## Overview

`@viamrobotics/rpc@0.2.0` is not consumable by `@viamrobotics/typescript-sdk` because the typescript SDK imports a few interfaces directly from the `src` directory. This is no longer possible in the `v0.2.0` release because:

- It adheres to latest JS publishing best practices and does not allow importing anything other than the explicitly exported distributable files.
    - The TypeScript SDK does this in two places. In one place, it's a typo. In the other place, it's because a necessary type interface is not exported by RPC.
- We accidentally forgot to include `.d.ts` files in the build step!
    - This used to be handled by webpack, but is not handled by vite, so we need to call `tsc` ourselves now

## Change log

- Add all interfaces that are arguments or return values (or deeply included in those interfaces) to the public exports of the `@viamrobotics/rpc` module
- Fix missing `.d.ts` build step in `rpc`

## Review requests

1. Pull this down locally
2. `make build-web`
3. `cd rpc/js`
4. `npm pack`
5. `cd` to the typescript SDK
6. `make build`
7. Replace both instances of `import { ... } from '@viamrobotics/rpc/src/dial'` with `from '@viamrobotics/rpc'`
8. `npm install path/to/viam/goutils/rpc/js/viamrobotics-rpc-0.2.1.tgz`
9. Validate via `npm run build`