### PR TITLE
Remove bad return value

### DIFF
--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -374,12 +374,11 @@ func (ss *simpleServer) ensureAuthed(ctx context.Context) (context.Context, erro
 				"error", err,
 				"empty expected audience", len(ss.authAudience) == 0,
 				"expected audience list", audienceList)
-			//return nil, status.Error(codes.Unauthenticated, "invalid audience")
+		} else {
+			ss.logger.Infow("unmarshalled audience claim",
+				"expected audience list", audienceList,
+				"claim audience", claimAudience)
 		}
-
-		ss.logger.Infow("unmarshalled audience claim",
-			"expected audience list", audienceList,
-			"claim audience", claimAudience)
 	}
 
 	if !audVerified {


### PR DESCRIPTION
Accidentally copy-pasted a return where we should not be returning, only logging.

Fixes [this issue](https://viaminc.slack.com/archives/C01Q5S8V6TB/p1710689886947519).