### PR TITLE
APP-2747 Add logging to send for debugging

### DIFF
--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -314,7 +314,8 @@ func (newCall *mongodbNewCallEventHandler) Send(event mongodbCallEvent, logger *
 		}
 	})
 	logger.Infow("returning from send",
-		"Event", event.Call)
+		"Event", event.Call,
+		"Sent", sent)
 	return sent
 }
 

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -605,6 +605,7 @@ func (queue *mongoDBWebRTCCallQueue) processNextSubscriptionEvent(next mongoutil
 				return
 			}
 			event := mongodbCallEvent{Call: callResp}
+			queue.logger.Infof("Number of answer channels: %d", len(answerChans))
 			for answerChan := range answerChans {
 				// We will send on this channel just once and it will eventually
 				// unsubscribe. We are not concerned with looping over channels
@@ -617,7 +618,6 @@ func (queue *mongoDBWebRTCCallQueue) processNextSubscriptionEvent(next mongoutil
 					return
 				}
 			}
-			queue.logger.Infof("Number of answer channels: %d", len(answerChans))
 			callAnswererTooBusy.Inc(queue.operatorID)
 			queue.logger.Warnw(
 				"all answerers for host too busy to answer call",


### PR DESCRIPTION
Hey yall, this PR is to add logging to the send method to determine what case it's hitting when it returns false. For now I just included the whole event with the intention of backing this out once we get to the root of this issue. I also added a log for how many answer channels there are as I realized in only logging on the warning, we don't know if only having 1 answer channel is normal or not. 