### PR TITLE
update base image for publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
+    container: ghcr.io/viamrobotics/rdk-devenv:amd64
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What changed
- switch base image from canon -> rdk-devenv
## Why
My previous PR #339 used a 3-part go version which broke parsing. Failed run [here](https://github.com/viamrobotics/goutils/actions/runs/10723655924).