### PR TITLE
[RSDK-6030] add Status() to ManagedProcess

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -31,12 +31,11 @@ type ManagedProcess interface {
 
 	// Stop signals and waits for the process to stop. An error is returned if
 	// there's any system level issue stopping the process.
-	Stop() error
+  Stop() error
 
   // Status return nil when the process is both alive and owned.
   // If err is non-nil, process may be a) alive but not owned or b) dead.
-  // Method not supported/implemented on Windows
-	Status() error
+  Status() error 
 }
 
 // NewManagedProcess returns a new, unstarted, from the given configuration.
@@ -110,8 +109,7 @@ func (p *managedProcess) ID() string {
 func (p *managedProcess) Status() error {
 	p.mu.Lock()
   defer p.mu.Unlock()
-  err := p.cmd.Process.Signal(syscall.Signal(0))
-  return err
+  return p.cmd.Process.Signal(syscall.Signal(0))
 }
 
 func (p *managedProcess) Start(ctx context.Context) error {

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -31,11 +31,11 @@ type ManagedProcess interface {
 
 	// Stop signals and waits for the process to stop. An error is returned if
 	// there's any system level issue stopping the process.
-  Stop() error
+	Stop() error
 
-  // Status return nil when the process is both alive and owned.
-  // If err is non-nil, process may be a) alive but not owned or b) dead.
-  Status() error 
+	// Status return nil when the process is both alive and owned.
+	// If err is non-nil, process may be a) alive but not owned or b) dead.
+	Status() error
 }
 
 // NewManagedProcess returns a new, unstarted, from the given configuration.
@@ -90,7 +90,7 @@ type managedProcess struct {
 	shouldLog bool
 	cmd       *exec.Cmd
 
-  stopped          bool
+	stopped          bool
 	onUnexpectedExit func(int) bool
 	managingCh       chan struct{}
 	killCh           chan struct{}
@@ -108,8 +108,8 @@ func (p *managedProcess) ID() string {
 
 func (p *managedProcess) Status() error {
 	p.mu.Lock()
-  defer p.mu.Unlock()
-  return p.cmd.Process.Signal(syscall.Signal(0))
+	defer p.mu.Unlock()
+	return p.cmd.Process.Signal(syscall.Signal(0))
 }
 
 func (p *managedProcess) Start(ctx context.Context) error {

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -182,13 +182,9 @@ func TestManagedProcessStart(t *testing.T) {
 
 			<-watcher.Events
 
-      if runtime.GOOS != "windows" {
-        test.That(t, proc.Status(), test.ShouldBeNil)
-      }
+      test.That(t, proc.Status(), test.ShouldBeNil)
       test.That(t, proc.Stop(), test.ShouldBeNil)
-      if runtime.GOOS != "windows" {
-        test.That(t, proc.Status(), test.ShouldNotBeNil)
-      }
+      test.That(t, proc.Status(), test.ShouldNotBeNil)
 
 			rd, err := os.ReadFile(tempFile.Name())
 			test.That(t, err, test.ShouldBeNil)
@@ -354,17 +350,15 @@ func TestManagedProcessStop(t *testing.T) {
 
 		<-watcher.Events
 
-		if runtime.GOOS != "windows" {
-			test.That(t, proc.Status(), test.ShouldBeNil)
-		}
+    test.That(t, proc.Status(), test.ShouldBeNil)
 		err = proc.Stop()
 		if runtime.GOOS == "windows" {
 			test.That(t, err, test.ShouldBeNil)
 		} else {
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 1")
-			test.That(t, proc.Status(), test.ShouldNotBeNil)
 		}
+		test.That(t, proc.Status(), test.ShouldNotBeNil)
 
 		proc = NewManagedProcess(ProcessConfig{
 			Name: "bash",
@@ -418,15 +412,11 @@ done`, tempFile.Name()))
 		}, logger)
 		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 		<-watcher.Events
-    if runtime.GOOS == "windows" {
-      test.That(t, proc.Status(), test.ShouldBeNil)
-    }
+    test.That(t, proc.Status(), test.ShouldBeNil)
     err = proc.Stop()
     test.That(t, err, test.ShouldNotBeNil)
     test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 115")
-    if runtime.GOOS == "windows" {
-      test.That(t, proc.Status(), test.ShouldNotBeNil)
-    }
+    test.That(t, proc.Status(), test.ShouldNotBeNil)
 
 		for _, signal := range knownSignals {
 			t.Run(fmt.Sprintf("sig=%s", sigStr(signal)), func(t *testing.T) {

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -182,7 +182,13 @@ func TestManagedProcessStart(t *testing.T) {
 
 			<-watcher.Events
 
-			test.That(t, proc.Stop(), test.ShouldBeNil)
+      if runtime.GOOS != "windows" {
+        test.That(t, proc.Status(), test.ShouldBeNil)
+      }
+      test.That(t, proc.Stop(), test.ShouldBeNil)
+      if runtime.GOOS != "windows" {
+        test.That(t, proc.Status(), test.ShouldNotBeNil)
+      }
 
 			rd, err := os.ReadFile(tempFile.Name())
 			test.That(t, err, test.ShouldBeNil)
@@ -348,12 +354,16 @@ func TestManagedProcessStop(t *testing.T) {
 
 		<-watcher.Events
 
+		if runtime.GOOS != "windows" {
+			test.That(t, proc.Status(), test.ShouldBeNil)
+		}
 		err = proc.Stop()
 		if runtime.GOOS == "windows" {
 			test.That(t, err, test.ShouldBeNil)
 		} else {
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 1")
+			test.That(t, proc.Status(), test.ShouldNotBeNil)
 		}
 
 		proc = NewManagedProcess(ProcessConfig{
@@ -408,9 +418,15 @@ done`, tempFile.Name()))
 		}, logger)
 		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 		<-watcher.Events
-		err = proc.Stop()
-		test.That(t, err, test.ShouldNotBeNil)
-		test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 115")
+    if runtime.GOOS == "windows" {
+      test.That(t, proc.Status(), test.ShouldBeNil)
+    }
+    err = proc.Stop()
+    test.That(t, err, test.ShouldNotBeNil)
+    test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 115")
+    if runtime.GOOS == "windows" {
+      test.That(t, proc.Status(), test.ShouldNotBeNil)
+    }
 
 		for _, signal := range knownSignals {
 			t.Run(fmt.Sprintf("sig=%s", sigStr(signal)), func(t *testing.T) {
@@ -696,6 +712,12 @@ func (fp *fakeProcess) Stop() error {
 	fp.stopCount++
 	if fp.stopErr {
 		return errors.New("stop")
+	}
+	return nil
+}
+func (fp *fakeProcess) Status() error {
+	if fp.stopErr || fp.startErr {
+		return errors.New("dead")
 	}
 	return nil
 }

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -184,7 +184,7 @@ func TestManagedProcessStart(t *testing.T) {
 
 			test.That(t, proc.Status(), test.ShouldBeNil)
 			test.That(t, proc.Stop(), test.ShouldBeNil)
-			test.That(t, proc.Status(), test.ShouldNotBeNil)
+			test.That(t, proc.Status().Error(), test.ShouldContainSubstring, "process already finished")
 
 			rd, err := os.ReadFile(tempFile.Name())
 			test.That(t, err, test.ShouldBeNil)

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -182,9 +182,9 @@ func TestManagedProcessStart(t *testing.T) {
 
 			<-watcher.Events
 
-      test.That(t, proc.Status(), test.ShouldBeNil)
-      test.That(t, proc.Stop(), test.ShouldBeNil)
-      test.That(t, proc.Status(), test.ShouldNotBeNil)
+			test.That(t, proc.Status(), test.ShouldBeNil)
+			test.That(t, proc.Stop(), test.ShouldBeNil)
+			test.That(t, proc.Status(), test.ShouldNotBeNil)
 
 			rd, err := os.ReadFile(tempFile.Name())
 			test.That(t, err, test.ShouldBeNil)
@@ -350,7 +350,7 @@ func TestManagedProcessStop(t *testing.T) {
 
 		<-watcher.Events
 
-    test.That(t, proc.Status(), test.ShouldBeNil)
+		test.That(t, proc.Status(), test.ShouldBeNil)
 		err = proc.Stop()
 		if runtime.GOOS == "windows" {
 			test.That(t, err, test.ShouldBeNil)
@@ -412,11 +412,11 @@ done`, tempFile.Name()))
 		}, logger)
 		test.That(t, proc.Start(context.Background()), test.ShouldBeNil)
 		<-watcher.Events
-    test.That(t, proc.Status(), test.ShouldBeNil)
-    err = proc.Stop()
-    test.That(t, err, test.ShouldNotBeNil)
-    test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 115")
-    test.That(t, proc.Status(), test.ShouldNotBeNil)
+		test.That(t, proc.Status(), test.ShouldBeNil)
+		err = proc.Stop()
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 115")
+		test.That(t, proc.Status(), test.ShouldNotBeNil)
 
 		for _, signal := range knownSignals {
 			t.Run(fmt.Sprintf("sig=%s", sigStr(signal)), func(t *testing.T) {
@@ -705,6 +705,7 @@ func (fp *fakeProcess) Stop() error {
 	}
 	return nil
 }
+
 func (fp *fakeProcess) Status() error {
 	if fp.stopErr || fp.startErr {
 		return errors.New("dead")

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -25,6 +25,7 @@ func parseSignal(sigStr, name string) (syscall.Signal, error) {
 	return 0, errors.New("signals not supported on Windows")
 }
 
+
 func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
 	ret := &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,


### PR DESCRIPTION
This change allows managed processes to check if their process is still running.
~This method (and the underlying Signal call from golang stdlib) is not supported on windows.~
Correction: Signal Interrupt is not supported on windows