### PR TITLE
RSDK-6130 Improve error message if CWD of process does not exist

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -128,7 +128,7 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	}
 
 	if p.cwd != "" {
-		if _, err := os.Stat(p.cwd); err != nil {
+		if _, err := os.Lstat(p.cwd); err != nil {
 			return fmt.Errorf("error with current working directory: %w", err)
 		}
 	}

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -128,7 +128,7 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	}
 
 	if _, err := os.Stat(p.cwd); err != nil {
-		return err
+		return fmt.Errorf("error with current working directory: %w", err)
 	}
 
 	if _, err := exec.LookPath(p.name); err != nil {

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -127,8 +127,10 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	default:
 	}
 
-	if _, err := os.Stat(p.cwd); err != nil {
-		return fmt.Errorf("error with current working directory: %w", err)
+	if p.cwd != "" {
+		if _, err := os.Stat(p.cwd); err != nil {
+			return fmt.Errorf("error with current working directory: %w", err)
+		}
 	}
 
 	if _, err := exec.LookPath(p.name); err != nil {

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -127,6 +127,10 @@ func (p *managedProcess) Start(ctx context.Context) error {
 	default:
 	}
 
+	if _, err := os.Stat(p.cwd); err != nil {
+		return err
+	}
+
 	if _, err := exec.LookPath(p.name); err != nil {
 		return err
 	}

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -128,12 +128,12 @@ func (p *managedProcess) validateCWD() error {
 			`error setting process working directory to %q: %w; also error getting current working directory: %w`,
 			p.cwd, lstaterr, cwdErr,
 		)
-	} else {
-		return fmt.Errorf(
-			`error setting process working directory to %q from current working directory %q: %w`,
-			p.cwd, cwd, lstaterr,
-		)
 	}
+
+	return fmt.Errorf(
+		`error setting process working directory to %q from current working directory %q: %w`,
+		p.cwd, cwd, lstaterr,
+	)
 }
 
 func (p *managedProcess) Start(ctx context.Context) error {

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -156,7 +156,7 @@ func TestManagedProcessStart(t *testing.T) {
 			cancel()
 			err := proc.Start(ctx)
 			test.That(t, err, test.ShouldNotBeNil)
-			test.That(t, err.Error(), test.ShouldContainSubstring, "error with current working directory")
+			test.That(t, err.Error(), test.ShouldContainSubstring, `error setting process working directory to "idontexist"`)
 		})
 	})
 	t.Run("Managed", func(t *testing.T) {

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -152,6 +152,21 @@ func TestManagedProcessStart(t *testing.T) {
 			test.That(t, err, test.ShouldNotBeNil)
 			test.That(t, err.Error(), test.ShouldContainSubstring, "exit status 1")
 		})
+		t.Run("providing a nonexistent cwd should fail", func(t *testing.T) {
+			logger := golog.NewTestLogger(t)
+			proc := NewManagedProcess(ProcessConfig{
+				Name:    "bash",
+				Args:    []string{"-c", "echo hello"},
+				OneShot: true,
+				Log:     true,
+				CWD:     "idontexist",
+			}, logger)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := proc.Start(ctx)
+			test.That(t, err, test.ShouldNotBeNil)
+			test.That(t, err.Error(), test.ShouldContainSubstring, "error with current working directory")
+		})
 	})
 	t.Run("Managed", func(t *testing.T) {
 		t.Run("starting with a canceled context should have no effect", func(t *testing.T) {

--- a/testutils/file.go
+++ b/testutils/file.go
@@ -39,20 +39,3 @@ func TempFile(tb testing.TB, name string) *os.File {
 	test.That(tb, err, test.ShouldBeNil)
 	return f
 }
-
-// TempFileAndDir created a new unique temporary file in a temporary directory using the
-// given name, and fails the test if it cannot. It returns the file, the temporary
-// directory path, and a cleanup function.
-func TempFileAndDir(tb testing.TB, name string) (*os.File, string, func()) {
-	tb.Helper()
-
-	dir := tb.TempDir()
-	tempFile := filepath.Join(tb.TempDir(), name)
-	//nolint:gosec
-	f, err := os.Create(tempFile)
-	test.That(tb, err, test.ShouldBeNil)
-
-	return f, dir, func() {
-		test.That(tb, f.Close(), test.ShouldBeNil)
-	}
-}

--- a/testutils/file.go
+++ b/testutils/file.go
@@ -39,3 +39,20 @@ func TempFile(tb testing.TB, name string) *os.File {
 	test.That(tb, err, test.ShouldBeNil)
 	return f
 }
+
+// TempFileAndDir created a new unique temporary file in a temporary directory using the
+// given name, and fails the test if it cannot. It returns the file, the temporary
+// directory path, and a cleanup function.
+func TempFileAndDir(tb testing.TB, name string) (*os.File, string, func()) {
+	tb.Helper()
+
+	dir := tb.TempDir()
+	tempFile := filepath.Join(tb.TempDir(), name)
+	//nolint:gosec
+	f, err := os.Create(tempFile)
+	test.That(tb, err, test.ShouldBeNil)
+
+	return f, dir, func() {
+		test.That(tb, f.Close(), test.ShouldBeNil)
+	}
+}


### PR DESCRIPTION
If current working directory (CWD) is provided, make sure it exists before starting the managed process. If it doesn't or there is some other error related to looking up the CWD, return a more descriptive error.