### PR TITLE
RSDK-7936 - grpc: set keepalive to handle network interface changes

### DIFF
--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/edaniels/golog"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -21,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -241,6 +243,10 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 	dialOpts := []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                15 * time.Second, // a little extra buffer to try to avoid ENHANCE_YOUR_CALM
+			PermitWithoutStream: true,
+		}),
 	}
 	if dOpts.insecure {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))


### PR DESCRIPTION
So on macOS, changing network interfaces does not appear to be an issue, but it is on Linux. As James pointed out, when you switch, it can take a very long time to have the gRPC connection start using the new network interface. This issue is further compounded by the cached gRPC dialer that rdk uses for app.viam.com based connections. Adding a keep alive solves the issue (by default it's not used) since once the keep alive is sent and enough are not ACKd, the http2 client transport is closed, the internal client load balancer sees this, and makes a new connection using a suitable interface that has a valid gateway.