### PR TITLE
RSDK-5534 Better synchronize answer workers

### DIFF
--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -229,8 +229,8 @@ func (ans *webrtcSignalingAnswerer) Stop() {
 
 	ans.cancelAnswerWorkers()
 	ans.answerMu.Lock()
+	defer ans.answerMu.Unlock()
 	ans.answerWorkers.Wait()
-	ans.answerMu.Unlock()
 }
 
 // answer accepts a single call offer, responds with a corresponding SDP, and


### PR DESCRIPTION
RSDK-5534

Better synchronize active goroutines in `wrtc_signaling_answerer.go`. Very similar to change in https://github.com/viamrobotics/goutils/pull/251.

- Renames `activeBackgroundWorkers` to `answerWorkers`
- Renames `cancelBackgroundWorkers` to `cancelAnswerWorkers`
- Adds an `answerMu` `RWMutex` to be `RLock`ed when adding an answer worker and `Lock`ed when waiting on answer workers

The linked ticket describes a data race where `activeBackgroundWorkers.Add(1)` was racing with `activeBackgroundWorkers.Wait()`. This was happening because the `Add` was in a separate goroutine from the `Wait` due to the asynchronous nature of our answering process, and there was no synchronization of `Add`s and `Wait`s.