### PR TITLE
RSDK-5562 Ignore sendDone errors in signaling answerer

### DIFF
--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -478,7 +478,12 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 		return err
 	}
 	if err := sendDone(); err != nil {
-		return err
+		// Errors from sendDone (such as EOF) are sometimes caused by the signaling
+		// server "ending" the exchange process earlier than the answerer due to
+		// the caller being able to establish a connection without all the
+		// answerer's ICE candidates (trickle ICE). Only Warn the error here to
+		// avoid accidentally Closing a healthy, established peer connection.
+		ans.logger.Warnw("error ending signaling exchange from answer client", "error", err)
 	}
 	successful = true
 	return nil


### PR DESCRIPTION
[RSDK-5562](https://viam.atlassian.net/browse/RSDK-5562) (one manifestation of the issue; I can make a separate ticket if desired)

This patch "fixes" the repro of immediate context cancelation from `client.New` I have and logs:
```
logger.go:130: 2024-02-13T09:52:42.292-0500 WARN    internal_signaler       rpc/wrtc_signaling_answerer.go:495 error ending signaling exchange from answer client       {"error": "EOF"}
```

cc @cheukt 

[RSDK-5562]: https://viam.atlassian.net/browse/RSDK-5562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ