### PR TITLE
RSDK-7280 Report more ICE timings

### DIFF
--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -38,6 +38,7 @@ func newBaseChannel(
 	peerConn *webrtc.PeerConnection,
 	dataChannel *webrtc.DataChannel,
 	onPeerDone func(),
+	onICEConnected func(),
 	logger golog.Logger,
 ) *webrtcBaseChannel {
 	ctx, cancel := context.WithCancel(ctx)
@@ -108,8 +109,13 @@ func newBaseChannel(
 					"conn_state", connectionState.String(),
 				)
 				doPeerDone()
+			case webrtc.ICEConnectionStateConnected:
+				if onICEConnected != nil {
+					onICEConnected()
+				}
+				fallthrough
 			case webrtc.ICEConnectionStateChecking, webrtc.ICEConnectionStateCompleted,
-				webrtc.ICEConnectionStateConnected, webrtc.ICEConnectionStateNew:
+				webrtc.ICEConnectionStateNew:
 				fallthrough
 			default:
 				candPair, hasCandPair := webrtcPeerConnCandPair(peerConn)

--- a/rpc/wrtc_base_channel_test.go
+++ b/rpc/wrtc_base_channel_test.go
@@ -44,8 +44,8 @@ func setupWebRTCBaseChannels(t *testing.T) (
 
 	peer1Done := make(chan struct{})
 	peer2Done := make(chan struct{})
-	bc1 := newBaseChannel(context.Background(), pc1, dc1, func() { close(peer1Done) }, logger)
-	bc2 := newBaseChannel(context.Background(), pc2, dc2, func() { close(peer2Done) }, logger)
+	bc1 := newBaseChannel(context.Background(), pc1, dc1, func() { close(peer1Done) }, nil, logger)
+	bc2 := newBaseChannel(context.Background(), pc2, dc2, func() { close(peer2Done) }, nil, logger)
 
 	<-bc1.Ready()
 	<-bc2.Ready()

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -162,9 +162,8 @@ func dialWebRTC(
 	)
 	onICEConnected := func() {
 		// Delay by up to 5s to allow more caller updates/better stats.
-		timer := time.NewTimer(5 * time.Second)
 		select {
-		case <-timer.C:
+		case <-time.After(5 * time.Second):
 		case <-ctx.Done():
 		}
 

--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -49,6 +49,7 @@ type activeWebRTCClientStream struct {
 func newWebRTCClientChannel(
 	peerConn *webrtc.PeerConnection,
 	dataChannel *webrtc.DataChannel,
+	onICEConnected func(),
 	logger golog.Logger,
 	unaryInterceptor grpc.UnaryClientInterceptor,
 	streamInterceptor grpc.StreamClientInterceptor,
@@ -58,6 +59,7 @@ func newWebRTCClientChannel(
 		peerConn,
 		dataChannel,
 		nil,
+		onICEConnected,
 		logger,
 	)
 	ch := &webrtcClientChannel{

--- a/rpc/wrtc_client_channel_test.go
+++ b/rpc/wrtc_client_channel_test.go
@@ -28,11 +28,11 @@ func TestWebRTCClientChannel(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
 
-	clientCh := newWebRTCClientChannel(pc1, dc1, logger, nil, nil)
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, nil, nil)
 	defer func() {
 		test.That(t, clientCh.Close(), test.ShouldBeNil)
 	}()
-	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, logger)
+	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, nil, logger)
 	defer func() {
 		test.That(t, serverCh.Close(), test.ShouldBeNil)
 	}()
@@ -339,11 +339,11 @@ func TestWebRTCClientChannelResetStream(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
 
-	clientCh := newWebRTCClientChannel(pc1, dc1, logger, nil, nil)
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, nil, nil)
 	defer func() {
 		test.That(t, clientCh.Close(), test.ShouldBeNil)
 	}()
-	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, logger)
+	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, nil, logger)
 	defer func() {
 		test.That(t, serverCh.Close(), test.ShouldBeNil)
 	}()
@@ -463,11 +463,11 @@ func TestWebRTCClientChannelWithInterceptor(t *testing.T) {
 		return streamer(ctx, desc, cc, method, opts...)
 	}
 
-	clientCh := newWebRTCClientChannel(pc1, dc1, logger, unaryInterceptor, streamInterceptor)
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, unaryInterceptor, streamInterceptor)
 	defer func() {
 		test.That(t, clientCh.Close(), test.ShouldBeNil)
 	}()
-	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, logger)
+	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, nil, logger)
 	defer func() {
 		test.That(t, serverCh.Close(), test.ShouldBeNil)
 	}()
@@ -546,11 +546,11 @@ func TestWebRTCClientChannelCanStopStreamRecvMsg(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
 
-	clientCh := newWebRTCClientChannel(pc1, dc1, logger, nil, nil)
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, nil, nil)
 	defer func() {
 		test.That(t, clientCh.Close(), test.ShouldBeNil)
 	}()
-	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, logger)
+	serverCh := newBaseChannel(context.Background(), pc2, dc2, nil, nil, logger)
 	defer func() {
 		test.That(t, serverCh.Close(), test.ShouldBeNil)
 	}()
@@ -611,7 +611,7 @@ func TestClientStreamCancel(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
 
-	clientCh := newWebRTCClientChannel(pc1, dc1, logger, nil, nil)
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, nil, nil)
 	defer func() {
 		test.That(t, clientCh.Close(), test.ShouldBeNil)
 	}()

--- a/rpc/wrtc_server_channel.go
+++ b/rpc/wrtc_server_channel.go
@@ -41,6 +41,7 @@ func newWebRTCServerChannel(
 		peerConn,
 		dataChannel,
 		func() { server.removePeer(peerConn) },
+		nil,
 		logger,
 	)
 	ch := &webrtcServerChannel{

--- a/rpc/wrtc_server_channel_test.go
+++ b/rpc/wrtc_server_channel_test.go
@@ -23,7 +23,7 @@ func TestWebRTCServerChannel(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
 
-	clientCh := newWebRTCClientChannel(pc1, dc1, logger, nil, nil)
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, nil, nil)
 	defer func() {
 		test.That(t, clientCh.Close(), test.ShouldBeNil)
 	}()
@@ -255,7 +255,7 @@ func TestWebRTCServerChannelResetStream(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
 
-	clientCh := newWebRTCClientChannel(pc1, dc1, logger, nil, nil)
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, nil, nil)
 	defer func() {
 		test.That(t, clientCh.Close(), test.ShouldBeNil)
 	}()


### PR DESCRIPTION
RSDK-7280

Logs:
- When/which local ICE candidates are gathered
- When/which remote ICE candidates are received
- How long from start of `dialWebRTC` to ICE connection state of connected
     - Number of caller updates in that time
     - Average duration of caller updates in that time
     - Max duration of caller updates in that time