### PR TITLE
RSDK-7935 - Fix header datarace

### DIFF
--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -392,6 +392,7 @@ func (s *webrtcServerStream) closeWithSendError(err error) (writeErr error) {
 }
 
 func (s *webrtcServerStream) writeHeaders() error {
+	// Grab the RLock to prevent headers from being set while written.
 	s.mu.RLock()
 	if !s.headersWritten.CompareAndSwap(false, true) {
 		s.mu.RUnlock()

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -392,12 +392,11 @@ func (s *webrtcServerStream) closeWithSendError(err error) (writeErr error) {
 }
 
 func (s *webrtcServerStream) writeHeaders() error {
-	// Grab the RLock to prevent headers from being set while written.
-	s.mu.RLock()
 	if !s.headersWritten.CompareAndSwap(false, true) {
-		s.mu.RUnlock()
 		return nil
 	}
+	// Grab the RLock to prevent headers from being set while written.
+	s.mu.RLock()
 	protoHeaders := metadataToProto(s.header)
 	s.mu.RUnlock()
 	return s.ch.writeHeaders(s.stream, &webrtcpb.ResponseHeaders{

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -392,10 +392,13 @@ func (s *webrtcServerStream) closeWithSendError(err error) (writeErr error) {
 }
 
 func (s *webrtcServerStream) writeHeaders() error {
+	s.mu.RLock()
 	if !s.headersWritten.CompareAndSwap(false, true) {
+		s.mu.RUnlock()
 		return nil
 	}
 	protoHeaders := metadataToProto(s.header)
+	s.mu.RUnlock()
 	return s.ch.writeHeaders(s.stream, &webrtcpb.ResponseHeaders{
 		Metadata: protoHeaders,
 	})

--- a/rpc/wrtc_server_stream_test.go
+++ b/rpc/wrtc_server_stream_test.go
@@ -1,0 +1,51 @@
+package rpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/test"
+	"google.golang.org/grpc/metadata"
+
+	"go.viam.com/utils/testutils"
+)
+
+func TestWebRTCServerStreamHeaderRace(t *testing.T) {
+	testutils.SkipUnlessInternet(t)
+	logger := golog.NewTestLogger(t)
+	pc1, pc2, dc1, dc2 := setupWebRTCPeers(t)
+
+	// clientCh is not used directly in the test but the test will leak goroutines if not used.
+	clientCh := newWebRTCClientChannel(pc1, dc1, nil, logger, nil, nil)
+	defer func() {
+		test.That(t, clientCh.Close(), test.ShouldBeNil)
+	}()
+
+	server := newWebRTCServer(logger)
+
+	serverCh := newWebRTCServerChannel(server, pc2, dc2, []string{"one", "two"}, logger)
+	defer func() {
+		test.That(t, serverCh.Close(), test.ShouldBeNil)
+	}()
+
+	<-clientCh.Ready()
+	<-serverCh.Ready()
+
+	stream := newWebRTCServerStream(context.Background(), nil, "", serverCh, nil, nil, logger)
+	defer stream.CloseRecv()
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		stream.SendHeader(metadata.New(map[string]string{"abc": "def"}))
+	}()
+	go func() {
+		defer wg.Done()
+		stream.SetHeader(metadata.New(map[string]string{"hello": "world"}))
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
if we call SetHeader and SendHeader at the same time, there's a chance at a datarace. Adding the RLock removes that possibility. The grpc-go impl has specific [locks](https://github.com/grpc/grpc-go/blob/f199062ef31ddda54152e1ca5e3d15fb63903dc3/internal/transport/transport.go#L469) for the header, but not sure if it's necessary. The main call into writeHeader already holds the RLock anyway (https://github.com/viamrobotics/goutils/blob/59474fccb894a0593029792c977ffb9bd173a4aa/rpc/wrtc_server_stream.go#L169).

Able to reproduce with a test that ran SetHeader and SendHeader side-by-side, and confirms that the race went away with this fix. Did not add that test into this PR because it's flaky