### PR TITLE
RSDK-8288: Make caller and answerer less sensitive to errors from signaling server

### DIFF
--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -362,7 +362,7 @@ func dialWebRTC(
 	utils.PanicCapturingGoWithCallback(func() {
 		if err := exchangeCandidates(); err != nil {
 			if haveInit && filterEOF(err, logger) == nil {
-				logger.Warnf("caller swallowed err: %v while exchanging ICE candidates", err)
+				logger.Warn("caller swallowed EOF err while exchanging ICE candidates")
 			} else {
 				sendErr(err)
 			}

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -181,7 +181,7 @@ func dialWebRTC(
 	exchangeCtx, exchangeCancel := context.WithCancel(signalCtx)
 	defer exchangeCancel()
 
-	// atomic bool representing whether initial sdp exchange has occured
+	// atomic bool representing whether initial sdp exchange has occurred
 	var haveInit atomic.Bool
 	haveInit.Store(false)
 

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -181,7 +181,7 @@ func dialWebRTC(
 	exchangeCtx, exchangeCancel := context.WithCancel(signalCtx)
 	defer exchangeCancel()
 
-	// atomic "bool" representing whether initial sdp exchange has occured
+	// atomic bool representing whether initial sdp exchange has occured
 	var haveInit atomic.Bool
 	haveInit.Store(false)
 

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -180,7 +180,7 @@ func dialWebRTC(
 	exchangeCtx, exchangeCancel := context.WithCancel(signalCtx)
 	defer exchangeCancel()
 
-	// atomic bool representing whether initial sdp exchange has occurred
+	// bool representing whether initial sdp exchange has occurred
 	haveInit := true
 
 	errCh := make(chan error)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -510,7 +510,7 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 			defer close(done)
 			if err := exchangeCandidates(); err != nil {
 				if filterEOF(err, ans.logger) == nil {
-					ans.logger.Warn("caller swallowed EOF err while exchanging ICE candidates")
+					ans.logger.Warn("answerer swallowed EOF err while exchanging ICE candidates")
 				} else {
 					sendErr(err)
 				}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -513,7 +513,7 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 			defer close(done)
 			if err := exchangeCandidates(); err != nil {
 				if haveInit && filterEOF(err, ans.logger) == nil {
-					ans.logger.Warnf("caller swallowed err: %v while exchanging ICE candidates", err)
+					ans.logger.Warn("caller swallowed EOF err while exchanging ICE candidates")
 				} else {
 					sendErr(err)
 				}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -461,8 +461,6 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 
 	serverChannel := ans.server.NewChannel(pc, dc, ans.hosts)
 
-	haveInit := false
-
 	if !init.OptionalConfig.DisableTrickle {
 		exchangeCandidates := func() error {
 			for {
@@ -483,7 +481,6 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 
 				switch s := ansResp.Stage.(type) {
 				case *webrtcpb.AnswerRequest_Init:
-					haveInit = true
 				case *webrtcpb.AnswerRequest_Update:
 					if ansResp.Uuid != uuid {
 						return errors.Errorf("uuid mismatch; have=%q want=%q", ansResp.Uuid, uuid)
@@ -512,7 +509,7 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 		utils.PanicCapturingGoWithCallback(func() {
 			defer close(done)
 			if err := exchangeCandidates(); err != nil {
-				if haveInit && filterEOF(err, ans.logger) == nil {
+				if filterEOF(err, ans.logger) == nil {
 					ans.logger.Warn("caller swallowed EOF err while exchanging ICE candidates")
 				} else {
 					sendErr(err)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -338,6 +338,7 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 			ans.logger.Warnf("answerer swallowing err %v", err)
 			return
 		}
+		ans.logger.Warnf("caller received err %v of type %T", err, err)
 		select {
 		case <-exchangeCtx.Done():
 		case errCh <- err:

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -334,9 +334,13 @@ func (ans *webrtcSignalingAnswerer) answer(client webrtcpb.SignalingService_Answ
 	errCh := make(chan error)
 	defer exchangeCancel()
 	sendErr := func(err error) {
+		if isEOF(err) {
+			ans.logger.Warnf("answerer swallowing err %v", err)
+			return
+		}
 		select {
 		case <-exchangeCtx.Done():
-		case errCh <- filterEOF(err, ans.logger):
+		case errCh <- err:
 		}
 	}
 


### PR DESCRIPTION
### Description
RSDK-8288: Make caller and answerer less sensitive to errors from signaling server
* Signaling caller and answerer are made less sensitive to signaling server errors by swallowing either `io.EOF` errors or grpc errors of the type `code = Internal desc = unexpected EOF` and logging it. 
* This is necessary since after one of the answerer/caller calls `sendDone()` and severs its connection to the signaling server, it is possible that the other has not had the chance to "finish" and timing can cause it to get a EOF error from its connection to the signaling server, causing the peer connection to be unecessarily closed. 