### PR TITLE
RSDK-8404: Add logging around incoming GRPC requests + Refactor AddFieldsToLogger function to account for new logger type

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -106,7 +106,6 @@ func AddFieldsToLogger(inp ZapCompatibleLogger, args ...interface{}) (loggerRet 
 			inp.Debugf("could not add fields to logger of type %s, returning self", typ.String())
 			return inp
 		}
-
 	}
 
 	// When using reflection to call receiver methods, the first argument must be the object.

--- a/logger.go
+++ b/logger.go
@@ -98,6 +98,17 @@ func AddFieldsToLogger(inp ZapCompatibleLogger, args ...interface{}) (loggerRet 
 		}
 	}()
 
+	typ := reflect.TypeOf(inp)
+	with, ok := typ.MethodByName("WithFields")
+	if !ok {
+		with, ok = typ.MethodByName("With")
+		if !ok {
+			inp.Debugf("could not add fields to logger of type %s, returning self", typ.String())
+			return inp
+		}
+
+	}
+
 	// When using reflection to call receiver methods, the first argument must be the object.
 	// The remaining arguments are the actual function parameters.
 	reflectArgs := make([]reflect.Value, len(args)+1)
@@ -106,19 +117,6 @@ func AddFieldsToLogger(inp ZapCompatibleLogger, args ...interface{}) (loggerRet 
 		reflectArgs[i+1] = reflect.ValueOf(arg)
 	}
 
-	typ := reflect.TypeOf(inp)
-	with, ok := typ.MethodByName("WithFields")
-	if ok {
-		// RDK WithFields() modifies the current logger (inp) rather than returing a new one
-		with.Func.Call(reflectArgs)
-		return inp
-	}
-
-	with, ok = typ.MethodByName("With")
-	if !ok {
-		inp.Debugf("could not add fields to logger of type %s, returning self", typ.String())
-		return inp
-	}
 	ret := with.Func.Call(reflectArgs)
 	loggerRet, ok = ret[0].Interface().(ZapCompatibleLogger)
 	if !ok {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -607,7 +607,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 				server.webrtcServer,
 				sOpts.webrtcOpts.ExternalSignalingDialOpts,
 				config,
-				utils.Sublogger(logger, "external_signaler"),
+				utils.Sublogger(logger, "signaler.external"),
 				true, // logStats == true
 			))
 		} else {
@@ -651,7 +651,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 				server.webrtcServer,
 				answererDialOpts,
 				config,
-				utils.Sublogger(logger, "internal_signaler"),
+				utils.Sublogger(logger, "signaler.external"),
 				false, // logStats == false
 			))
 		}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -651,7 +651,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 				server.webrtcServer,
 				answererDialOpts,
 				config,
-				utils.Sublogger(logger, "signaler.external"),
+				utils.Sublogger(logger, "signaler.internal"),
 				false, // logStats == false
 			))
 		}

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -52,7 +52,7 @@ func newWebRTCServerStream(
 	onDone func(id uint64),
 	logger utils.ZapCompatibleLogger,
 ) *webrtcServerStream {
-	bs := newWebRTCBaseStream(ctx, cancelCtx, stream, onDone, utils.Sublogger(logger, "networking.grpc_requests"))
+	bs := newWebRTCBaseStream(ctx, cancelCtx, stream, onDone, utils.Sublogger(logger, "grpc_requests"))
 	s := &webrtcServerStream{
 		webrtcBaseStream: bs,
 		ch:               channel,

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -52,7 +52,7 @@ func newWebRTCServerStream(
 	onDone func(id uint64),
 	logger utils.ZapCompatibleLogger,
 ) *webrtcServerStream {
-	bs := newWebRTCBaseStream(ctx, cancelCtx, stream, onDone, logger)
+	bs := newWebRTCBaseStream(ctx, cancelCtx, stream, onDone, utils.Sublogger(logger, "networking.grpc_requests"))
 	s := &webrtcServerStream{
 		webrtcBaseStream: bs,
 		ch:               channel,
@@ -263,6 +263,7 @@ func isContextCanceled(err error) bool {
 
 func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 	s.logger = utils.AddFieldsToLogger(s.logger, "method", headers.Method)
+	s.logger.Debug("incoming grpc request")
 
 	handlerFunc, ok := s.ch.server.handler(headers.Method)
 	if !ok {


### PR DESCRIPTION
### Description
RSDK-8404: Add logging around incoming GRPC requests.

Also, RDK logger `WithFields()` now returns a new logger instead of a modifying the current logger, so this function needed a small refactor to account for that 