### PR TITLE
Improve test utilities for temp file and file watcher creation

### DIFF
--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
-	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
 	"go.viam.com/test"
 
@@ -54,21 +53,6 @@ func TestManagedProcessID(t *testing.T) {
 	test.That(t, p2.ID(), test.ShouldEqual, "2")
 }
 
-func createWatchedTempFile(t *testing.T) (*fsnotify.Watcher, *os.File, func()) {
-	t.Helper()
-
-	watcher, err := fsnotify.NewWatcher()
-	test.That(t, err, test.ShouldBeNil)
-
-	tempFile, cleanupTF := testutils.TempFile(t)
-	watcher.Add(tempFile.Name())
-
-	return watcher, tempFile, func() {
-		test.That(t, watcher.Close(), test.ShouldBeNil)
-		cleanupTF()
-	}
-}
-
 func TestManagedProcessStart(t *testing.T) {
 	t.Run("OneShot", func(t *testing.T) {
 		t.Run("starting with a canceled context should fail", func(t *testing.T) {
@@ -88,7 +72,7 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("starting with an eventually canceled context should fail", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			watcher, tempFile, cleanup := createWatchedTempFile(t)
+			watcher, tempFile, cleanup := testutils.WatchedFile(t)
 			defer cleanup()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -188,7 +172,7 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("starting with a normal context should run until stop", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			watcher, tempFile, cleanup := createWatchedTempFile(t)
+			watcher, tempFile, cleanup := testutils.WatchedFile(t)
 			defer cleanup()
 
 			proc := NewManagedProcess(ProcessConfig{
@@ -246,7 +230,7 @@ func TestManagedProcessManage(t *testing.T) {
 	t.Run("a managed process that dies should be restarted", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 
-		watcher, tempFile, cleanup := createWatchedTempFile(t)
+		watcher, tempFile, cleanup := testutils.WatchedFile(t)
 		defer cleanup()
 
 		proc := NewManagedProcess(ProcessConfig{
@@ -332,7 +316,7 @@ func TestManagedProcessStop(t *testing.T) {
 	t.Run("stopping a managed process gives it a chance to finish", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 
-		watcher, tempFile, cleanup := createWatchedTempFile(t)
+		watcher, tempFile, cleanup := testutils.WatchedFile(t)
 		defer cleanup()
 
 		proc := NewManagedProcess(ProcessConfig{
@@ -394,7 +378,7 @@ func TestManagedProcessStop(t *testing.T) {
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher, tempFile, cleanup := createWatchedTempFile(t)
+		watcher, tempFile, cleanup := testutils.WatchedFile(t)
 		defer cleanup()
 
 		var bashScriptBuilder strings.Builder
@@ -447,7 +431,7 @@ done`, tempFile.Name()))
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher1, tempFile, cleanup := createWatchedTempFile(t)
+		watcher1, tempFile, cleanup := testutils.WatchedFile(t)
 		defer cleanup()
 
 		bashScript1 := fmt.Sprintf(`
@@ -487,11 +471,11 @@ done`, tempFile.Name()))
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher1, tempFile1, cleanup1 := createWatchedTempFile(t)
+		watcher1, tempFile1, cleanup1 := testutils.WatchedFile(t)
 		defer cleanup1()
-		watcher2, tempFile2, cleanup2 := createWatchedTempFile(t)
+		watcher2, tempFile2, cleanup2 := testutils.WatchedFile(t)
 		defer cleanup2()
-		watcher3, tempFile3, cleanup3 := createWatchedTempFile(t)
+		watcher3, tempFile3, cleanup3 := testutils.WatchedFile(t)
 		defer cleanup3()
 
 		trapScript := `
@@ -553,7 +537,7 @@ done`, tempFile.Name()))
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher1, tempFile, cleanup := createWatchedTempFile(t)
+		watcher1, tempFile, cleanup := testutils.WatchedFile(t)
 		defer cleanup()
 
 		proc := NewManagedProcess(ProcessConfig{

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -123,10 +123,6 @@ func TestManagedProcessStart(t *testing.T) {
 		})
 		t.Run("OnUnexpectedExit is ignored", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
-
-			// TODO do we need this?
-			testutils.TempFile(t)
-
 			proc := NewManagedProcess(ProcessConfig{
 				Name:             "bash",
 				Args:             []string{"-c", "exit 1"},

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -54,22 +54,13 @@ func TestManagedProcessID(t *testing.T) {
 	test.That(t, p2.ID(), test.ShouldEqual, "2")
 }
 
-func createTempFile(t *testing.T) (*os.File, func()) {
-	t.Helper()
-
-	f := testutils.TempFile(t, "something.txt")
-	return f, func() {
-		test.That(t, f.Close(), test.ShouldBeNil)
-	}
-}
-
 func createWatchedTempFile(t *testing.T) (*fsnotify.Watcher, *os.File, func()) {
 	t.Helper()
 
 	watcher, err := fsnotify.NewWatcher()
 	test.That(t, err, test.ShouldBeNil)
 
-	tempFile, cleanupTF := createTempFile(t)
+	tempFile, cleanupTF := testutils.TempFile(t)
 	watcher.Add(tempFile.Name())
 
 	return watcher, tempFile, func() {
@@ -123,7 +114,7 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("starting with a normal context", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			tempFile, cleanup := createTempFile(t)
+			tempFile, cleanup := testutils.TempFile(t)
 			defer cleanup()
 
 			proc := NewManagedProcess(ProcessConfig{
@@ -151,7 +142,7 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("OnUnexpectedExit is ignored", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			_, cleanup := createTempFile(t)
+			_, cleanup := testutils.TempFile(t)
 			defer cleanup()
 
 			proc := NewManagedProcess(ProcessConfig{

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -72,8 +72,7 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("starting with an eventually canceled context should fail", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			watcher, tempFile, cleanup := testutils.WatchedFile(t)
-			defer cleanup()
+			watcher, tempFile := testutils.WatchedFile(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
@@ -98,8 +97,7 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("starting with a normal context", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			tempFile, cleanup := testutils.TempFile(t)
-			defer cleanup()
+			tempFile := testutils.TempFile(t)
 
 			proc := NewManagedProcess(ProcessConfig{
 				Name:    "bash",
@@ -126,8 +124,8 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("OnUnexpectedExit is ignored", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			_, cleanup := testutils.TempFile(t)
-			defer cleanup()
+			// TODO do we need this?
+			testutils.TempFile(t)
 
 			proc := NewManagedProcess(ProcessConfig{
 				Name:             "bash",
@@ -172,8 +170,7 @@ func TestManagedProcessStart(t *testing.T) {
 		t.Run("starting with a normal context should run until stop", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
 
-			watcher, tempFile, cleanup := testutils.WatchedFile(t)
-			defer cleanup()
+			watcher, tempFile := testutils.WatchedFile(t)
 
 			proc := NewManagedProcess(ProcessConfig{
 				Name: "bash",
@@ -230,8 +227,7 @@ func TestManagedProcessManage(t *testing.T) {
 	t.Run("a managed process that dies should be restarted", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 
-		watcher, tempFile, cleanup := testutils.WatchedFile(t)
-		defer cleanup()
+		watcher, tempFile := testutils.WatchedFile(t)
 
 		proc := NewManagedProcess(ProcessConfig{
 			Name: "bash",
@@ -316,8 +312,7 @@ func TestManagedProcessStop(t *testing.T) {
 	t.Run("stopping a managed process gives it a chance to finish", func(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 
-		watcher, tempFile, cleanup := testutils.WatchedFile(t)
-		defer cleanup()
+		watcher, tempFile := testutils.WatchedFile(t)
 
 		proc := NewManagedProcess(ProcessConfig{
 			Name: "bash",
@@ -378,8 +373,7 @@ func TestManagedProcessStop(t *testing.T) {
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher, tempFile, cleanup := testutils.WatchedFile(t)
-		defer cleanup()
+		watcher, tempFile := testutils.WatchedFile(t)
 
 		var bashScriptBuilder strings.Builder
 		for _, sig := range knownSignals {
@@ -431,8 +425,7 @@ done`, tempFile.Name()))
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher1, tempFile, cleanup := testutils.WatchedFile(t)
-		defer cleanup()
+		watcher1, tempFile := testutils.WatchedFile(t)
 
 		bashScript1 := fmt.Sprintf(`
 			trap "echo SIGTERM >> '%s'" SIGTERM
@@ -471,12 +464,9 @@ done`, tempFile.Name()))
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher1, tempFile1, cleanup1 := testutils.WatchedFile(t)
-		defer cleanup1()
-		watcher2, tempFile2, cleanup2 := testutils.WatchedFile(t)
-		defer cleanup2()
-		watcher3, tempFile3, cleanup3 := testutils.WatchedFile(t)
-		defer cleanup3()
+		watcher1, tempFile1 := testutils.WatchedFile(t)
+		watcher2, tempFile2 := testutils.WatchedFile(t)
+		watcher3, tempFile3 := testutils.WatchedFile(t)
 
 		trapScript := `
 			trap "echo SIGTERM >> '%s'" SIGTERM
@@ -537,8 +527,7 @@ done`, tempFile.Name()))
 		}
 		logger := golog.NewTestLogger(t)
 
-		watcher1, tempFile, cleanup := testutils.WatchedFile(t)
-		defer cleanup()
+		watcher1, tempFile := testutils.WatchedFile(t)
 
 		proc := NewManagedProcess(ProcessConfig{
 			Name: "bash",

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"time"
 
 	"github.com/edaniels/golog"
-	"github.com/pkg/errors"
 	"go.viam.com/test"
 
 	"go.viam.com/utils"

--- a/pexec/process_manager_test.go
+++ b/pexec/process_manager_test.go
@@ -190,11 +190,10 @@ func TestProcessManagerStart(t *testing.T) {
 		test.That(t, pm.Start(context.Background()), test.ShouldBeNil)
 
 		t.Run("adding a process after starting starts it", func(t *testing.T) {
-			temp, err := os.CreateTemp("", "*.txt")
-			test.That(t, err, test.ShouldBeNil)
-			defer os.Remove(temp.Name())
+			temp := testutils.TempFile(t, "something.txt")
+			defer temp.Close()
 
-			_, err = pm.AddProcessFromConfig(context.Background(),
+			_, err := pm.AddProcessFromConfig(context.Background(),
 				ProcessConfig{
 					ID:   "1",
 					Name: "bash",
@@ -271,11 +270,10 @@ func TestProcessManagerStart(t *testing.T) {
 			test.That(t, pm.Stop(), test.ShouldBeNil)
 		}()
 
-		temp, err := os.CreateTemp("", "*.txt")
-		test.That(t, err, test.ShouldBeNil)
-		defer os.Remove(temp.Name())
+		temp := testutils.TempFile(t, "something.txt")
+		defer temp.Close()
 
-		_, err = pm.AddProcessFromConfig(context.Background(),
+		_, err := pm.AddProcessFromConfig(context.Background(),
 			ProcessConfig{
 				ID:   "1",
 				Name: "bash",

--- a/pexec/process_manager_test.go
+++ b/pexec/process_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/fsnotify/fsnotify"
 	"go.viam.com/test"
+	"go.viam.com/utils/testutils"
 
 	"go.viam.com/utils"
 )
@@ -26,7 +27,7 @@ func createNWatchedFiles(t *testing.T, n int) (*fsnotify.Watcher, []*os.File, fu
 	var cleanupTFs []func()
 
 	for i := 0; i < n; i++ {
-		f, cleanup := createTempFile(t)
+		f, cleanup := testutils.TempFile(t)
 		tempFiles = append(tempFiles, f)
 		cleanupTFs = append(cleanupTFs, cleanup)
 
@@ -216,7 +217,7 @@ func TestProcessManagerStart(t *testing.T) {
 		test.That(t, pm.Start(context.Background()), test.ShouldBeNil)
 
 		t.Run("adding a process after starting starts it", func(t *testing.T) {
-			temp, cleanup := createTempFile(t)
+			temp, cleanup := testutils.TempFile(t)
 			defer cleanup()
 
 			_, err := pm.AddProcessFromConfig(context.Background(),
@@ -291,7 +292,7 @@ func TestProcessManagerStart(t *testing.T) {
 			test.That(t, pm.Stop(), test.ShouldBeNil)
 		}()
 
-		temp, cleanup := createTempFile(t)
+		temp, cleanup := testutils.TempFile(t)
 		defer cleanup()
 
 		_, err := pm.AddProcessFromConfig(context.Background(),

--- a/pexec/process_manager_test.go
+++ b/pexec/process_manager_test.go
@@ -189,8 +189,7 @@ func TestProcessManagerStart(t *testing.T) {
 		test.That(t, pm.Start(context.Background()), test.ShouldBeNil)
 
 		t.Run("adding a process after starting starts it", func(t *testing.T) {
-			temp, cleanup := testutils.TempFile(t)
-			defer cleanup()
+			temp := testutils.TempFile(t)
 
 			_, err := pm.AddProcessFromConfig(context.Background(),
 				ProcessConfig{
@@ -230,8 +229,7 @@ func TestProcessManagerStart(t *testing.T) {
 			// a "timed" ctx should only have an effect on one shots
 			ctx, cancel = context.WithCancel(context.Background())
 
-			watcher, tempFiles, cleanup := testutils.WatchedFiles(t, 2)
-			defer cleanup()
+			watcher, tempFiles := testutils.WatchedFiles(t, 2)
 			tempFile1 := tempFiles[0]
 			tempFile2 := tempFiles[1]
 
@@ -264,8 +262,7 @@ func TestProcessManagerStart(t *testing.T) {
 			test.That(t, pm.Stop(), test.ShouldBeNil)
 		}()
 
-		temp, cleanup := testutils.TempFile(t)
-		defer cleanup()
+		temp := testutils.TempFile(t)
 
 		_, err := pm.AddProcessFromConfig(context.Background(),
 			ProcessConfig{
@@ -334,8 +331,7 @@ func TestProcessManagerStop(t *testing.T) {
 		logger := golog.NewTestLogger(t)
 		pm := NewProcessManager(logger)
 
-		watcher, tempFiles, cleanup := testutils.WatchedFiles(t, 3)
-		defer cleanup()
+		watcher, tempFiles := testutils.WatchedFiles(t, 3)
 		tempFile1 := tempFiles[0]
 		tempFile2 := tempFiles[1]
 		tempFile3 := tempFiles[2]
@@ -380,8 +376,7 @@ func TestProcessManagerStop(t *testing.T) {
 		pm := NewProcessManager(logger)
 		test.That(t, pm.Start(context.Background()), test.ShouldBeNil)
 
-		watcher, tempFiles, cleanup := testutils.WatchedFiles(t, 2)
-		defer cleanup()
+		watcher, tempFiles := testutils.WatchedFiles(t, 2)
 		tempFile1 := tempFiles[0]
 		tempFile2 := tempFiles[1]
 

--- a/pexec/process_manager_test.go
+++ b/pexec/process_manager_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/edaniels/golog"
 	"go.viam.com/test"
-	"go.viam.com/utils/testutils"
 
 	"go.viam.com/utils"
+	"go.viam.com/utils/testutils"
 )
 
 func TestProcessManagerProcessIDs(t *testing.T) {

--- a/testutils/file.go
+++ b/testutils/file.go
@@ -78,3 +78,20 @@ func WatchedFiles(tb testing.TB, n int) (*fsnotify.Watcher, []*os.File, func()) 
 		}
 	}
 }
+
+// WatchedFile creates a file watcher and a unique temporary file named "something.txt",
+// or fails the test if it cannot. It returns the watcher, the file, and a clean-up
+// function.
+func WatchedFile(tb testing.TB) (*fsnotify.Watcher, *os.File, func()) {
+	tb.Helper()
+
+	watcher, tempFiles, cleanup := WatchedFiles(tb, 1)
+
+	count := len(tempFiles)
+	if count != 1 {
+		defer cleanup()
+		tb.Fatalf("expected to create exactly 1 temporary file but created %d", count)
+	}
+
+	return watcher, tempFiles[0], cleanup
+}

--- a/testutils/file.go
+++ b/testutils/file.go
@@ -42,6 +42,9 @@ func TempFile(tb testing.TB) (*os.File, func()) {
 
 	return f, func() {
 		test.That(tb, f.Close(), test.ShouldBeNil)
+		// Since the file was placed in a directory that was created via TB.TempDir, it
+		// will automatically be deleted after the test and all its subtests complete, so
+		// we do not need to remove it manually.
 	}
 }
 

--- a/testutils/file.go
+++ b/testutils/file.go
@@ -67,18 +67,14 @@ func WatchedFiles(tb testing.TB, n int) (*fsnotify.Watcher, []*os.File) {
 	watcher, err := fsnotify.NewWatcher()
 	test.That(tb, err, test.ShouldBeNil)
 	tb.Cleanup(func() {
-		if err := watcher.Close(); err != nil {
-			tb.Errorf("error closing watcher: %s", err.Error())
-		}
+		test.That(tb, watcher.Close(), test.ShouldBeNil)
 	})
 
 	var tempFiles []*os.File
 	for i := 0; i < n; i++ {
 		f := TempFile(tb)
 		tempFiles = append(tempFiles, f)
-		if err := watcher.Add(f.Name()); err != nil {
-			tb.Errorf("error adding file %q to watch: %s", f.Name(), err.Error())
-		}
+		test.That(tb, watcher.Add(f.Name()), test.ShouldBeNil)
 	}
 
 	return watcher, tempFiles
@@ -92,11 +88,7 @@ func WatchedFile(tb testing.TB) (*fsnotify.Watcher, *os.File) {
 	tb.Helper()
 
 	watcher, tempFiles := WatchedFiles(tb, 1)
-
-	count := len(tempFiles)
-	if count != 1 {
-		tb.Fatalf("expected to create exactly 1 temporary file but created %d", count)
-	}
+	test.That(tb, len(tempFiles), test.ShouldEqual, 1)
 
 	return watcher, tempFiles[0]
 }

--- a/testutils/file.go
+++ b/testutils/file.go
@@ -30,12 +30,22 @@ func TempDir(dir, pattern string) (string, error) {
 	return dir, err
 }
 
-// TempFile returns a new unique temporary file using the given name.
-func TempFile(tb testing.TB, name string) *os.File {
+// TempFile creates a unique temporary file named "something.txt" or fails the test if it
+// cannot. It returns the file and a clean-up function.
+func TempFile(tb testing.TB) (*os.File, func()) {
+	return tempFileNamed(tb, "something.txt")
+}
+
+// tempFileNamed creates a unique temporary file with the given name or fails the test if
+// it cannot. It returns the file and a clean-up function.
+func tempFileNamed(tb testing.TB, name string) (*os.File, func()) {
 	tb.Helper()
 	tempFile := filepath.Join(tb.TempDir(), name)
 	//nolint:gosec
 	f, err := os.Create(tempFile)
 	test.That(tb, err, test.ShouldBeNil)
-	return f
+
+	return f, func() {
+		test.That(tb, f.Close(), test.ShouldBeNil)
+	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/viamrobotics/goutils/pull/276 - I noticed we have a bunch of boilerplate setup/tear-down code around creating temp files and watchers - this PR encapsulates these procedures into helpers.