### PR TITLE
RSDK-8545 Leverage SOCKS proxy for direct dialing and ICE

### DIFF
--- a/rpc/const.go
+++ b/rpc/const.go
@@ -8,4 +8,9 @@ var (
 
 	// keepAliveTime is how often to establish Keepalive pings/expectations.
 	keepAliveTime = 10 * time.Second
+
+	// socksProxyEnvVar is the name of the environment variable used by Viam's
+	// SOCKS proxies to indicate the address through which to route all network
+	// traffic via SOCKS5.
+	socksProxyEnvVar = "VIAM_SOCKS_PROXY"
 )

--- a/rpc/const.go
+++ b/rpc/const.go
@@ -9,8 +9,8 @@ var (
 	// keepAliveTime is how often to establish Keepalive pings/expectations.
 	keepAliveTime = 10 * time.Second
 
-	// socksProxyEnvVar is the name of the environment variable used by Viam's
-	// SOCKS proxies to indicate the address through which to route all network
-	// traffic via SOCKS5.
-	socksProxyEnvVar = "VIAM_SOCKS_PROXY"
+	// socksProxyEnvVar is the name of an environment variable used by SOCKS
+	// proxies to indicate the address through which to route all network traffic
+	// via SOCKS5.
+	socksProxyEnvVar = "SOCKS_PROXY"
 )

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -262,7 +262,7 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 		}
 
 		dialOpts = append(dialOpts, grpc.WithContextDialer(func(_ context.Context, addr string) (net.Conn, error) {
-			logger.Info("Behind SOCKS proxy; routing direct dial through proxy")
+			logger.Info("behind SOCKS proxy; routing direct dial through proxy")
 			return dialer.Dial("tcp", addr)
 		}))
 	}

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -142,7 +142,7 @@ func dialWebRTC(
 	if dOpts.webrtcOpts.Config != nil {
 		config = *dOpts.webrtcOpts.Config
 	}
-	extendedConfig := extendWebRTCConfig(&config, configResp.Config)
+	extendedConfig := extendWebRTCConfig(&config, configResp.Config, false)
 	peerConn, dataChannel, err := newPeerConnectionForClient(ctx, extendedConfig, dOpts.webrtcOpts.DisableTrickleICE, logger)
 	if err != nil {
 		return nil, err

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -29,7 +29,6 @@ const (
 	externalDNSLookupTimeoutForProxy = 5 * time.Second
 	// Address for external DNS server.
 	externalDNSServerForProxy = "1.1.1.1:53"
-	networkTypeTCP4           = "tcp4"
 )
 
 // DefaultICEServers is the default set of ICE servers to use for WebRTC session negotiation.
@@ -87,8 +86,8 @@ func newWebRTCAPI(isClient bool, logger utils.ZapCompatibleLogger) (*webrtc.API,
 
 	// Use SOCKS proxy from environment as ICE proxy dialer and net transport.
 	if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" {
-		logger.Info("Behind SOCKS proxy; setting ICE proxy dialer")
-		dialer, err := proxy.SOCKS5(networkTypeTCP4, proxyAddr, nil, proxy.Direct)
+		logger.Info("behind SOCKS proxy; setting ICE proxy dialer")
+		dialer, err := proxy.SOCKS5("tcp4", proxyAddr, nil, proxy.Direct)
 		if err != nil {
 			return nil, fmt.Errorf("error creating SOCKS proxy dialer to address %q from environment: %w",
 				proxyAddr, err)
@@ -140,7 +139,7 @@ func (pd *proxyNet) ResolveIPAddr(network, address string) (*net.IPAddr, error) 
 		Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
 			// Ignore all passed in values. Dial via tcp4 (only protocol supported by
 			// golang SOCKS) to an external DNS server.
-			return pd.proxyDialer.Dial(networkTypeTCP4, externalDNSServerForProxy)
+			return pd.proxyDialer.Dial("tcp4", externalDNSServerForProxy)
 		},
 	}
 

--- a/rpc/wrtc_signaling.go
+++ b/rpc/wrtc_signaling.go
@@ -36,6 +36,13 @@ func DecodeSDP(in string, sdp *webrtc.SessionDescription) error {
 	return err
 }
 
+// extendWebRTCConfig will take a WebRTC configuration and an extension to that
+// configuration obtained by calling `OptionalWebRTCConfig` against the
+// signaling server and append the latter's ICE servers and creds to the
+// former. This is particularly useful for adding a TURN URL to the ICE servers
+// list. `replaceUDPWithTCP`, when true, will replace URLs suffixed with "udp"
+// with the same URL suffixed with "tcp"; this is useful when running behind
+// a SOCKS proxy that can only forward the TCP protocol.
 func extendWebRTCConfig(original *webrtc.Configuration, optional *webrtcpb.WebRTCConfig,
 	replaceUDPWithTCP bool,
 ) webrtc.Configuration {
@@ -51,8 +58,6 @@ func extendWebRTCConfig(original *webrtc.Configuration, optional *webrtcpb.WebRT
 			if replaceUDPWithTCP {
 				urls = nil
 				for _, url := range server.Urls {
-					// TODO(benji): Check if this is necessary.
-					// Modify URLs that end with "transport=udp" to say "transport=tcp".
 					if strings.HasSuffix(url, "udp") {
 						newURL := url[:len(url)-len("udp")] + "tcp"
 						urls = append(urls, newURL)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -80,9 +80,10 @@ func newWebRTCSignalingAnswerer(
 }
 
 const (
-	defaultMaxAnswerers    = 2
-	answererConnectTimeout = 10 * time.Second
-	answererReconnectWait  = time.Second
+	defaultMaxAnswerers               = 2
+	answererConnectTimeout            = 10 * time.Second
+	answererConnectTimeoutBehindProxy = time.Minute
+	answererReconnectWait             = time.Second
 )
 
 // Start connects to the signaling service and listens forever until instructed to stop
@@ -103,7 +104,13 @@ func (ans *webrtcSignalingAnswerer) Start() {
 			default:
 			}
 
-			setupCtx, timeoutCancel := context.WithTimeout(ans.closeCtx, answererConnectTimeout)
+			timeout := answererConnectTimeout
+			// Bump timeout from 10 seconds to 1 minute if behind a SOCKS proxy. It
+			// may take longer to connect to the signaling server in that case.
+			if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" {
+				timeout = answererConnectTimeoutBehindProxy
+			}
+			setupCtx, timeoutCancel := context.WithTimeout(ans.closeCtx, timeout)
 			conn, err := Dial(setupCtx, ans.address, ans.logger, ans.dialOpts...)
 			timeoutCancel()
 			if err != nil {
@@ -307,10 +314,42 @@ type answerAttempt struct {
 // the designated WebRTC data channel is passed off to the underlying Server which
 // is then used as the server end of a gRPC connection.
 func (aa *answerAttempt) connect(ctx context.Context) (err error) {
+	// If SOCKS proxy is indicated by environment, extend WebRTC config with an
+	// `OptionalWebRTCConfig` call to the signaling server. The usage of a SOCKS
+	// proxy indicates that the server may need a local TURN ICE candidate to
+	// make a conntion to any peer. Nomination of that type of candidate is only
+	// possible through extending the WebRTC config with a TURN URL (and
+	// associated username and password).
+	webrtcConfig := aa.webrtcConfig
+	if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" {
+		aa.logger.Info("Behind SOCKS proxy; extending WebRTC config with TURN URL")
+		aa.connMu.Lock()
+		conn := aa.conn
+		aa.connMu.Unlock()
+
+		// Use first host on answerer for rpc-host field in metadata.
+		signalingClient := webrtcpb.NewSignalingServiceClient(conn)
+		md := metadata.New(map[string]string{RPCHostMetadataField: aa.hosts[0]})
+
+		signalCtx := metadata.NewOutgoingContext(ctx, md)
+		configResp, err := signalingClient.OptionalWebRTCConfig(signalCtx,
+			&webrtcpb.OptionalWebRTCConfigRequest{})
+		if err != nil {
+			// Any error below indicates the signaling server is not present.
+			if s, ok := status.FromError(err); ok && (s.Code() == codes.Unimplemented ||
+				(s.Code() == codes.InvalidArgument && s.Message() == hostNotAllowedMsg)) {
+				return ErrNoWebRTCSignaler
+			}
+			return err
+		}
+		webrtcConfig = extendWebRTCConfig(&webrtcConfig, configResp.Config, true)
+		aa.logger.Debugw("Extended WebRTC config", "ICE servers", webrtcConfig.ICEServers)
+	}
+
 	pc, dc, err := newPeerConnectionForServer(
 		ctx,
 		aa.offerSDP,
-		aa.webrtcConfig,
+		webrtcConfig,
 		!aa.trickleEnabled,
 		aa.logger,
 	)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -322,7 +322,7 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 	// associated username and password).
 	webrtcConfig := aa.webrtcConfig
 	if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" {
-		aa.logger.Info("Behind SOCKS proxy; extending WebRTC config with TURN URL")
+		aa.logger.Info("behind SOCKS proxy; extending WebRTC config with TURN URL")
 		aa.connMu.Lock()
 		conn := aa.conn
 		aa.connMu.Unlock()
@@ -343,7 +343,7 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 			return err
 		}
 		webrtcConfig = extendWebRTCConfig(&webrtcConfig, configResp.Config, true)
-		aa.logger.Debugw("Extended WebRTC config", "ICE servers", webrtcConfig.ICEServers)
+		aa.logger.Debugw("extended WebRTC config", "ICE servers", webrtcConfig.ICEServers)
 	}
 
 	pc, dc, err := newPeerConnectionForServer(


### PR DESCRIPTION
[RSDK-8545](https://viam.atlassian.net/browse/RSDK-8545)

Makes dialing and ICE code sensitive to the `SOCKS_PROXY` environment variable. This variable will be set by viam-agent and indicates the address of the rust proxy through which the RDK should forward its network traffic.

This is a tough one to write unit tests for. I can do it if reviewers wish, but the tests may end up strawman-esque in the sense that I would need a full integration test to ensure routing through a SOCKS proxy "works". The manual testing I have done is to:
1. Run the [grill proxy](https://github.com/viam-labs/ble-managed/tree/main/grill_proxy) on a rock4
2. Run the [flutter proxy](https://github.com/viam-labs/ble-managed/tree/main/phone_proxy) on an iPhone
3. Run the RDK on the same rock4 with `VIAM_SOCKS_PROXY` set to `localhost:5000`
4. Disable wi-fi on the rock4
5. Connect via the Golang SDK on my laptop to the rock4 (success)
6. Connect via the app.viam.com "Control" tab to the rock4 (success)

[RSDK-8545]: https://viam.atlassian.net/browse/RSDK-8545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cc @viamrobotics/netcode 