### PR TITLE
[RSDK-8570] Add StoppableWorkers from RDK

### DIFF
--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -19,7 +19,7 @@ type StoppableWorkers struct {
 }
 
 // NewStoppableWorkers creates a new StoppableWorkers instance. The instance's
-// context will derived from passed in context.
+// context will be derived from passed in context.
 func NewStoppableWorkers(ctx context.Context) *StoppableWorkers {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	return &StoppableWorkers{ctx: ctx, cancelFunc: cancelFunc}

--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -3,13 +3,7 @@ package utils
 import (
 	"context"
 	"sync"
-
-	goutils "go.viam.com/utils"
 )
-
-// TODO: When this struct is widely used and feature complete, move this to goutils instead of
-// here. Until then, we cannot use this in any package imported by utils (e.g., the logging
-// package) without introducing a circular import dependency.
 
 // StoppableWorkers is a collection of goroutines that can be stopped at a later time.
 type StoppableWorkers interface {
@@ -54,7 +48,7 @@ func (sw *stoppableWorkersImpl) AddWorkers(funcs ...func(context.Context)) {
 		// the loop before the goroutine starts up, it starts this function instead of the next
 		// one. For details, see https://go.dev/blog/loopvar-preview
 		f := f
-		goutils.PanicCapturingGo(func() {
+		PanicCapturingGo(func() {
 			defer sw.activeBackgroundWorkers.Done()
 			f(sw.cancelCtx)
 		})

--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -36,6 +36,7 @@ func (sw *StoppableWorkers) Add(worker func(context.Context)) error {
 	// Read-lock to allow concurrent worker addition. The Stop method will write-lock.
 	sw.mu.RLock()
 	if sw.ctx.Err() != nil {
+		sw.mu.RUnlock()
 		return StoppableWorkersAlreadyStopped
 	}
 	sw.workers.Add(1)

--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 )
 
-// StoppableWorkersAlreadyStopped is returned by Add when the StoppableWorkers
+// ErrStoppableWorkersAlreadyStopped is returned by Add when the StoppableWorkers
 // instance has already been stopped.
-var StoppableWorkersAlreadyStopped = errors.New("cannot add worker: already stopped")
+var ErrStoppableWorkersAlreadyStopped = errors.New("cannot add worker: already stopped")
 
 // StoppableWorkers is a collection of goroutines that can be stopped at a
 // later time.
@@ -39,7 +39,7 @@ func (sw *StoppableWorkers) Add(worker func(context.Context)) error {
 	sw.mu.RLock()
 	if sw.ctx.Err() != nil {
 		sw.mu.RUnlock()
-		return StoppableWorkersAlreadyStopped
+		return ErrStoppableWorkersAlreadyStopped
 	}
 	sw.workers.Add(1)
 	sw.mu.RUnlock()

--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 )
 
+// StoppableWorkersAlreadyStopped is returned by Add when the StoppableWorkers
+// instance has already been stopped.
 var StoppableWorkersAlreadyStopped = errors.New("cannot add worker: already stopped")
 
 // StoppableWorkers is a collection of goroutines that can be stopped at a

--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"context"
+	"sync"
+
+	goutils "go.viam.com/utils"
+)
+
+// TODO: When this struct is widely used and feature complete, move this to goutils instead of
+// here. Until then, we cannot use this in any package imported by utils (e.g., the logging
+// package) without introducing a circular import dependency.
+
+// StoppableWorkers is a collection of goroutines that can be stopped at a later time.
+type StoppableWorkers interface {
+	AddWorkers(...func(context.Context))
+	Stop()
+	Context() context.Context
+}
+
+// stoppableWorkersImpl is the implementation of StoppableWorkers. The linter will complain if you
+// try to make a copy of something that contains a sync.WaitGroup (and returning a value at the end
+// of NewStoppableWorkers() would make a copy of it), so we do everything through the
+// StoppableWorkers interface to avoid making copies (since interfaces do everything by pointer).
+type stoppableWorkersImpl struct {
+	mu                      sync.Mutex
+	cancelCtx               context.Context
+	cancelFunc              func()
+	activeBackgroundWorkers sync.WaitGroup
+}
+
+// NewStoppableWorkers runs the functions in separate goroutines. They can be stopped later.
+func NewStoppableWorkers(funcs ...func(context.Context)) StoppableWorkers {
+	cancelCtx, cancelFunc := context.WithCancel(context.Background())
+	workers := &stoppableWorkersImpl{cancelCtx: cancelCtx, cancelFunc: cancelFunc}
+	workers.AddWorkers(funcs...)
+	return workers
+}
+
+// AddWorkers starts up additional goroutines for each function passed in. If you call this after
+// calling Stop(), it will return immediately without starting any new goroutines.
+func (sw *stoppableWorkersImpl) AddWorkers(funcs ...func(context.Context)) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+
+	if sw.cancelCtx.Err() != nil { // We've already stopped everything.
+		return
+	}
+
+	sw.activeBackgroundWorkers.Add(len(funcs))
+	for _, f := range funcs {
+		// In Go 1.21 and earlier, variables created in a loop were reused from one iteration to
+		// the next. Make a "fresh" copy of it here so that, if we're on to the next iteration of
+		// the loop before the goroutine starts up, it starts this function instead of the next
+		// one. For details, see https://go.dev/blog/loopvar-preview
+		f := f
+		goutils.PanicCapturingGo(func() {
+			defer sw.activeBackgroundWorkers.Done()
+			f(sw.cancelCtx)
+		})
+	}
+}
+
+// Stop shuts down all the goroutines we started up.
+func (sw *stoppableWorkersImpl) Stop() {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+
+	sw.cancelFunc()
+	sw.activeBackgroundWorkers.Wait()
+}
+
+// Context gets the context the workers are checking on. Using this function is expected to be
+// rare: usually you shouldn't need to interact with the context directly.
+func (sw *stoppableWorkersImpl) Context() context.Context {
+	return sw.cancelCtx
+}

--- a/stoppable_workers_test.go
+++ b/stoppable_workers_test.go
@@ -23,12 +23,11 @@ func TestStoppableWorkers(t *testing.T) {
 
 	t.Run("concurrent workers", func(t *testing.T) {
 		sw := utils.NewStoppableWorkers(ctx)
-		go func() {
-			test.That(t, sw.Add(normalWorker), test.ShouldBeNil)
-		}()
-		go func() {
-			test.That(t, sw.Add(normalWorker), test.ShouldBeNil)
-		}()
+		concurrentWorker := func(ctx context.Context) {
+			go normalWorker(ctx)
+		}
+		test.That(t, sw.Add(concurrentWorker), test.ShouldBeNil)
+		test.That(t, sw.Add(concurrentWorker), test.ShouldBeNil)
 		sw.Stop()
 	})
 
@@ -58,14 +57,14 @@ func normalWorker(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			break
+			return
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
 }
 
 func panickingWorker(_ context.Context) {
-	panic("this worker panicked")
+	panic("this worker panicked; ignore expected stack trace above")
 }
 
 func nestedWorkersWorker(ctx context.Context) {

--- a/stoppable_workers_test.go
+++ b/stoppable_workers_test.go
@@ -48,7 +48,7 @@ func TestStoppableWorkers(t *testing.T) {
 		sw := utils.NewStoppableWorkers(ctx)
 		sw.Stop()
 		test.That(t, sw.Add(normalWorker), test.ShouldBeError,
-			utils.StoppableWorkersAlreadyStopped)
+			utils.ErrStoppableWorkersAlreadyStopped)
 		sw.Stop() // stopping twice should cause no `panic`
 	})
 }

--- a/stoppable_workers_test.go
+++ b/stoppable_workers_test.go
@@ -1,0 +1,76 @@
+package utils_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+
+	"go.viam.com/utils"
+)
+
+func TestStoppableWorkers(t *testing.T) {
+	// Goleak checks from `VerifyTestMain` for `utils_test` should cause the
+	// following tests to fail if `StoppableWorkers` leaks any goroutines.
+	ctx := context.Background()
+
+	t.Run("one worker", func(t *testing.T) {
+		sw := utils.NewStoppableWorkers(ctx)
+		test.That(t, sw.Add(normalWorker), test.ShouldBeNil)
+		sw.Stop()
+	})
+
+	t.Run("concurrent workers", func(t *testing.T) {
+		sw := utils.NewStoppableWorkers(ctx)
+		go func() {
+			test.That(t, sw.Add(normalWorker), test.ShouldBeNil)
+		}()
+		go func() {
+			test.That(t, sw.Add(normalWorker), test.ShouldBeNil)
+		}()
+		sw.Stop()
+	})
+
+	t.Run("nested workers", func(t *testing.T) {
+		sw := utils.NewStoppableWorkers(ctx)
+		test.That(t, sw.Add(nestedWorkersWorker), test.ShouldBeNil)
+		sw.Stop()
+	})
+
+	t.Run("panicking worker", func(t *testing.T) {
+		sw := utils.NewStoppableWorkers(ctx)
+		// Both adding and stopping a panicking worker should cause no `panic`s.
+		test.That(t, sw.Add(panickingWorker), test.ShouldBeNil)
+		sw.Stop()
+	})
+
+	t.Run("already stopped", func(t *testing.T) {
+		sw := utils.NewStoppableWorkers(ctx)
+		sw.Stop()
+		test.That(t, sw.Add(normalWorker), test.ShouldBeError,
+			utils.StoppableWorkersAlreadyStopped)
+		sw.Stop() // stopping twice should cause no `panic`
+	})
+}
+
+func normalWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			break
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func panickingWorker(_ context.Context) {
+	panic("this worker panicked")
+}
+
+func nestedWorkersWorker(ctx context.Context) {
+	nestedSW := utils.NewStoppableWorkers(ctx)
+	nestedSW.Add(normalWorker)
+
+	normalWorker(ctx)
+}

--- a/stoppable_workers_test.go
+++ b/stoppable_workers_test.go
@@ -1,11 +1,10 @@
 package utils_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
-
-	"go.viam.com/test"
 
 	"go.viam.com/utils"
 )
@@ -17,7 +16,23 @@ func TestStoppableWorkers(t *testing.T) {
 
 	t.Run("one worker", func(t *testing.T) {
 		sw := utils.NewStoppableWorkers(ctx)
-		test.That(t, sw.Add(normalWorker), test.ShouldBeNil)
+		sw.Add(normalWorker)
+		sw.Stop()
+	})
+
+	t.Run("one worker background constructor", func(t *testing.T) {
+		sw := utils.NewBackgroundStoppableWorkers(normalWorker)
+		sw.Stop()
+	})
+
+	t.Run("heavy workers", func(t *testing.T) {
+		sw := utils.NewStoppableWorkers(ctx)
+		sw.Add(heavyWorker)
+		sw.Add(heavyWorker)
+		sw.Add(heavyWorker)
+
+		// Sleep for a second to let heavy workers do work.
+		time.Sleep(1 * time.Second)
 		sw.Stop()
 	})
 
@@ -26,30 +41,28 @@ func TestStoppableWorkers(t *testing.T) {
 		concurrentWorker := func(ctx context.Context) {
 			go normalWorker(ctx)
 		}
-		test.That(t, sw.Add(concurrentWorker), test.ShouldBeNil)
-		test.That(t, sw.Add(concurrentWorker), test.ShouldBeNil)
+		sw.Add(concurrentWorker)
 		sw.Stop()
 	})
 
 	t.Run("nested workers", func(t *testing.T) {
 		sw := utils.NewStoppableWorkers(ctx)
-		test.That(t, sw.Add(nestedWorkersWorker), test.ShouldBeNil)
+		sw.Add(nestedWorkersWorker)
 		sw.Stop()
 	})
 
 	t.Run("panicking worker", func(t *testing.T) {
 		sw := utils.NewStoppableWorkers(ctx)
 		// Both adding and stopping a panicking worker should cause no `panic`s.
-		test.That(t, sw.Add(panickingWorker), test.ShouldBeNil)
+		sw.Add(panickingWorker)
 		sw.Stop()
 	})
 
 	t.Run("already stopped", func(t *testing.T) {
 		sw := utils.NewStoppableWorkers(ctx)
 		sw.Stop()
-		test.That(t, sw.Add(normalWorker), test.ShouldBeError,
-			utils.ErrStoppableWorkersAlreadyStopped)
-		sw.Stop() // stopping twice should cause no `panic`
+		sw.Add(normalWorker) // adding after Stop should cause no `panic`
+		sw.Stop()            // stopping twice should cause no `panic`
 	})
 }
 
@@ -59,6 +72,22 @@ func normalWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// like `normalWorker`, but writes and reads bytes from a buffer.
+func heavyWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(10 * time.Millisecond):
+			var buffer bytes.Buffer
+			data := make([]byte, 10000)
+			buffer.Write(data)
+			readData := make([]byte, buffer.Len())
+			buffer.Read(readData)
 		}
 	}
 }

--- a/stoppable_workers_test.go
+++ b/stoppable_workers_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"go.viam.com/test"
+
 	"go.viam.com/utils"
 )
 
@@ -18,11 +20,17 @@ func TestStoppableWorkers(t *testing.T) {
 		sw := utils.NewStoppableWorkers(ctx)
 		sw.Add(normalWorker)
 		sw.Stop()
+		ctx := sw.Context()
+		test.That(t, ctx, test.ShouldNotBeNil)
+		test.That(t, ctx.Err(), test.ShouldBeError, context.Canceled)
 	})
 
 	t.Run("one worker background constructor", func(t *testing.T) {
 		sw := utils.NewBackgroundStoppableWorkers(normalWorker)
 		sw.Stop()
+		ctx := sw.Context()
+		test.That(t, ctx, test.ShouldNotBeNil)
+		test.That(t, ctx.Err(), test.ShouldBeError, context.Canceled)
 	})
 
 	t.Run("heavy workers", func(t *testing.T) {
@@ -31,18 +39,42 @@ func TestStoppableWorkers(t *testing.T) {
 		sw.Add(heavyWorker)
 		sw.Add(heavyWorker)
 
-		// Sleep for a second to let heavy workers do work.
-		time.Sleep(1 * time.Second)
+		// Sleep for half a second to let heavy workers do work.
+		time.Sleep(500 * time.Millisecond)
 		sw.Stop()
 	})
 
 	t.Run("concurrent workers", func(t *testing.T) {
-		sw := utils.NewStoppableWorkers(ctx)
-		concurrentWorker := func(ctx context.Context) {
-			go normalWorker(ctx)
+		ints := make(chan int)
+		writeWorker := func(ctx context.Context) {
+			var count int
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(100 * time.Millisecond):
+					ints <- count
+				}
+			}
 		}
-		sw.Add(concurrentWorker)
+		var receivedInts []int
+		readWorker := func(ctx context.Context) {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case i := <-ints:
+					receivedInts = append(receivedInts, i)
+				}
+			}
+		}
+
+		sw := utils.NewBackgroundStoppableWorkers(writeWorker, readWorker)
+		// Sleep for a second to let concurrent workers do work.
+		time.Sleep(500 * time.Millisecond)
 		sw.Stop()
+
+		test.That(t, len(receivedInts), test.ShouldBeGreaterThan, 0)
 	})
 
 	t.Run("nested workers", func(t *testing.T) {

--- a/stoppable_workers_test.go
+++ b/stoppable_workers_test.go
@@ -63,13 +63,13 @@ func normalWorker(ctx context.Context) {
 	}
 }
 
-func panickingWorker(_ context.Context) {
-	panic("this worker panicked; ignore expected stack trace above")
-}
-
 func nestedWorkersWorker(ctx context.Context) {
 	nestedSW := utils.NewStoppableWorkers(ctx)
 	nestedSW.Add(normalWorker)
 
 	normalWorker(ctx)
+}
+
+func panickingWorker(_ context.Context) {
+	panic("this worker panicked; ignore expected stack trace above")
 }


### PR DESCRIPTION
Having it in RDK also bit me again today: during 20% Happy Hour, I tried using it in the `logging` package, but introduced a circular dependency (logging would import utils, which imports logging). I haven't needed to tweak the implementation in months; I think this is ready for goutils!

The linter and compiler are happy. I haven't tried this copy out more than that, but the first commit is a byte-for-byte copy of the widely-used version in RDK, and then the second commit is adapting it for goutils.

Benji thought we could get rid of the interface/struct split, and I'm open to such a change, though don't see how to do it myself. but in the meantime, here's the start.