### PR TITLE
RSDK-1687 Better synchronize `Stop` and `processHeaders`

### DIFF
--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -277,6 +277,10 @@ func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 		}
 	}
 
+	s.ch.server.peerConnsMu.RLock()
+	s.ch.server.processHeadersWorkers.Add(1)
+	s.ch.server.peerConnsMu.RUnlock()
+
 	// take a ticket
 	select {
 	case <-s.ch.server.ctx.Done():
@@ -293,22 +297,11 @@ func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 	}
 
 	s.headersReceived = true
-	s.ch.server.processHeadersLock.Lock()
-	// Check once more if underlying webrtcServer was `Stop`ped before lock was
-	// acquired (context was canceled).
-	if err := s.ch.server.ctx.Err(); err != nil {
-		if err := s.closeWithSendError(status.FromContextError(err).Err()); err != nil {
-			s.logger.Errorw("error closing", "error", err)
-		}
-		s.ch.server.processHeadersLock.Unlock()
-		return
-	}
-
 	utils.PanicCapturingGo(func() {
 		defer func() {
+			s.ch.server.processHeadersWorkers.Done()
 			<-s.ch.server.callTickets // return a ticket
 		}()
-		defer s.ch.server.processHeadersLock.Unlock()
 		if err := handlerFunc(s); err != nil {
 			if errors.Is(err, io.ErrClosedPipe) || isContextCanceled(err) {
 				return


### PR DESCRIPTION
RSDK-1687

Changes `wrtc_server.go` and `wrtc_server_stream.go` logic:
- Renames `mu` to `peerConnsMu`.
- Renames `activeBackgroundWorkers` to `processHeadersWorkers`.
- Adds a `processHeadersMu` to guard it
- `RLock`s the `processHeadersMu` when `Add`ing to `processHeadersWorkers`
- `Lock`s the `processHeadersMu` when `Wait`ing on `processHeadersWorkers`

The linked ticket describes a data race where `activeBackgroundWorkers.Add(1)` was racing with `activeBackgroundWorkers.Wait()`. This was happening because the `Add` was in a separate goroutine from the `Wait` due to the asynchronous nature of WebRTC "callbacks", and there was no synchronization of `Add`s and `Wait`s.

cc @viamrobotics/netcode .