### PR TITLE
RSDK-7010 Invalidate JWT access token upon Unauthenticated error

### DIFF
--- a/rpc/client_interceptors.go
+++ b/rpc/client_interceptors.go
@@ -60,6 +60,7 @@ func UnaryClientReauthInterceptor(creds *perRPCJWTCredentials) grpc.UnaryClientI
 			if creds != nil {
 				creds.accessToken = ""
 			}
+		default:
 		}
 		return err
 	}

--- a/rpc/client_interceptors.go
+++ b/rpc/client_interceptors.go
@@ -48,9 +48,10 @@ func contextWithSpanMetadata(ctx context.Context) context.Context {
 	return ctx
 }
 
-// UnaryClientReauthInterceptor clears the access token stored on creds in the
-// event of an "Unauthenticated" or "PermissionDenied" gRPC error to force re-auth.
-func UnaryClientReauthInterceptor(creds *perRPCJWTCredentials) grpc.UnaryClientInterceptor {
+// UnaryClientInvalidAuthInterceptor clears the access token stored on creds in
+// the event of an "Unauthenticated" or "PermissionDenied" gRPC error to force
+// re-auth.
+func UnaryClientInvalidAuthInterceptor(creds *perRPCJWTCredentials) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{},
 		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {

--- a/rpc/client_interceptors.go
+++ b/rpc/client_interceptors.go
@@ -56,12 +56,9 @@ func UnaryClientInvalidAuthInterceptor(creds *perRPCJWTCredentials) grpc.UnaryCl
 		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
 		err := invoker(ctx, method, req, reply, cc, opts...)
-		switch status.Code(err) {
-		case codes.Unauthenticated, codes.PermissionDenied:
-			if creds != nil {
-				creds.accessToken = ""
-			}
-		default:
+		if c := status.Code(err); c == codes.Unauthenticated || c == codes.PermissionDenied &&
+			creds != nil {
+			creds.accessToken = ""
 		}
 		return err
 	}

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -331,8 +331,8 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 			connPtr = &rpcCreds.conn
 		}
 		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(rpcCreds))
-		unaryInterceptors = append(unaryInterceptors, UnaryClientReauthInterceptor(rpcCreds))
-		// ReauthInterceptors will not work for streaming calls; we can only
+		unaryInterceptors = append(unaryInterceptors, UnaryClientInvalidAuthInterceptor(rpcCreds))
+		// InvalidAuthInterceptor will not work for streaming calls; we can only
 		// intercept the creation of a stream, and the ensuring of authentication
 		// server-side happens per RPC request (per usage of the stream).
 	}

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -290,8 +290,6 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 	if dOpts.unaryInterceptor != nil {
 		unaryInterceptors = append(unaryInterceptors, dOpts.unaryInterceptor)
 	}
-	unaryInterceptor := grpc_middleware.ChainUnaryClient(unaryInterceptors...)
-	dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(unaryInterceptor))
 
 	var streamInterceptors []grpc.StreamClientInterceptor
 	streamInterceptors = append(streamInterceptors, grpc_zap.StreamClientInterceptor(grpcLogger))
@@ -299,8 +297,6 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 	if dOpts.streamInterceptor != nil {
 		streamInterceptors = append(streamInterceptors, dOpts.streamInterceptor)
 	}
-	streamInterceptor := grpc_middleware.ChainStreamClient(streamInterceptors...)
-	dialOpts = append(dialOpts, grpc.WithStreamInterceptor(streamInterceptor))
 
 	var connPtr *ClientConn
 	var closeCredsFunc func() error
@@ -335,7 +331,16 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 			connPtr = &rpcCreds.conn
 		}
 		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(rpcCreds))
+		unaryInterceptors = append(unaryInterceptors, UnaryClientReauthInterceptor(rpcCreds))
+		// ReauthInterceptors will not work for streaming calls; we can only
+		// intercept the creation of a stream, and the ensuring of authentication
+		// server-side happens per RPC request (per usage of the stream).
 	}
+
+	unaryInterceptor := grpc_middleware.ChainUnaryClient(unaryInterceptors...)
+	dialOpts = append(dialOpts, grpc.WithUnaryInterceptor(unaryInterceptor))
+	streamInterceptor := grpc_middleware.ChainStreamClient(streamInterceptors...)
+	dialOpts = append(dialOpts, grpc.WithStreamInterceptor(streamInterceptor))
 
 	var conn ClientConn
 	var cached bool

--- a/rpc/dialer_test.go
+++ b/rpc/dialer_test.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"errors"
 	"net"
 	"testing"
 
@@ -556,7 +555,7 @@ func TestReauth(t *testing.T) {
 		timesAuthEnsured++
 		// Fail until client has reauthenticated (timesAuthed > 1).
 		if timesAuthed <= 1 {
-			return nil, errors.New("Unauthenticated")
+			return nil, status.Error(codes.Unauthenticated, "bad")
 		}
 		return context.Background(), nil
 	}

--- a/rpc/dialer_test.go
+++ b/rpc/dialer_test.go
@@ -563,7 +563,7 @@ func TestReauth(t *testing.T) {
 	rpcServer, err := NewServer(
 		logger,
 		WithAuthHandler(CredentialsTypeAPIKey, fakeAuthHandler),
-		WithEnsureAuthedHander(fakeEnsureAuthedHandler),
+		WithEnsureAuthedHandler(fakeEnsureAuthedHandler),
 	)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/rpc/dialer_test.go
+++ b/rpc/dialer_test.go
@@ -543,7 +543,7 @@ func TestWithStreamInterceptor(t *testing.T) {
 	test.That(t, interceptedCount, test.ShouldEqual, 1)
 }
 
-func TestReauth(t *testing.T) {
+func TestInvalidAuth(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 
 	var timesAuthed, timesAuthEnsured int

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -138,6 +138,7 @@ type simpleServer struct {
 	tlsAuthHandler       func(ctx context.Context, entities ...string) error
 	authHandlersForCreds map[CredentialsType]credAuthHandlers
 	authToHandler        AuthenticateToHandler
+	ensureAuthedHandler  func(ctx context.Context) (context.Context, error)
 
 	// authAudience is the JWT audience (aud) that will be used/expected
 	// for our service.
@@ -296,6 +297,7 @@ func NewServer(logger golog.Logger, opts ...ServerOption) (Server, error) {
 		authToHandler:        sOpts.authToHandler,
 		authAudience:         sOpts.authAudience,
 		authIssuer:           sOpts.authIssuer,
+		ensureAuthedHandler:  sOpts.ensureAuthedHandler,
 		exemptMethods:        make(map[string]bool),
 		publicMethods:        make(map[string]bool),
 		tlsConfig:            sOpts.tlsConfig,

--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -286,6 +287,10 @@ func (ss *simpleServer) tryAuth(ctx context.Context) (context.Context, error) {
 func (ss *simpleServer) ensureAuthed(ctx context.Context) (context.Context, error) {
 	// Use handler if set (only used for testing).
 	if ss.ensureAuthedHandler != nil {
+		// If not in a testing environment, return an error.
+		if !testing.Testing() {
+			return nil, errors.New("cannot use custom ensureAuthed handler in production")
+		}
 		return ss.ensureAuthedHandler(ctx)
 	}
 

--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -284,6 +284,11 @@ func (ss *simpleServer) tryAuth(ctx context.Context) (context.Context, error) {
 }
 
 func (ss *simpleServer) ensureAuthed(ctx context.Context) (context.Context, error) {
+	// Use handler if set (only used for testing).
+	if ss.ensureAuthedHandler != nil {
+		return ss.ensureAuthedHandler(ctx)
+	}
+
 	tokenString, err := tokenFromContext(ctx)
 	if err != nil {
 		// check TLS state

--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -287,10 +286,6 @@ func (ss *simpleServer) tryAuth(ctx context.Context) (context.Context, error) {
 func (ss *simpleServer) ensureAuthed(ctx context.Context) (context.Context, error) {
 	// Use handler if set (only used for testing).
 	if ss.ensureAuthedHandler != nil {
-		// If not in a testing environment, return an error.
-		if !testing.Testing() {
-			return nil, errors.New("cannot use custom ensureAuthed handler in production")
-		}
 		return ss.ensureAuthedHandler(ctx)
 	}
 

--- a/rpc/server_options.go
+++ b/rpc/server_options.go
@@ -363,7 +363,9 @@ func WithAuthHandler(forType CredentialsType, handler AuthHandler) ServerOption 
 }
 
 // WithEnsureAuthedHandler returns a ServerOptions which adds custom logic for
-// the ensuring of authentication on each incoming request.
+// the ensuring of authentication on each incoming request. Can only be used
+// in testing environments (will produce an error when ensuring authentication
+// otherwise).
 func WithEnsureAuthedHandler(eah func(ctx context.Context) (context.Context, error)) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) error {
 		o.ensureAuthedHandler = eah

--- a/rpc/server_options.go
+++ b/rpc/server_options.go
@@ -67,6 +67,10 @@ type serverOptions struct {
 	// stats monitoring on the connections.
 	statsHandler stats.Handler
 
+	// ensureAuthedHandler is the callback used to ensure that the context of an
+	// incoming RPC request is properly authenticated.
+	ensureAuthedHandler func(ctx context.Context) (context.Context, error)
+
 	unknownStreamDesc *grpc.StreamDesc
 }
 
@@ -355,6 +359,15 @@ func WithTLSAuthHandler(entities []string) ServerOption {
 func WithAuthHandler(forType CredentialsType, handler AuthHandler) ServerOption {
 	return withCredAuthHandlers(forType, credAuthHandlers{
 		AuthHandler: handler,
+	})
+}
+
+// WithEnsureAuthedHandler returns a ServerOptions which adds custom logic for
+// the ensuring of authentication on each incoming request.
+func WithEnsureAuthedHander(eah func(ctx context.Context) (context.Context, error)) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) error {
+		o.ensureAuthedHandler = eah
+		return nil
 	})
 }
 

--- a/rpc/server_options.go
+++ b/rpc/server_options.go
@@ -364,7 +364,7 @@ func WithAuthHandler(forType CredentialsType, handler AuthHandler) ServerOption 
 
 // WithEnsureAuthedHandler returns a ServerOptions which adds custom logic for
 // the ensuring of authentication on each incoming request.
-func WithEnsureAuthedHander(eah func(ctx context.Context) (context.Context, error)) ServerOption {
+func WithEnsureAuthedHandler(eah func(ctx context.Context) (context.Context, error)) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) error {
 		o.ensureAuthedHandler = eah
 		return nil


### PR DESCRIPTION
RSDK-7010

Adds a unary client interceptor to clear the `accessToken` set on `perRPCJWTCredentials` in the event of an error containing the substring `"Unauthenticated"`. Clearing the `accessToken` causes an attempt to reauthenticate on the next RPC request. Adds a test for this behavior.