### PR TITLE
RSDK-6659: wait on running goroutines before concluding test

### DIFF
--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -190,8 +190,6 @@ func TestWebRTCAnswererImmediateStop(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	ch := make(chan struct{})
-
 	go func() {
 		defer wg.Done()
 		answerer.Start()
@@ -200,14 +198,5 @@ func TestWebRTCAnswererImmediateStop(t *testing.T) {
 		defer wg.Done()
 		answerer.Stop()
 	}()
-	go func() {
-		defer close(ch)
-		wg.Wait()
-	}()
-
-	select {
-	case <-ch:
-	case <-time.After(time.Second * 30):
-		t.Fatalf("timeout: found hanging goroutines")
-	}
+	wg.Wait()
 }


### PR DESCRIPTION
Description:
We had observed a datarace in the test `TestWebRTCAnswererImmediateStop` that resulted in an attempt to write logs after completion of the test. To fix this, we wait on the running goroutines to complete before closing the test. 