### PR TITLE
RSDK-7691: Exempt `DataChannel.readLoop` from leak detection.

### DIFF
--- a/leak.go
+++ b/leak.go
@@ -11,6 +11,7 @@ func FindGoroutineLeaks(options ...goleak.Option) error {
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
 		goleak.IgnoreTopFunction("github.com/desertbit/timer.timerRoutine"),              // gRPC uses this
 		goleak.IgnoreTopFunction("github.com/letsencrypt/pebble/va.VAImpl.processTasks"), // no way to stop it,
+		goleak.IgnoreTopFunction("github.com/pion/webrtc/v3.(*DataChannel).readLoop"),    // RSDK-7514, RSDK-7691
 	)
 	return goleak.Find(optsCopy...)
 }


### PR DESCRIPTION
Once this is in and tagged I'll create an RDK PR that:
* Bumps goutils
* Removes the wait on the "on close" channel from module/shared conn closing.

cc @benjirewis for visibility
