### PR TITLE
Code Cleanup: Errors

### DIFF
--- a/rpc/js/src/errors.ts
+++ b/rpc/js/src/errors.ts
@@ -1,31 +1,38 @@
+/* eslint-disable max-classes-per-file */
+
 export class ConnectionClosedError extends Error {
   constructor(msg: string) {
     super(msg);
+    this.name = 'ConnectionClosedError';
     Object.setPrototypeOf(this, ConnectionClosedError.prototype);
   }
 
-  static isError(error: any): boolean {
+  static isError(error: unknown): boolean {
     if (error instanceof ConnectionClosedError) {
       return true;
     }
+
     if (typeof error === 'string') {
       return error === 'Response closed without headers';
     }
+
     if (error instanceof Error) {
       return error.message === 'Response closed without headers';
     }
+
     return false;
   }
 }
 
 export class GRPCError extends Error {
-  public readonly code: number;
-  public readonly grpcMessage: string;
-
-  constructor(code: number, message: string) {
-    super(`Code=${code} Message=${message}`);
+  constructor(
+    readonly code: number,
+    readonly grpcMessage: string
+  ) {
+    super(`Code=${code} Message=${grpcMessage}`);
+    this.name = 'GRPCError';
     this.code = code;
-    this.grpcMessage = message;
+    this.grpcMessage = grpcMessage;
     Object.setPrototypeOf(this, GRPCError.prototype);
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/viamrobotics/goutils/pull/232, https://github.com/viamrobotics/goutils/pull/233, https://github.com/viamrobotics/goutils/pull/235, and https://github.com/viamrobotics/goutils/pull/236 as a continuation of the effort to cleanup the dial code for better maintainability. This PR focuses on cleaning up the errors code for readability. The intent of the changes were not to change the codes behavior, so we will need to test this thoroughly.