### PR TITLE
bump min golang

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -11,9 +11,7 @@ jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
+    container: ghcr.io/viamrobotics/rdk-devenv:amd64
     timeout-minutes: 30
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.viam.com/utils
 
-go 1.20
+go 1.21.13
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/logger.go
+++ b/logger.go
@@ -51,7 +51,7 @@ type ZapCompatibleLogger interface {
 // calling its `Sublogger` method if it is an RDK logger, or its `Named` method if it is a Zap logger.
 // If neither method is available, it logs a debug message and returns the original logger.
 func Sublogger(inp ZapCompatibleLogger, subname string) (loggerRet ZapCompatibleLogger) {
-	loggerRet = inp
+	loggerRet = inp //nolint:wastedassign
 
 	// loggerRet is initialized to inp as a return value and is intentionally never re-assigned
 	// before calling functions that can panic so that defer + recover returns the original logger
@@ -88,7 +88,7 @@ func Sublogger(inp ZapCompatibleLogger, subname string) (loggerRet ZapCompatible
 // calling its `WithFields` method if it is an RDK logger, or its `With` method if it is a Zap logger.
 // If neither method is available, it logs a debug message and returns the original logger.
 func AddFieldsToLogger(inp ZapCompatibleLogger, args ...interface{}) (loggerRet ZapCompatibleLogger) {
-	loggerRet = inp
+	loggerRet = inp //nolint:wastedassign
 
 	// loggerRet is initialized to inp as a return value and is intentionally never re-assigned
 	// before calling functions that can panic so that defer + recover returns the original logger


### PR DESCRIPTION
## What changed
- bump min golang in go.mod to 1.21.13
- (incidental) change base image of license_finder job so it gets newer license_finder which can handle new go.mod syntax
- (incidental) add `nolint:wastedassign` for defer/recover pattern -- someone who understands intent here should review to make sure this is still needed
## Why
netip vuln https://pkg.go.dev/vuln/GO-2024-2887