### PR TITLE
RSDK-7678 - Server streaming does not obey context cancels over WebRTC

### DIFF
--- a/rpc/wrtc_client_channel_test.go
+++ b/rpc/wrtc_client_channel_test.go
@@ -606,7 +606,6 @@ func TestClientStreamCancel(t *testing.T) {
 	// 2. After the initial request, the client closes its send side of the stream (replicating what happens in a server-side streaming scenario).
 	// 2. 3 messages are sent from the server. After the 3rd message, the client stream is cancelled.
 	// 3. The server should receive a RST_STREAM message and cancel the server context.
-
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
@@ -630,15 +629,15 @@ func TestClientStreamCancel(t *testing.T) {
 					pongStatus, _ := status.FromError(errors.New("pong"))
 
 					for i := 0; i < 10; i++ {
-						// Using channels is not enough ensure that the client reset
-						// went through in time.
-						// Sleep here to let client process messages and send reset.
-						time.Sleep(10 * time.Millisecond)
-
 						if stream.Context().Err() != nil {
 							return nil
 						}
 						stream.SendMsg(pongStatus.Proto())
+
+						// Using channels is not enough ensure that the client reset
+						// went through in time.
+						// Sleep here to let client process messages and send reset.
+						time.Sleep(10 * time.Millisecond)
 					}
 					// Failure as this means the context was never cancelled.
 					t.Fail()

--- a/rpc/wrtc_client_channel_test.go
+++ b/rpc/wrtc_client_channel_test.go
@@ -603,9 +603,10 @@ func TestWebRTCClientChannelCanStopStreamRecvMsg(t *testing.T) {
 func TestClientStreamCancel(t *testing.T) {
 	// Tests that clients can cancel server streams over WebRTC.
 	// 1. We set up a server with a stream endpoint and call it with a client.
-	// 2. After the initial request, the client closes its send side of the stream (replicating what happens in a server-side streaming scenario).
-	// 2. 3 messages are sent from the server. After the 3rd message, the client stream is cancelled.
-	// 3. The server should receive a RST_STREAM message and cancel the server context.
+	// 2. After the initial request, the client closes its send side of the stream
+	//    (replicating what happens in a server-side streaming scenario).
+	// 3. 3 messages are sent from the server. After the 3rd message, the client stream is cancelled.
+	// 4. The server should receive a RST_STREAM message and cancel the server context.
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
@@ -630,7 +631,7 @@ func TestClientStreamCancel(t *testing.T) {
 
 					for i := 0; i < 10; i++ {
 						if stream.Context().Err() != nil {
-							return nil
+							return stream.Context().Err()
 						}
 						stream.SendMsg(pongStatus.Proto())
 

--- a/rpc/wrtc_client_stream.go
+++ b/rpc/wrtc_client_stream.go
@@ -31,7 +31,10 @@ type webrtcClientStream struct {
 	userCtx          context.Context
 	headersReceived  chan struct{}
 	trailersReceived bool
-	sendClosed       bool
+
+	// sendClose represents whether the send direction of the stream is closed. However,
+	// control flow signals such as RST_STREAM will still be sent.
+	sendClosed bool
 }
 
 // newWebRTCClientStream creates a gRPC stream from the given client channel with a

--- a/rpc/wrtc_client_stream.go
+++ b/rpc/wrtc_client_stream.go
@@ -144,16 +144,12 @@ func checkWriteErrForStreamClose(err error) error {
 	return err
 }
 
-// resetStream cancels the stream and sends a reset signal.
+// resetStream cancels the stream and should always send a reset signal.
 // It is also not safe to call concurrently with SendMsg.
 func (s *webrtcClientStream) resetStream() (err error) {
 	s.webrtcBaseStream.mu.Lock()
 	defer s.webrtcBaseStream.mu.Unlock()
 
-	if s.sendClosed {
-		// no need to reset an already closed stream
-		return nil
-	}
 	s.sendClosed = true
 
 	defer func() {


### PR DESCRIPTION
actual code change is tiny - risk should be low as well since reset stream is only ever called when context is cancelled and in that case, the request should be cancelled anyway