### PR TITLE
RSDK-7647 - fallback to empty webrtc config when method is unimplemented

### DIFF
--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -301,9 +301,9 @@ async function getOptionalWebRTCConfig(
           return;
         }
         pResolve(result);
-      // In some cases the `OptionalWebRTCConfig` method seems to be unimplemented, even
-      // when building `viam-server` from latest. Falling back to a default config seems
-      // harmless in these cases, and allows connection to continue.
+        // In some cases the `OptionalWebRTCConfig` method seems to be unimplemented, even
+        // when building `viam-server` from latest. Falling back to a default config seems
+        // harmless in these cases, and allows connection to continue.
       } else if (status === grpc.Code.Unimplemented) {
         pResolve(new WebRTCConfig());
         return;

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -301,6 +301,9 @@ async function getOptionalWebRTCConfig(
           return;
         }
         pResolve(result);
+      // In some cases the `OptionalWebRTCConfig` method seems to be unimplemented, even
+      // when building `viam-server` from latest. Falling back to a default config seems
+      // harmless in these cases, and allows connection to continue.
       } else if (status === grpc.Code.Unimplemented) {
         pResolve(new WebRTCConfig());
         return;

--- a/rpc/js/src/dial.ts
+++ b/rpc/js/src/dial.ts
@@ -301,6 +301,9 @@ async function getOptionalWebRTCConfig(
           return;
         }
         pResolve(result);
+      } else if (status === grpc.Code.Unimplemented) {
+        pResolve(new WebRTCConfig());
+        return;
       } else {
         pReject(statusMessage);
       }


### PR DESCRIPTION
There is a bizarre little issue where `viam-server`, even on latest, is giving `Unimplemented` errors when calling `OptionalWebRTCConfig` in some typescript tests. I've spent a decent amount of time trying to decipher why and failing to do so; the problem only exists in typescript. However, defaulting to returning an empty config when an `Unimplemented` error is received allows tests to run as expected. 

Note that there is precedent for us doing this; currently an analogous piece of logic exists in `rust-utils`. 