### PR TITLE
RSDK-8802: Add StoppableWorkers.StartTimer/NextTick.

### DIFF
--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -15,7 +15,6 @@ type StoppableWorkers struct {
 	mu         sync.RWMutex
 	ctx        context.Context
 	cancelFunc func()
-	timer      *time.Timer
 
 	workers sync.WaitGroup
 }
@@ -46,16 +45,49 @@ func NewBackgroundStoppableWorkers(workers ...func(context.Context)) *StoppableW
 	return sw
 }
 
-// Add starts up a goroutine for the passed-in function. Workers:
-//
-//   - MUST respond appropriately to errors on the context parameter.
-//   - MUST NOT add more workers to the `StoppableWorkers` group to which
-//     they belong.
+// NewStoppableWorkerWithTicker creates a `StoppableWorkers` object with a single worker that gets
+// called every `tickRate`. Calls to the input `worker` function are serialized. I.e: a slow "work"
+// iteration will just slow down when the next one is called.
+func NewStoppableWorkerWithTicker(tickRate time.Duration, workFn func(context.Context)) *StoppableWorkers {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	sw := &StoppableWorkers{ctx: ctx, cancelFunc: cancelFunc}
+	sw.workers.Add(1)
+	PanicCapturingGo(func() {
+		defer sw.workers.Done()
+
+		timer := time.NewTicker(tickRate)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			select {
+			case <-timer.C:
+				workFn(ctx)
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+
+	return sw
+}
+
+// Add starts up a goroutine for the passed-in function. Workers must respond appropriately to
+// errors on the context parameter.
 //
 // The worker will not be added if the StoppableWorkers instance has already
 // been stopped. Any `panic`s from workers will be `recover`ed and logged.
 func (sw *StoppableWorkers) Add(worker func(context.Context)) {
-	// Read-lock to allow concurrent worker addition. The Stop method will write-lock.
+	// Acquire the read lock to allow concurrent worker addition. The Stop method will
+	// write-lock. `Add` is guaranteed to either:
+	// - Observe the context is canceled -- the worker will not be run, nor will the `workers`
+	//   WaitGroup be incremented
+	// - Observe the context is not canceled atomically with incrementing the `workers`
+	//   WaitGroup. `Stop` is guaranteed to wait for this new worker to complete before returning.
 	sw.mu.RLock()
 	if sw.ctx.Err() != nil {
 		sw.mu.RUnlock()
@@ -70,37 +102,18 @@ func (sw *StoppableWorkers) Add(worker func(context.Context)) {
 	})
 }
 
-// StartTimer is an optional call that creates a timer that can be used in conjunction with
-// `NextTick`.
-func (sw *StoppableWorkers) StartTimer(duration time.Duration) {
-	sw.timer = time.NewTimer(duration)
-}
-
-// NextTick blocks until the timer ticks or the StoppableWorkers has been canceled. It returns true
-// if the timer has ticked and false if the context is canceled. Such that one can write a loop to
-// do work as such:
-//
-//	for sw.NextTick() {
-//	  doWork()
-//	}
-func (sw *StoppableWorkers) NextTick() bool {
-	select {
-	case <-sw.timer.C:
-		return true
-	case <-sw.ctx.Done():
-		return false
-	}
-}
-
 // Stop idempotently shuts down all the goroutines we started up.
 func (sw *StoppableWorkers) Stop() {
+	// Call `cancelFunc` with the write lock that competes with "readers" that can add workers. This
+	// guarantees `Add` worker calls that start a goroutine have incremented the `workers` WaitGroup
+	// prior to `Stop` calling `Wait`.
 	sw.mu.Lock()
-	defer sw.mu.Unlock()
 	if sw.ctx.Err() != nil {
 		return
 	}
-
 	sw.cancelFunc()
+	sw.mu.Unlock()
+
 	sw.workers.Wait()
 }
 


### PR DESCRIPTION
I like the idea of having a `NextTick` for my worker. But I think there are some oddities with this so floating it around first.

We should chat about what our options are here as a next step.