### PR TITLE
APP-3746: Redirect to login when no auth cookie present

### DIFF
--- a/web/auth0.go
+++ b/web/auth0.go
@@ -238,7 +238,8 @@ func (h *callbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	stateCookie, err := r.Cookie(h.redirectStateCookieName)
-	if HandleError(w, err, h.logger, "getting redirect cookie") {
+	if err != nil {
+		http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
 		return
 	}
 


### PR DESCRIPTION
When there is no cookie present, redirect back to login. The application should then request authentication flow again. In most cases the user will already be logged in and see nothing. This just add another redirect. In other cases the user will need to login again if the auth provider cannot validate the state and cookies.