### PR TITLE
DATA-3010 - allow method to access *grpc.ClientConn's GetState method from an rpc.ClientConn

### DIFF
--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -72,6 +72,11 @@ func newWebRTCClientChannel(
 	return ch
 }
 
+// GRPCConn returns  nil as this is a webrtc based connection.
+func (ch *webrtcClientChannel) GRPCConn() GRPCClientConnInterface {
+	return nil
+}
+
 func (ch *webrtcClientChannel) PeerConn() *webrtc.PeerConnection {
 	return ch.webrtcBaseChannel.peerConn
 }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/DATA-3010)

1. Add `GRPCConn() GRPCClientConnInterface` method to the `rpc.ClientConn` interface
2. Add `rpc.GRPCClientConnInterface` type which allows other types to implement to the subset of the methods of `*rpc.ClientConn` viam needs, starting with just `GetState() connectivity.State` to allow checking whether or not the underlying GRPC connection is healthy.
3. Add `rpc.GrpcOverHTTPClientConn.GRPCConn()` returning the underlying `*rpc.ClientConn`
4. Add `webrtcClientChannel.GRPCConn()` returning nil (as it is a webrtc based connection)