### PR TITLE
RSDK-6151 parallel mDNS / WebRTC dials

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,14 +78,6 @@ jobs:
       run: sudo -u testbot bash -lc 'CI=true make test-web'
 
     - if: failure()
-      run: |
-        pwd
-        ls rpc
-        ls rpc/examples
-        ls rpc/examples/echo/
-        ls rpc/examples/echo/playwright-report
-
-    - if: failure()
       name: Upload js test report
       uses: actions/upload-artifact@v3
       with:

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -20,9 +20,6 @@ import (
 // via WebRTC if a signaling server is detected or provided. Otherwise it attempts to connect directly.
 // TODO(GOUT-7): figure out decent way to handle reconnect on connection termination.
 func Dial(ctx context.Context, address string, logger golog.Logger, opts ...DialOption) (ClientConn, error) {
-	start := time.Now()
-	defer func() { logger.Infof("dial time: %dms", time.Since(start).Milliseconds()) }()
-
 	var dOpts dialOptions
 	for _, opt := range opts {
 		opt.apply(&dOpts)
@@ -79,7 +76,7 @@ func dialInner(
 	}
 	if cached {
 		if dOpts.debug {
-			logger.Infow("connected (cached)", "address", address)
+			logger.Debugw("connected (cached)", "address", address)
 		}
 	}
 	return conn, nil

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -257,7 +257,7 @@ func dial(
 			logger.Debug("failed dial attempt, may still try direct", "error", err)
 		}
 	}
-	wg.Wait()
+
 	if conn != nil {
 		return conn, cached, nil
 	}

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -218,7 +218,7 @@ func dial(
 				// TODO(RSDK-6493): Investigate if we must `skipDirect` here.
 				dialCh <- dialResult{err: err, skipDirect: true}
 			case ctxParallel.Err() != nil:
-				dialCh <- dialResult{err: err, skipDirect: true}
+				dialCh <- dialResult{err: ctxParallel.Err(), skipDirect: true}
 			default:
 				dialCh <- dialResult{err: err}
 			}

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -93,6 +93,9 @@ func dial(
 	dOpts *dialOptions,
 	tryLocal bool,
 ) (ClientConn, bool, error) {
+	start := time.Now()
+	defer func() { logger.Infof("dial time: %dms", time.Since(start).Milliseconds()) }()
+
 	var isJustDomain bool
 	if strings.HasPrefix(address, "unix://") {
 		dOpts.mdnsOptions.Disable = true

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -135,10 +135,12 @@ func dial(
 	)
 	defer cancelParallel()
 	if !dOpts.mdnsOptions.Disable && tryLocal && isJustDomain {
+		dOptsCopy := *dOpts
+
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			conn, cached, err := dialMulticastDNS(ctxParallel, address, logger, dOpts)
+			conn, cached, err := dialMulticastDNS(ctxParallel, address, logger, &dOptsCopy)
 			switch {
 			case err != nil:
 				dialCh <- dialResult{err: err}
@@ -167,7 +169,6 @@ func dial(
 					dialCh <- dialResult{err: err, skipDirect: true}
 					return
 				}
-				// TODO: add lock or copy dOpts to safely mutate concurrently
 				fixupWebRTCOptions(dOpts, target, port)
 
 				// When connecting to an external signaler for WebRTC, we assume we can use the external auth's material.

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -142,7 +142,8 @@ func dial(
 			case err != nil:
 				dialCh <- dialResult{err: err}
 			case conn != nil:
-				// TODO(docs): how can we get a `nil` connection when there is no error?
+				// TODO(RSDK-6490): investigate why we can get a `nil` connection that is
+				// not accompanied with an error.
 				dialCh <- dialResult{conn: conn, cached: cached, usedMDNS: true}
 			default:
 				dialCh <- dialResult{err: errors.New("no connection")}

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -125,6 +125,10 @@ func dial(
 		isJustDomain = net.ParseIP(address) == nil
 	}
 
+	// RSDK-6151: We make concurrent dial attempts via mDNS and WebRTC, taking the first
+	// connection that succeeds. We then cancel the slower connection and wait for its
+	// coroutine to complete. If the slower connection succeeds before it can be
+	// cancelled then we explicitly close it to prevent a memory leak.
 	var (
 		wg                          sync.WaitGroup
 		dialCh                      = make(chan dialResult)

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -103,14 +103,15 @@ func dial(
 	tryLocal bool,
 ) (ClientConn, bool, error) {
 	var isJustDomain bool
-	if strings.HasPrefix(address, "unix://") {
+	switch {
+	case strings.HasPrefix(address, "unix://"):
 		dOpts.mdnsOptions.Disable = true
 		dOpts.webrtcOpts.Disable = true
 		dOpts.insecure = true
 		dOpts.disableDirect = false
-	} else if strings.ContainsRune(address, ':') {
+	case strings.ContainsRune(address, ':'):
 		isJustDomain = false
-	} else {
+	default:
 		isJustDomain = net.ParseIP(address) == nil
 	}
 

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -108,12 +108,10 @@ func dial(
 		dOpts.webrtcOpts.Disable = true
 		dOpts.insecure = true
 		dOpts.disableDirect = false
+	} else if strings.ContainsRune(address, ':') {
+		isJustDomain = false
 	} else {
-		if strings.ContainsRune(address, ':') {
-			isJustDomain = false
-		} else {
-			isJustDomain = net.ParseIP(address) == nil
-		}
+		isJustDomain = net.ParseIP(address) == nil
 	}
 
 	connCh := make(chan dialSuccess, 2)

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -215,7 +215,7 @@ func dial(
 				}
 				dialCh <- dialResult{conn: conn, cached: cached}
 			case !errors.Is(err, ErrNoWebRTCSignaler):
-				// TODO(docs): why don't we try dialing directly after this error?
+				// TODO(RSDK-6493): Investigate if we must `skipDirect` here.
 				dialCh <- dialResult{err: err, skipDirect: true}
 			case ctxParallel.Err() != nil:
 				dialCh <- dialResult{err: err, skipDirect: true}

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -225,6 +225,8 @@ func dial(
 		}()
 	}
 
+        // Make sure the slower connection attempt is fully cancelled, or if the attempt succeeded,
+        // close the slower connection.
 	go func() {
 		wg.Wait()
 		close(dialCh)

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -19,6 +19,9 @@ import (
 // via WebRTC if a signaling server is detected or provided. Otherwise it attempts to connect directly.
 // TODO(GOUT-7): figure out decent way to handle reconnect on connection termination.
 func Dial(ctx context.Context, address string, logger golog.Logger, opts ...DialOption) (ClientConn, error) {
+	start := time.Now()
+	defer func() { logger.Infof("dial time: %dms", time.Since(start).Milliseconds()) }()
+
 	var dOpts dialOptions
 	for _, opt := range opts {
 		opt.apply(&dOpts)
@@ -75,7 +78,7 @@ func dialInner(
 	}
 	if cached {
 		if dOpts.debug {
-			logger.Debugw("connected (cached)", "address", address)
+			logger.Infow("connected (cached)", "address", address)
 		}
 	}
 	return conn, nil
@@ -93,9 +96,6 @@ func dial(
 	dOpts *dialOptions,
 	tryLocal bool,
 ) (ClientConn, bool, error) {
-	start := time.Now()
-	defer func() { logger.Infof("dial time: %dms", time.Since(start).Milliseconds()) }()
-
 	var isJustDomain bool
 	if strings.HasPrefix(address, "unix://") {
 		dOpts.mdnsOptions.Disable = true

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -123,10 +123,10 @@ func dial(
 		isJustDomain = net.ParseIP(address) == nil
 	}
 
-	// RSDK-6151: We make concurrent dial attempts via mDNS and WebRTC, taking the first
-	// connection that succeeds. We then cancel the slower connection and wait for its
-	// coroutine to complete. If the slower connection succeeds before it can be
-	// cancelled then we explicitly close it to prevent a memory leak.
+	// We make concurrent dial attempts via mDNS and WebRTC, taking the first connection
+	// that succeeds. We then cancel the slower connection and wait for its coroutine to
+	// complete. If the slower connection succeeds before it can be cancelled then we
+	// explicitly close it to prevent a memory leak.
 	var (
 		wg                          sync.WaitGroup
 		dialCh                      = make(chan dialResult)

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -231,12 +231,10 @@ func dial(
 		cached   bool
 		err      error
 		usedMDNS bool
-		mu       sync.Mutex
 	)
 	for result := range dialCh {
 		switch {
 		case result.err == nil && result.conn != nil:
-			mu.Lock()
 			if conn != nil {
 				errClose := conn.Close()
 				if errClose != nil {
@@ -244,13 +242,10 @@ func dial(
 				}
 			}
 			conn, cached, usedMDNS = result.conn, result.cached, result.usedMDNS
-			mu.Unlock()
 			cancelParallel()
 		case result.err != nil && result.skipDirect:
 			logger.Debug("failed dial attempt, will not try direct", "error", err)
-			mu.Lock()
 			err = result.err
-			mu.Unlock()
 		default:
 			logger.Debug("failed dial attempt, may still try direct", "error", err)
 		}

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -167,7 +167,7 @@ func dial(
 				}
 				target, port, err := getWebRTCTargetFromAddressWithDefaults(signalingAddress)
 				if err != nil {
-					// TODO(docs): why don't we try dialing directly after this error?
+					// TODO(RSDK-6493): Investigate if we must `skipDirect` here.
 					dialCh <- dialResult{err: err, skipDirect: true}
 					return
 				}

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -139,14 +139,15 @@ func dial(
 			conn, cached, err := dialMulticastDNS(ctxParallel, address, logger, dOpts)
 			switch {
 			case err != nil:
-				logger.Warnw("error dialing with mDNS; falling back to other methods", "error", err)
+				logger.Debug("error dialing with mDNS; falling back to other methods", "error", err)
 				dialCh <- dialResult{err: err}
 			case conn != nil:
+				logger.Debug("connected via mDNS")
 				// TODO(docs): how can we get a `nil` connection when there is no error?
 				dialCh <- dialResult{conn: conn, cached: cached}
 			default:
 				errNoConn := errors.New("no connection")
-				logger.Warnw("error dialing with mDNS; falling back to other methods", "error", errNoConn)
+				logger.Debug("error dialing with mDNS; falling back to other methods", "error", errNoConn)
 				dialCh <- dialResult{err: errNoConn}
 			}
 		}()
@@ -248,12 +249,12 @@ func dial(
 			mu.Unlock()
 			cancelParallel()
 		case result.err != nil && result.exitEarly:
-			logger.Warnw("failed dial attempt, will not try direct", "error", err)
+			logger.Debug("failed dial attempt, will not try direct", "error", err)
 			mu.Lock()
 			err = result.err
 			mu.Unlock()
 		default:
-			logger.Warnw("failed dial attempt, may still try direct", "error", err)
+			logger.Debug("failed dial attempt, may still try direct", "error", err)
 		}
 	}
 	wg.Wait()

--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -89,7 +89,7 @@ func dialInner(
 // no way to connect on any of them.
 var ErrConnectionOptionsExhausted = errors.New("exhausted all connection options with no way to connect")
 
-// dialResult contains information about a concurrent dial attempt
+// dialResult contains information about a concurrent dial attempt.
 type dialResult struct {
 	// a successfully established connection
 	conn ClientConn

--- a/rpc/doc.go
+++ b/rpc/doc.go
@@ -10,10 +10,16 @@ https://github.com/jsmouret/grpc-over-webrtc.
 
 # Connection
 
-All connections to RPC servers are done by way of the Dial method which will try multiple
-mechanisms to connect to a target server. By default it will try to connect in the following
-order: mDNS (direct/WebRTC), WebRTC, Direct gRPC. This ordering can be modified by disabling
-some of these methods with DialOptions.
+All connections to RPC servers are done by way of the Dial method which will try the
+following mechanisms to connect to a target server:
+
+1. mDNS (direct/WebRTC)
+2. WebRTC
+3. Direct gRPC
+
+By default it will try to connect with mDNS (1) and WebRTC (2) in parallel and use the
+first established connection. If both fail then it will try to connection with Direct
+gRPC. This ordering can be modified by disabling some of these methods with DialOptions.
 
 # Direct gRPC
 


### PR DESCRIPTION
Update dial logic to attempt mDNS and WebRTC connections in parallel.

# Testing

I ran a script that dials a robot 20 times using the current (serial) and newly implemented (parallel) dial logic. I ran this comparison under two network conditions:

* **hotspot -> viam**: Client and server on different networks, so mDNS will always fail.
* **viam -> viam**: Client and server on the same network, so mDNS may succeed.

Here are the results (in seconds):

| | Serial Hotspot->Viam | Parallel Hotspot->Viam | Serial Viam->Viam | Parallel Viam->Viam |
|------------|----------------------|------------------------|-------------------|---------------------|
| Avg        |                 5.28 |                   2.67 |              1.99 |                1.30 |
| Stdev      |                 1.30 |                   0.64 |              2.48 |                1.14 |

See [this spreadsheet](https://docs.google.com/spreadsheets/d/1m4uZfDQQoO7aIOB1DM1ZLcYMJ6QYirZAVtwTLaDw_rQ/edit#gid=1355373522) for more details.

# TODO

* [x] close unused connection if successful
* [x] run [this test](https://github.com/viamrobotics/goutils/pull/234#issuecomment-1894172191) from the same subnet to utilize mDNS
* [x] ~is the performance improvement worth the extra complexity?~ Yes, the performance profile (see Testing above) shows significant improvement, especially in cases where mDNS will always fail).
* [x] handle config mutations that might happen in parallel (either pass copies or lock as needed)