### PR TITLE
RSDK-239 RSDK-6343 Disallow IPV6 connections

### DIFF
--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -55,8 +55,8 @@ func newWebRTCAPI(isClient bool, logger golog.Logger) (*webrtc.API, error) {
 	settingEngine.SetIncludeLoopbackCandidate(true)
 	settingEngine.SetRelayAcceptanceMinWait(3 * time.Second)
 	settingEngine.SetIPFilter(func(ip net.IP) bool {
-		// RSDK-239: Disallow ipv6 connections. Viam <-> GRPC has a compatibility
-		// problem.
+		// Disallow ipv6 connections. Viam <-> GRPC has a compatibility problem.
+		// See related grpc-go issue: https://github.com/grpc/grpc-go/issues/3272.
 		//
 		// Stolen from net/ip.go, `IP.String` method.
 		if p4 := ip.To4(); len(p4) == net.IPv4len {

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"sync"
 	"time"
 
@@ -53,6 +54,17 @@ func newWebRTCAPI(isClient bool, logger golog.Logger) (*webrtc.API, error) {
 	// while the client (controlling) provides an mDNS candidate that may resolve to 127.0.0.1.
 	settingEngine.SetIncludeLoopbackCandidate(true)
 	settingEngine.SetRelayAcceptanceMinWait(3 * time.Second)
+	settingEngine.SetIPFilter(func(ip net.IP) bool {
+		// RSDK-239: Disallow ipv6 connections. Viam <-> GRPC has a compatibility
+		// problem.
+		//
+		// Stolen from net/ip.go, `IP.String` method.
+		if p4 := ip.To4(); len(p4) == net.IPv4len {
+			return true
+		}
+
+		return false
+	})
 
 	options := []func(a *webrtc.API){webrtc.WithMediaEngine(&m), webrtc.WithInterceptorRegistry(&i)}
 	if utils.Debug {

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -55,7 +55,7 @@ func newWebRTCAPI(isClient bool, logger golog.Logger) (*webrtc.API, error) {
 	settingEngine.SetIncludeLoopbackCandidate(true)
 	settingEngine.SetRelayAcceptanceMinWait(3 * time.Second)
 	settingEngine.SetIPFilter(func(ip net.IP) bool {
-		// Disallow ipv6 connections. Viam <-> GRPC has a compatibility problem.
+		// Disallow ipv6 addresses since grpc-go does not currently support IPv6 scoped literals.
 		// See related grpc-go issue: https://github.com/grpc/grpc-go/issues/3272.
 		//
 		// Stolen from net/ip.go, `IP.String` method.


### PR DESCRIPTION
[RSDK-239](https://viam.atlassian.net/browse/RSDK-239)
[RSDK-6343](https://viam.atlassian.net/browse/RSDK-6343)

When using something like tailscale (also reportedly happens from within certain docker images), it is sometimes the case that a WebRTC agent will propose an ICE candidate with an IPV6 address. While Viam does not support IPV6, we were not explicitly disallowing IPV6 ICE candidates to be elected in our Golang connections. This caused odd hangs in `RecvMsg` when connecting to remotes through tailscale.

The issue really only presented itself when a main robot had a stream to a remote robot. I was able to repro the error with a Mac on tailscale on network 1 listing a remote of a Linux machine on tailscale on network 2 with a webcam. When the wifi on the Mac was turned off and on again, the reconnection logic sometimes elected an IPV6 remote ICE candidate, and connection hung indefinitely in [`RecvMsg`](https://github.com/viamrobotics/goutils/blob/main/rpc/wrtc_base_stream.go#L108):

```
2024-01-22T11:56:22.367-0800	DEBUG	robot_server.webrtc	rpc/wrtc_base_channel.go:126	selected candidate pair	{"conn_id": "PeerConnection-1705953380117166000", "candidate_pair": "(local) udp4 host 5556ab87-7565-4a50-a9f6-eebbfd5d3c3e.local:51260 <-> (remote) udp6 host [fd7a:115c:a1e0::4008:c78]:60335"}
```

That happened 6/10 times tested. After the change, the hang was avoided 20/20 times, and the elected remote ICE candidate was always IPV4.

```
2024-01-22T12:04:18.108-0800	DEBUG	robot_server.webrtc	rpc/wrtc_base_channel.go:126	selected candidate pair	{"conn_id": "PeerConnection-1705953856911532000", "candidate_pair": "(local) udp4 host bab32ead-05fa-46be-929e-5876638e3278.local:63709 <-> (remote) udp4 host 100.72.12.120:38174"}
```

Huge props to @dgottlieb 🎉 for discovering that this issue had to do with tailscale, and writing the entire patch of this PR (apologies for stealing your thunder and turning it into a PR, Dan, just wanted to include all the relevant testing context).

[RSDK-6343]: https://viam.atlassian.net/browse/RSDK-6343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RSDK-239]: https://viam.atlassian.net/browse/RSDK-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ