### PR TITLE
RSDK-7244: Expose data channel so TS SDK can listen for disconnect

### DIFF
--- a/rpc/examples/echo/frontend/package-lock.json
+++ b/rpc/examples/echo/frontend/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../../../js": {
       "name": "@viamrobotics/rpc",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package-lock.json
+++ b/rpc/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/rpc",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/package.json
+++ b/rpc/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/rpc",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "Apache-2.0",
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.13.0",

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -265,6 +265,7 @@ class authenticatedTransport implements grpc.Transport {
 export interface WebRTCConnection {
   transportFactory: grpc.TransportFactory;
   peerConnection: RTCPeerConnection;
+  dataChannel: RTCDataChannel;
 }
 
 async function getOptionalWebRTCConfig(
@@ -319,6 +320,8 @@ async function getOptionalWebRTCConfig(
 // PeerConnection itself. Care should be taken with the PeerConnection and is currently returned for experimental
 // use.
 // TODO(GOUT-7): figure out decent way to handle reconnect on connection termination
+// eslint-disable-next-line sonarjs/cognitive-complexity
+// eslint-disable-next-line func-style
 export async function dialWebRTC(
   signalingAddress: string,
   host: string,
@@ -637,7 +640,7 @@ export async function dialWebRTC(
     }
 
     successful = true;
-    return { transportFactory: cc.transportFactory(), peerConnection: pc };
+    return { transportFactory: cc.transportFactory(), peerConnection: pc, dataChannel: dc };
   } finally {
     if (!successful) {
       pc.close();

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -640,7 +640,11 @@ export async function dialWebRTC(
     }
 
     successful = true;
-    return { transportFactory: cc.transportFactory(), peerConnection: pc, dataChannel: dc };
+    return {
+      transportFactory: cc.transportFactory(),
+      peerConnection: pc,
+      dataChannel: dc,
+    };
   } finally {
     if (!successful) {
       pc.close();


### PR DESCRIPTION
RSDK-7244 describes how the TS SDK does not attempt reconnect when a disconnect occurs.

The TS SDK attempts to reconnect to the peer in a [backoff loop](https://github.com/viamrobotics/viam-typescript-sdk/blob/f49f6857de9277f72f1e4894b985ea976ae51ea0/src/robot/client.ts#L186). This happens whenever a [disconnect event](https://github.com/viamrobotics/viam-typescript-sdk/blob/f49f6857de9277f72f1e4894b985ea976ae51ea0/src/robot/client.ts#L177) occurs.

The TS SDK currently listens to `iceconnectionstatechange` `close` events on the `RTCPeerConnection` to [emit the disconnect](https://github.com/viamrobotics/viam-typescript-sdk/blob/f49f6857de9277f72f1e4894b985ea976ae51ea0/src/robot/client.ts#L469-L483) necessary to start the reconnection. These events are never being emitted, as confirmed with browser WebRTC logging. `connectionstatechange` events are not emitted either.

Instead, we must listen to the `RTCDataChannel` `close` events which is actually what goutils [already does](https://github.com/viamrobotics/goutils/blob/612b3f81b6b71c94b89805e63390b6ec5336d8ca/rpc/js/src/ClientChannel.ts#L38) to know when to close the `RTCPeerConnection`.

https://github.com/viamrobotics/goutils/pull/287: **this PR** exposes the `RTCDataChannel`
https://github.com/viamrobotics/viam-typescript-sdk/pull/291: listens to `close` events on the `RTCDataChannel`