### PR TITLE
[APP-5672] lowercase and lengthen random string to mitigate name collision

### DIFF
--- a/mongo/namespace.go
+++ b/mongo/namespace.go
@@ -101,6 +101,9 @@ func RandomizeNamespaces() (newNamespaces map[string][]string, restore func()) {
 	defer namespacesMu.Unlock()
 	oldNamespaces := map[randomizedName][]randomizedName{}
 	for db, colls := range namespaces {
+		// APP-5672: We choose 20 random lower case characters as a simple heuristic to avoid
+		// collisions. We use lower case letters specifically because MongoDB, for historical
+		// reasons, disallows creating a database with the same letters but different capitalization.
 		newDBName := randomizedName{ptr: db, from: *db, to: "test-" + strings.ToLower(utils.RandomAlphaString(20))}
 		oldNamespaces[newDBName] = nil
 		for _, coll := range colls {

--- a/mongo/namespace.go
+++ b/mongo/namespace.go
@@ -3,6 +3,7 @@ package mongoutils
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"go.viam.com/utils"
@@ -100,10 +101,10 @@ func RandomizeNamespaces() (newNamespaces map[string][]string, restore func()) {
 	defer namespacesMu.Unlock()
 	oldNamespaces := map[randomizedName][]randomizedName{}
 	for db, colls := range namespaces {
-		newDBName := randomizedName{ptr: db, from: *db, to: "test-" + utils.RandomAlphaString(5)}
+		newDBName := randomizedName{ptr: db, from: *db, to: "test-" + strings.ToLower(utils.RandomAlphaString(20))}
 		oldNamespaces[newDBName] = nil
 		for _, coll := range colls {
-			newCollName := randomizedName{ptr: coll, from: *coll, to: utils.RandomAlphaString(5)}
+			newCollName := randomizedName{ptr: coll, from: *coll, to: strings.ToLower(utils.RandomAlphaString(20))}
 			oldNamespaces[newDBName] = append(oldNamespaces[newDBName], newCollName)
 			*coll = newCollName.to
 		}


### PR DESCRIPTION
Our tests in `app` call setup utils via `backingMongoDBURI`  which eventually sets up randomized namespaces for out DBs. We sometimes run into an issue with testing in which the random portion of the names for the test databases have the same characters but in different casing which results in a cascade of test failures. The quick solution is to lengthen the random portion and then lowercase it (should at least prevent the mixed-case error). If I remember correctly, if the name is exactly the same, there is logic to handle that?

@dgottlieb I believe we talked about this a while ago briefly, but figured I'd get your eyes!