### PR TITLE
RSDK-6041 - Add dial timeout to ts 

### DIFF
--- a/rpc/examples/echo/frontend/package-lock.json
+++ b/rpc/examples/echo/frontend/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../../../js": {
       "name": "@viamrobotics/rpc",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package-lock.json
+++ b/rpc/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/rpc",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package.json
+++ b/rpc/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/src/BaseChannel.ts
+++ b/rpc/js/src/BaseChannel.ts
@@ -57,6 +57,7 @@ export class BaseChannel {
     }
     this.closed = true;
     this.closedReason = err;
+    this.pReject?.(err);
     this.peerConn.close();
   }
 

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -44,7 +44,7 @@ export interface DialOptions {
   // externalAuthAddress, externalAuthToEntity, webrtcOptions.signalingAccessToken
   accessToken?: string | undefined;
 
-  // set timeout in milliseconds for dialing. default is 5000.
+  // set timeout in milliseconds for dialing.
   dialTimeout?: number | undefined;
 }
 
@@ -589,12 +589,14 @@ export async function dialWebRTC(
 
     const cc = new ClientChannel(pc, dc);
 
-    // set timeout for dial attempt
-    setTimeout(() => {
-      if (!successful) {
-        cc.close();
-      }
-    }, opts.dialTimeout ?? 5000);
+    // set timeout for dial attempt if a timeout is specified
+    if (opts.dialTimeout) {
+      setTimeout(() => {
+        if (!successful) {
+          cc.close();
+        }
+      }, opts.dialTimeout);
+    }
 
     cc.ready
       .then(() => clientEndResolve())

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -44,7 +44,7 @@ export interface DialOptions {
   // externalAuthAddress, externalAuthToEntity, webrtcOptions.signalingAccessToken
   accessToken?: string | undefined;
 
-  // set timeout in milliseconds for dialing the robot. default is 5000.
+  // set timeout in milliseconds for dialing. default is 5000.
   dialTimeout?: number | undefined;
 }
 

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -45,7 +45,7 @@ export interface DialOptions {
   accessToken?: string | undefined;
 
   // set timeout in milliseconds for dialing the robot. default is 5000.
-  dialTimeout?: number| undefined;
+  dialTimeout?: number | undefined;
 }
 
 export interface DialWebRTCOptions {
@@ -517,9 +517,9 @@ export async function dialWebRTC(
         const remoteSDP = new RTCSessionDescription(
           JSON.parse(atob(init.getSdp()))
         );
-        if (cc.isClosed()){
+        if (cc.isClosed()) {
           sendError('client channel is closed');
-          return
+          return;
         }
         await pc.setRemoteDescription(remoteSDP);
 
@@ -590,12 +590,15 @@ export async function dialWebRTC(
     const cc = new ClientChannel(pc, dc);
 
     // set timeout for dial attempt
-    setTimeout(() => {
-      if(!successful){
-        cc.close()
-      }
-    }, opts?.dialTimeout ? opts?.dialTimeout: 5000)
-    
+    setTimeout(
+      () => {
+        if (!successful) {
+          cc.close();
+        }
+      },
+      opts?.dialTimeout ? opts?.dialTimeout : 5000
+    );
+
     cc.ready
       .then(() => clientEndResolve())
       .catch((err) => clientEndReject(err));

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -596,7 +596,7 @@ export async function dialWebRTC(
           cc.close();
         }
       },
-      opts?.dialTimeout ? opts?.dialTimeout : 5000
+      opts.dialTimeout ?? 5000
     );
 
     cc.ready

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -590,14 +590,11 @@ export async function dialWebRTC(
     const cc = new ClientChannel(pc, dc);
 
     // set timeout for dial attempt
-    setTimeout(
-      () => {
-        if (!successful) {
-          cc.close();
-        }
-      },
-      opts.dialTimeout ?? 5000
-    );
+    setTimeout(() => {
+      if (!successful) {
+        cc.close();
+      }
+    }, opts.dialTimeout ?? 5000);
 
     cc.ready
       .then(() => clientEndResolve())

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -572,9 +572,11 @@ export async function dialWebRTC(
           clientEndReject(new ConnectionClosedError('failed to dial'));
           return;
         }
-        if (cc?.isClosed()){
-          clientEndReject(new ConnectionClosedError('client channel is closed'));
-          return
+        if (cc?.isClosed()) {
+          clientEndReject(
+            new ConnectionClosedError('client channel is closed')
+          );
+          return;
         }
         console.error(statusMessage);
         clientEndReject(statusMessage);


### PR DESCRIPTION
adding dial timeout lets us give up on failed connection attempts faster, shouldn't matter too much for fast connections, but 95% time is a lot faster (on app, which auto redials)

tested by linking the libraries together, so checked that the dialTimeout option actually works

data collected doesn't show the value of the change very well, but from previous anecdotal data, any connection that fails on the first try will take 20s, but with the new change it would be closer to 8-9s (since first failures usually take 15s or so)

| Attempt | With Change (# fails) | Without Change (# fails) |
|---------|-----------------------|--------------------------|
| 1       | 9.5 (1)               | 30.07                    |
| 2       | 4.61                  | 3                        |
| 3       | 1.591                 | 6.7                      |
| 4       | 1.282                 | 1.5                      |
| 5       | 1.216                 | 1.2                      |
| 6       | 2.234                 | 1.1                      |
| 7       | 1.465                 | 1.8                      |
| 8       | 10.7 (1)              | 5.9                      |
| 9       | 2.031                 | 1.59                     |
| 10      | 1.639                 | 1.4                      |

seems like we can actually make the default lower, but can see for now