### PR TITLE
RSDK-8377: Allow RDK to maintain track of Loggers that call With()

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -104,19 +104,19 @@ func LogWith(inp ZapCompatibleLogger, args ...interface{}) (loggerRet ZapCompati
 		// RDK WithFields() modifies the current logger (inp) rather than returing a new one
 		with.Func.Call(reflectArgs)
 		return inp
-	} else {
-		with, ok = typ.MethodByName("With")
-		if !ok {
-			inp.Debugf("could not add fields to logger of type %s, returning self", typ.String())
-			return inp
-		}
-		ret := with.Func.Call(reflectArgs)
-		loggerRet, ok = ret[0].Interface().(ZapCompatibleLogger)
-		if !ok {
-			inp.Debug("with func returned an unexpected type, returning self")
-			return inp
-		}
 
-		return loggerRet
+	with, ok = typ.MethodByName("With")
+	if !ok {
+		inp.Debugf("could not add fields to logger of type %s, returning self", typ.String())
+		return inp
 	}
+	ret := with.Func.Call(reflectArgs)
+	loggerRet, ok = ret[0].Interface().(ZapCompatibleLogger)
+	if !ok {
+		inp.Debug("with func returned an unexpected type, returning self")
+		return inp
+	}
+
+	return loggerRet
+	
 }

--- a/logger.go
+++ b/logger.go
@@ -79,7 +79,7 @@ func Sublogger(inp ZapCompatibleLogger, subname string) (loggerRet ZapCompatible
 	return loggerRet
 }
 
-// With adds fields for logging to a given ZapCompatibleLogger instance.
+// LogWith adds fields for logging to a given ZapCompatibleLogger instance.
 // This function uses reflection to dynamically add fields to the provided logger by
 // calling its `WithFields` method if it is an RDK logger, or its `With` method if it is a Zap logger.
 // If neither method is available, it logs a debug message and returns the original logger.

--- a/logger.go
+++ b/logger.go
@@ -104,6 +104,7 @@ func LogWith(inp ZapCompatibleLogger, args ...interface{}) (loggerRet ZapCompati
 		// RDK WithFields() modifies the current logger (inp) rather than returing a new one
 		with.Func.Call(reflectArgs)
 		return inp
+	}
 
 	with, ok = typ.MethodByName("With")
 	if !ok {
@@ -118,5 +119,4 @@ func LogWith(inp ZapCompatibleLogger, args ...interface{}) (loggerRet ZapCompati
 	}
 
 	return loggerRet
-	
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -105,7 +105,7 @@ func TestSubloggerWithInvalidLogger(t *testing.T) {
 
 func TestLogWithZapLogger(t *testing.T) {
 	logger := golog.NewTestLogger(t)
-	loggerWith := LogWith(logger, "key", "value")
+	loggerWith := AddFieldsToLogger(logger, "key", "value")
 	test.That(t, loggerWith, test.ShouldNotBeNil)
 	test.That(t, loggerWith, test.ShouldNotEqual, logger)
 	test.That(t, reflect.TypeOf(loggerWith), test.ShouldEqual, reflect.TypeOf(logger))
@@ -113,7 +113,7 @@ func TestLogWithZapLogger(t *testing.T) {
 
 func TestLogWithMockRDKLogger(t *testing.T) {
 	logger := &MockLogger{Name: "main"}
-	loggerWith := LogWith(logger, "key", "value")
+	loggerWith := AddFieldsToLogger(logger, "key", "value")
 	test.That(t, loggerWith, test.ShouldNotBeNil)
 	test.That(t, loggerWith, test.ShouldEqual, logger) // MockLogger modifies the logger in place
 	test.That(t, reflect.TypeOf(loggerWith), test.ShouldEqual, reflect.TypeOf(logger))
@@ -122,7 +122,7 @@ func TestLogWithMockRDKLogger(t *testing.T) {
 
 func TestLogWithInvalidLogger(t *testing.T) {
 	logger := &InvalidLogger{name: "main"}
-	loggerWith := LogWith(logger, "key", "value")
+	loggerWith := AddFieldsToLogger(logger, "key", "value")
 	// With returns logger (itself) if adding fields fails, which we expect
 	test.That(t, loggerWith, test.ShouldEqual, logger)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -118,7 +118,6 @@ func TestLogWithMockRDKLogger(t *testing.T) {
 	test.That(t, loggerWith, test.ShouldEqual, logger) // MockLogger modifies the logger in place
 	test.That(t, reflect.TypeOf(loggerWith), test.ShouldEqual, reflect.TypeOf(logger))
 	test.That(t, loggerWith.(*MockLogger).Name, test.ShouldEqual, "WithFields called")
-
 }
 
 func TestLogWithInvalidLogger(t *testing.T) {
@@ -126,5 +125,4 @@ func TestLogWithInvalidLogger(t *testing.T) {
 	loggerWith := LogWith(logger, "key", "value")
 	// With returns logger (itself) if adding fields fails, which we expect
 	test.That(t, loggerWith, test.ShouldEqual, logger)
-
 }

--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -47,7 +47,7 @@ func newBaseChannel(
 		ctx:         ctx,
 		cancel:      cancel,
 		ready:       make(chan struct{}),
-		logger:      logger.With("ch", dataChannel.ID()),
+		logger:      utils.LogWith(logger, "ch", dataChannel.ID()),
 	}
 	ch.bufferWriteCond = sync.NewCond(ch.bufferWriteMu.RLocker())
 	dataChannel.OnOpen(ch.onChannelOpen)

--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -47,7 +47,7 @@ func newBaseChannel(
 		ctx:         ctx,
 		cancel:      cancel,
 		ready:       make(chan struct{}),
-		logger:      utils.LogWith(logger, "ch", dataChannel.ID()),
+		logger:      utils.AddFieldsToLogger(logger, "ch", dataChannel.ID()),
 	}
 	ch.bufferWriteCond = sync.NewCond(ch.bufferWriteMu.RLocker())
 	dataChannel.OnOpen(ch.onChannelOpen)

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -204,7 +204,7 @@ func NewMongoDBWebRTCCallQueue(
 		operatorsColl: operatorsColl,
 		cancelCtx:     cancelCtx,
 		cancelFunc:    cancelFunc,
-		logger:        logger.With("operator_id", operatorID),
+		logger:        utils.LogWith(logger, "operator_id", operatorID),
 
 		csStateUpdates:        make(chan changeStreamStateUpdate),
 		callExchangeSubs:      map[string]map[*mongodbCallExchange]struct{}{},

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -204,7 +204,7 @@ func NewMongoDBWebRTCCallQueue(
 		operatorsColl: operatorsColl,
 		cancelCtx:     cancelCtx,
 		cancelFunc:    cancelFunc,
-		logger:        utils.LogWith(logger, "operator_id", operatorID),
+		logger:        utils.AddFieldsToLogger(logger, "operator_id", operatorID),
 
 		csStateUpdates:        make(chan changeStreamStateUpdate),
 		callExchangeSubs:      map[string]map[*mongodbCallExchange]struct{}{},

--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -271,7 +271,7 @@ func (ch *webrtcClientChannel) newStream(
 			ch,
 			stream,
 			ch.removeStreamByID,
-			utils.LogWith(ch.webrtcBaseChannel.logger, "id", id),
+			utils.AddFieldsToLogger(ch.webrtcBaseChannel.logger, "id", id),
 		)
 		activeStream = activeWebRTCClientStream{clientStream}
 		ch.streams[id] = activeStream

--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -271,7 +271,7 @@ func (ch *webrtcClientChannel) newStream(
 			ch,
 			stream,
 			ch.removeStreamByID,
-			ch.webrtcBaseChannel.logger.With("id", id),
+			utils.LogWith(ch.webrtcBaseChannel.logger, "id", id),
 		)
 		activeStream = activeWebRTCClientStream{clientStream}
 		ch.streams[id] = activeStream

--- a/rpc/wrtc_server_channel.go
+++ b/rpc/wrtc_server_channel.go
@@ -101,7 +101,7 @@ func (ch *webrtcServerChannel) onChannelMessage(msg webrtc.DataChannelMessage) {
 	}
 
 	id := stream.Id
-	logger := ch.webrtcBaseChannel.logger.With("id", id)
+	logger := utils.LogWith(ch.webrtcBaseChannel.logger, "id", id)
 
 	ch.mu.Lock()
 	serverStream, ok := ch.streams[id]

--- a/rpc/wrtc_server_channel.go
+++ b/rpc/wrtc_server_channel.go
@@ -101,7 +101,7 @@ func (ch *webrtcServerChannel) onChannelMessage(msg webrtc.DataChannelMessage) {
 	}
 
 	id := stream.Id
-	logger := utils.LogWith(ch.webrtcBaseChannel.logger, "id", id)
+	logger := utils.AddFieldsToLogger(ch.webrtcBaseChannel.logger, "id", id)
 
 	ch.mu.Lock()
 	serverStream, ok := ch.streams[id]

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -262,7 +262,7 @@ func isContextCanceled(err error) bool {
 }
 
 func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
-	s.logger = utils.LogWith(s.logger, "method", headers.Method)
+	s.logger = utils.AddFieldsToLogger(s.logger, "method", headers.Method)
 
 	handlerFunc, ok := s.ch.server.handler(headers.Method)
 	if !ok {

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -262,7 +262,7 @@ func isContextCanceled(err error) bool {
 }
 
 func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
-	s.logger = s.logger.With("method", headers.Method)
+	s.logger = utils.LogWith(s.logger, "method", headers.Method)
 
 	handlerFunc, ok := s.ch.server.handler(headers.Method)
 	if !ok {


### PR DESCRIPTION
### Description
RSDK-8377: Allow RDK to maintain track of Loggers that call With()
* Adds `LogWith()` util function that calls `With()` on `zap.SugaredLoggers` and `WithField()` on RDK loggers using reflection so that we do not lose track of RDK loggers that call `With()` in `goutils`.
* Change all instances of `With()` to `utils.LogWith()`
### Testing
* A few tests to ensure that the correct one of `With()` / `WithField()` is called depending on the type of logger. 