### PR TITLE
move workflows to hosted

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   buf-push:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [x64]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     steps:
@@ -27,7 +27,7 @@ jobs:
   dispatch:
     needs: buf-push
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [x64]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     strategy:

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   buf-push:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [x64, qemu-host]
+    runs-on: [x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     steps:
@@ -27,7 +27,7 @@ jobs:
   dispatch:
     needs: buf-push
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [x64, qemu-host]
+    runs-on: [x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
     strategy:

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
-    runs-on: [x64]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
       options: --platform linux/amd64

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
-    runs-on: [x64, qemu-host]
+    runs-on: [x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
       options: --platform linux/amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: [x64, qemu-host]
+    runs-on: [x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
       options: --platform linux/amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: [x64]
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
       options: --platform linux/amd64


### PR DESCRIPTION
## What changed
- remove four `qemu-host` tags across 3 workflows
## Why
- these jobs don't require emulation