### PR TITLE
Bugfix: unlock mutex before returning

### DIFF
--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -113,6 +113,9 @@ func (sw *StoppableWorkers) Stop() {
 		return
 	}
 	sw.cancelFunc()
+	// Make sure to unlock the mutex before waiting for background goroutines to shut down! That
+	// way, any goroutine that was waiting on this lock (e.g., it was trying to spawn another
+	// background worker) won't deadlock, and we'll shut down properly.
 	sw.mu.Unlock()
 
 	sw.workers.Wait()

--- a/stoppable_workers.go
+++ b/stoppable_workers.go
@@ -109,6 +109,7 @@ func (sw *StoppableWorkers) Stop() {
 	// prior to `Stop` calling `Wait`.
 	sw.mu.Lock()
 	if sw.ctx.Err() != nil {
+		sw.mu.Unlock()
 		return
 	}
 	sw.cancelFunc()


### PR DESCRIPTION
See discussion at https://github.com/viamrobotics/goutils/pull/353/files#r1777286836. I also put in a comment on a part I wished had a comment in it. :wink: Without it, my first instinct is to go back to using `defer sw.mu.Unlock()` immediately after locking it.