### PR TITLE
Code Cleanup: Peer

### DIFF
--- a/rpc/js/src/dial-webrtc.ts
+++ b/rpc/js/src/dial-webrtc.ts
@@ -21,7 +21,7 @@ import { ClientChannel } from './ClientChannel';
 import { ConnectionClosedError } from './errors';
 import { Status } from './gen/google/rpc/status_pb';
 import { iceCandidateToProto, iceCandidateFromProto } from './ice-candidate';
-import { newPeerConnectionForClient, addSdpFields } from './peer';
+import { newPeerConnectionForClient, addSDPFields } from './peer';
 
 export interface WebRTCConnection {
   // TODO: Add doc comments for these properties
@@ -407,7 +407,7 @@ const startClient = (
   client.start({ 'rpc-host': host });
 
   const callRequest = new CallRequest();
-  const description = addSdpFields(
+  const description = addSDPFields(
     peerConnection.localDescription,
     options.additionalSdpFields
   );


### PR DESCRIPTION
This is a follow-up to https://github.com/viamrobotics/goutils/pull/232, https://github.com/viamrobotics/goutils/pull/233, and https://github.com/viamrobotics/goutils/pull/235 as a continuation of the effort to cleanup the dial code for better maintainability. This PR focuses on cleaning up the `peer` code for readability. The intent of the changes were not to change the codes behavior, so we will need to test this thoroughly.

This PR is followed up by https://github.com/viamrobotics/goutils/pull/237