### PR TITLE
[APP-4184]: Add DisconnectWithReconnect for mongo shutdown simulation

### DIFF
--- a/testutils/mongodb.go
+++ b/testutils/mongodb.go
@@ -97,8 +97,9 @@ var (
 
 // DisconnectWithReconnect closes sockets referenced by cachedBackingMongoDBClient
 // to simulate a db disconnection. The returned callback can be used to reinitialize
-// connection to the same db deployment. Use this function to validating behavior of
-// client shutdown scenarios.
+// connection to the same db deployment. Use this function to validate behavior of
+// client shutdown scenarios. Note: it is up to the caller of this function to call
+// the callback.
 func DisconnectWithReconnect() (func() (*mongo.Client, error), error) {
 	if cachedBackingMongoDBClient == nil {
 		logger.Debug("client is already nil, cannot disconnect")


### PR DESCRIPTION
Motivation came from trying to manually tear down a mongo client in a testing suite and pull it back up after completion - the "pulling back up" failed because the disconnected mongo client was cached in memory. This PR adds handling for that case. Left inline comments / open questions to consider before going through with PR. Let me know what you think.