### PR TITLE
RSDK-8320: Allow RDK Loggers to Call Sublogger()

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -47,6 +47,10 @@ type ZapCompatibleLogger interface {
 	Fatalw(msg string, keysAndValues ...interface{})
 }
 
+// Sublogger creates a sublogger from the given ZapCompatibleLogger instance.
+// This function uses reflection to dynamically create a sublogger from the provided logger by
+// calling its `Sublogger` method if it is an RDK logger, or its `Named` method if it is a Zap logger.
+// If neither method is available, it logs a debug message and returns the original logger.
 func Sublogger(inp ZapCompatibleLogger, subname string) ZapCompatibleLogger {
 	typ := reflect.TypeOf(inp)
 	sublogger, ok := typ.MethodByName("Sublogger")

--- a/logger.go
+++ b/logger.go
@@ -58,7 +58,6 @@ func Sublogger(inp ZapCompatibleLogger, subname string) (loggerRet ZapCompatible
 		if r := recover(); r != nil {
 			inp.Debugf("panic occurred while creating sublogger: %v, returning self", r)
 		}
-
 	}()
 
 	typ := reflect.TypeOf(inp)

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -25,80 +24,66 @@ func (m *InvalidLogger) With(args ...interface{}) *zap.SugaredLogger {
 }
 
 func (m *InvalidLogger) Debug(args ...interface{}) {
-	fmt.Println(args...)
 }
 
 func (m *InvalidLogger) Debugf(template string, args ...interface{}) {
-	fmt.Printf(template, args...)
 }
 
 func (m *InvalidLogger) Debugw(msg string, keysAndValues ...interface{}) {
-	fmt.Println(msg, keysAndValues)
 }
 
 func (m *InvalidLogger) Info(args ...interface{}) {
-	fmt.Println(args...)
 }
 
 func (m *InvalidLogger) Infof(template string, args ...interface{}) {
-	fmt.Printf(template, args...)
 }
 
 func (m *InvalidLogger) Infow(msg string, keysAndValues ...interface{}) {
-	fmt.Println(msg, keysAndValues)
 }
 
 func (m *InvalidLogger) Warn(args ...interface{}) {
-	fmt.Println(args...)
 }
 
 func (m *InvalidLogger) Warnf(template string, args ...interface{}) {
-	fmt.Printf(template, args...)
 }
 
 func (m *InvalidLogger) Warnw(msg string, keysAndValues ...interface{}) {
-	fmt.Println(msg, keysAndValues)
 }
 
 func (m *InvalidLogger) Error(args ...interface{}) {
-	fmt.Println(args...)
 }
 
 func (m *InvalidLogger) Errorf(template string, args ...interface{}) {
-	fmt.Printf(template, args...)
 }
 
 func (m *InvalidLogger) Errorw(msg string, keysAndValues ...interface{}) {
-	fmt.Println(msg, keysAndValues)
 }
 
 func (m *InvalidLogger) Fatal(args ...interface{}) {
-	fmt.Println(args...)
 }
 
 func (m *InvalidLogger) Fatalf(template string, args ...interface{}) {
-	fmt.Printf(template, args...)
 }
 
 func (m *InvalidLogger) Fatalw(msg string, keysAndValues ...interface{}) {
-	fmt.Println(msg, keysAndValues)
 }
 
-// InvalidLogger fulfills the ZapCompatibleLogger interface with a Sublogger() method to simulate
-// calling utils.Sublogger() on an RDK logger.
+// MockLogger fulfills the ZapCompatibleLogger interface by extending InvalidLogger with a Sublogger() method. This type
+// is used to simulate calling utils.Sublogger() on an RDK logger.
 type MockLogger struct {
 	InvalidLogger
 	name string
 }
 
 func (m *MockLogger) Sublogger(subname string) ZapCompatibleLogger {
-	return &InvalidLogger{name: m.name + "." + subname}
+	return &MockLogger{name: m.name + "." + subname}
 }
 
 func TestSubloggerWithZapLogger(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	sublogger := Sublogger(logger, "sub")
 	test.That(t, sublogger, test.ShouldNotBeNil)
+	test.That(t, sublogger, test.ShouldNotEqual, logger)
 	test.That(t, reflect.TypeOf(sublogger), test.ShouldEqual, reflect.TypeOf(logger))
 }
 
@@ -106,12 +91,13 @@ func TestSubloggerWithMockRDKLogger(t *testing.T) {
 	logger := &MockLogger{name: "main"}
 	sublogger := Sublogger(logger, "sub")
 	test.That(t, sublogger, test.ShouldNotBeNil)
+	test.That(t, sublogger, test.ShouldNotEqual, logger)
 	test.That(t, reflect.TypeOf(sublogger), test.ShouldEqual, reflect.TypeOf(logger))
 }
 
 func TestSubloggerWithInvalidLogger(t *testing.T) {
 	logger := &InvalidLogger{name: "main"}
 	sublogger := Sublogger(logger, "sub")
-	// Sublogger returns logger (itself) if creating a sublogger fails
+	// Sublogger returns logger (itself) if creating a sublogger fails, which we expect
 	test.That(t, sublogger, test.ShouldEqual, logger)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.uber.org/zap"
+	"go.viam.com/test"
+)
+
+// InvalidLogger fulfills the ZapCompatibleLogger interface without a Named() or Sublogger() method, used to test
+// that utils.Sublogger() should fail without either of these methods.
+type InvalidLogger struct {
+	name string
+}
+
+func (m *InvalidLogger) Desugar() *zap.Logger {
+	return zap.NewNop()
+}
+
+func (m *InvalidLogger) With(args ...interface{}) *zap.SugaredLogger {
+	return zap.NewNop().Sugar()
+}
+
+func (m *InvalidLogger) Debug(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func (m *InvalidLogger) Debugf(template string, args ...interface{}) {
+	fmt.Printf(template, args...)
+}
+
+func (m *InvalidLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	fmt.Println(msg, keysAndValues)
+}
+
+func (m *InvalidLogger) Info(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func (m *InvalidLogger) Infof(template string, args ...interface{}) {
+	fmt.Printf(template, args...)
+}
+
+func (m *InvalidLogger) Infow(msg string, keysAndValues ...interface{}) {
+	fmt.Println(msg, keysAndValues)
+}
+
+func (m *InvalidLogger) Warn(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func (m *InvalidLogger) Warnf(template string, args ...interface{}) {
+	fmt.Printf(template, args...)
+}
+
+func (m *InvalidLogger) Warnw(msg string, keysAndValues ...interface{}) {
+	fmt.Println(msg, keysAndValues)
+}
+
+func (m *InvalidLogger) Error(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func (m *InvalidLogger) Errorf(template string, args ...interface{}) {
+	fmt.Printf(template, args...)
+}
+
+func (m *InvalidLogger) Errorw(msg string, keysAndValues ...interface{}) {
+	fmt.Println(msg, keysAndValues)
+}
+
+func (m *InvalidLogger) Fatal(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func (m *InvalidLogger) Fatalf(template string, args ...interface{}) {
+	fmt.Printf(template, args...)
+}
+
+func (m *InvalidLogger) Fatalw(msg string, keysAndValues ...interface{}) {
+	fmt.Println(msg, keysAndValues)
+}
+
+// InvalidLogger fulfills the ZapCompatibleLogger interface with a Sublogger() method to simulate
+// calling utils.Sublogger() on an RDK logger.
+type MockLogger struct {
+	InvalidLogger
+	name string
+}
+
+func (m *MockLogger) Sublogger(subname string) ZapCompatibleLogger {
+	return &InvalidLogger{name: m.name + "." + subname}
+}
+
+func TestSubloggerWithZapLogger(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	sublogger := Sublogger(logger, "sub")
+	test.That(t, sublogger, test.ShouldNotBeNil)
+	test.That(t, reflect.TypeOf(sublogger), test.ShouldEqual, reflect.TypeOf(logger))
+}
+
+func TestSubloggerWithMockRDKLogger(t *testing.T) {
+	logger := &MockLogger{name: "main"}
+	sublogger := Sublogger(logger, "sub")
+	test.That(t, sublogger, test.ShouldNotBeNil)
+	test.That(t, reflect.TypeOf(sublogger), test.ShouldEqual, reflect.TypeOf(logger))
+}
+
+func TestSubloggerWithInvalidLogger(t *testing.T) {
+	logger := &InvalidLogger{name: "main"}
+	sublogger := Sublogger(logger, "sub")
+	// Sublogger returns logger (itself) if creating a sublogger fails
+	test.That(t, sublogger, test.ShouldEqual, logger)
+}

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -39,7 +39,7 @@ type ManagedProcess interface {
 
 // NewManagedProcess returns a new, unstarted, from the given configuration.
 func NewManagedProcess(config ProcessConfig, logger utils.ZapCompatibleLogger) ManagedProcess {
-	logger = logger.Named(fmt.Sprintf("process.%s_%s", config.ID, config.Name))
+	logger = utils.Sublogger(logger, fmt.Sprintf("process.%s_%s", config.ID, config.Name))
 
 	if config.StopSignal == 0 {
 		config.StopSignal = syscall.SIGTERM
@@ -257,7 +257,7 @@ func (p *managedProcess) manage(stdOut, stdErr io.ReadCloser) {
 	var activeLoggers sync.WaitGroup
 	if p.shouldLog || p.logWriter != nil {
 		logPipe := func(name string, pipe io.ReadCloser, isErr bool) {
-			logger := p.logger.Named(name)
+			logger := utils.Sublogger(p.logger, name)
 			defer activeLoggers.Done()
 			pipeR := bufio.NewReader(pipe)
 			logWriterError := false

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -607,7 +607,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 				server.webrtcServer,
 				sOpts.webrtcOpts.ExternalSignalingDialOpts,
 				config,
-				logger.Named("external_signaler"),
+				utils.Sublogger(logger, "external_signaler"),
 				true, // logStats == true
 			))
 		} else {
@@ -651,7 +651,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 				server.webrtcServer,
 				answererDialOpts,
 				config,
-				logger.Named("internal_signaler"),
+				utils.Sublogger(logger, "internal_signaler"),
 				false, // logStats == false
 			))
 		}

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -104,7 +104,7 @@ func dialWebRTC(
 ) (ch *webrtcClientChannel, err error) {
 	dialStart := time.Now()
 
-	logger = logger.Named("webrtc")
+	logger = utils.Sublogger(logger, "webrtc")
 	dialCtx, timeoutCancel := context.WithTimeout(ctx, getDefaultOfferDeadline())
 	defer timeoutCancel()
 

--- a/rpc/wrtc_logger.go
+++ b/rpc/wrtc_logger.go
@@ -62,5 +62,5 @@ func (l webrtcLogger) Errorf(format string, args ...interface{}) {
 
 // NewLogger returns a new webrtc logger under the given scope.
 func (lf WebRTCLoggerFactory) NewLogger(scope string) logging.LeveledLogger {
-	return webrtcLogger{lf.Logger.Named(scope)}
+	return webrtcLogger{utils.Sublogger(lf.Logger, scope)}
 }


### PR DESCRIPTION
### Description
RSDK-8320: Allow RDK loggers to call sublogger when creating new loggers in goutils
* We are unable to maintain any pointers to loggers created by `Named()`. Now that RDK loggers can be passed into goutils without any conversion, we can create and register new loggers in `goutils` by calling `Sublogger()`.
* `goutils` still needs to be compatible with the Zap logging interface because of `app`. In order to allow RDK loggers to call `Sublogger()` a `utils.Sublogger()` function is added in this PR which uses reflection to either call `Sublogger()` if it is an RDK logger, or `Named()` if it is a Zap logger. 
* This way, when RDK loggers are passed into `goutils`, `Sublogger()` is called registering these new loggers. 
* Replaces all instances of `Named()` in `goutils` with `utils.Sublogger()`
* We still don't have the ability to control a few log lines owned by loggers called with `With()`, but it seems like a minimal surface. 
### Testing
* Ran app + RDK and respective test suite against these changes to ensure nothing breaks.
* Print logger registry to confirm these loggers are being registered. 