### PR TITLE
RSDK-8287 - ManagedProcess fails on relative executable paths with a modified CWD

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -154,10 +154,6 @@ func (p *managedProcess) Start(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := exec.LookPath(p.name); err != nil {
-		return err
-	}
-
 	if p.oneShot {
 		// Here we use the context since we block on waiting for the command
 		// to finish running.

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -152,17 +152,10 @@ func TestManagedProcessStart(t *testing.T) {
 		})
 		t.Run("resolves relative path with different cwd", func(t *testing.T) {
 			logger := golog.NewTestLogger(t)
-			cwd := t.TempDir()
-			// change to this tempdir and create a new sub folder called newWD
-			err := os.Chdir(cwd)
-			test.That(t, err, test.ShouldBeNil)
-			newWD := "newWD"
-			err = os.Mkdir(filepath.Join(cwd, newWD), 0o700)
-			test.That(t, err, test.ShouldBeNil)
-
+			newWD := t.TempDir()
 			// create an executable file in there that we will refence as a just "./exec.sh"
 			executablePath := filepath.Join(newWD, "exec.sh")
-			err = os.WriteFile(executablePath, []byte("#!/bin/sh\necho hi\n"), 0o700)
+			err := os.WriteFile(executablePath, []byte("#!/bin/sh\necho hi\n"), 0o700)
 			test.That(t, err, test.ShouldBeNil)
 
 			logReader, logWriter := io.Pipe()


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-8287

See ticket for more information