### PR TITLE
RSDK-8480 - Actually pass server impl into auth stream handler

### DIFF
--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -216,7 +216,7 @@ func (ss *simpleServer) authStreamInterceptor(
 			return err
 		}
 		serverStream = ctxWrappedServerStream{serverStream, nextCtx}
-		return handler(nextCtx, serverStream)
+		return handler(srv, serverStream)
 	}
 
 	// private auth

--- a/rpc/server_auth_test.go
+++ b/rpc/server_auth_test.go
@@ -578,7 +578,9 @@ func TestServerPublicMethods(t *testing.T) {
 		test.That(t, echoResp.Message, test.ShouldEqual, "hello")
 
 		// test the stream service
-		_, err = client.EchoMultiple(context.Background(), &pb.EchoMultipleRequest{Message: "hello"})
+		echoMultClient, err := client.EchoMultiple(context.Background(), &pb.EchoMultipleRequest{Message: "hello"})
+		test.That(t, err, test.ShouldBeNil)
+		_, err = echoMultClient.Recv()
 		test.That(t, err, test.ShouldBeNil)
 		err = <-errChan
 		test.That(t, err, test.ShouldBeNil)
@@ -655,7 +657,9 @@ func TestServerPublicMethods(t *testing.T) {
 		test.That(t, echoResp.Message, test.ShouldEqual, "hello")
 
 		// test the stream service
-		_, err = client.EchoMultiple(context.Background(), &pb.EchoMultipleRequest{Message: "hello"})
+		echoMultClient, err := client.EchoMultiple(context.Background(), &pb.EchoMultipleRequest{Message: "hello"})
+		test.That(t, err, test.ShouldBeNil)
+		_, err = echoMultClient.Recv()
 		test.That(t, err, test.ShouldBeNil)
 		err = <-errChan
 		test.That(t, err, test.ShouldBeNil)


### PR DESCRIPTION
this has been an existing bug for at least a few years - we get the server panic but as long as we close down properly the error actually gets lost as streamClients don't error even if the server side definitely did, the error only shows up after we try to receive the message.