### PR TITLE
RSDK-8215 - Decrease amount of GOAWAY errors

### DIFF
--- a/rpc/const.go
+++ b/rpc/const.go
@@ -1,4 +1,11 @@
 package rpc
 
-// MaxMessageSize is the maximum size a gRPC message can be.
-var MaxMessageSize = 1 << 25
+import "time"
+
+var (
+	// MaxMessageSize is the maximum size a gRPC message can be.
+	MaxMessageSize = 1 << 25
+
+	// keepAliveTime is how often to establish Keepalive pings/expectations.
+	keepAliveTime = 10 * time.Second
+)

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -8,7 +8,6 @@ import (
 	"hash/fnv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/edaniels/golog"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -244,7 +243,7 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 		grpc.WithBlock(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxMessageSize)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                15 * time.Second, // a little extra buffer to try to avoid ENHANCE_YOUR_CALM
+			Time:                keepAliveTime * 2, // a little extra buffer to try to avoid ENHANCE_YOUR_CALM
 			PermitWithoutStream: true,
 		}),
 	}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
@@ -179,7 +180,12 @@ func NewServer(logger golog.Logger, opts ...ServerOption) (Server, error) {
 		return nil, err
 	}
 
-	var serverOpts []grpc.ServerOption
+	serverOpts := []grpc.ServerOption{
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             keepAliveTime / 2, // a little extra buffer to try to avoid ENHANCE_YOUR_CALM
+			PermitWithoutStream: true,
+		}),
+	}
 
 	var firstSeenTLSCert *tls.Certificate
 	if sOpts.tlsConfig != nil {


### PR DESCRIPTION
Adding the server side params eliminates the GOAWAY errors coming from the internal signaling server (tested by running a local config in RDK for 20 mins), TBD as to whether it'll stop errors coming from cloud connections (so far, I've seen reduced rates, but usually some pop up after 8 mins). There's a possibility that after pushing this change to app, this log will go away as well, but possible that app load balancer may continue to issue these errors.

We could also look into filtering that specific log out, since there's no real issue as far as we can tell