### PR TITLE
Export SocksProxyEnvVar

### DIFF
--- a/rpc/const.go
+++ b/rpc/const.go
@@ -9,8 +9,8 @@ var (
 	// keepAliveTime is how often to establish Keepalive pings/expectations.
 	keepAliveTime = 10 * time.Second
 
-	// socksProxyEnvVar is the name of an environment variable used by SOCKS
+	// SocksProxyEnvVar is the name of an environment variable used by SOCKS
 	// proxies to indicate the address through which to route all network traffic
 	// via SOCKS5.
-	socksProxyEnvVar = "SOCKS_PROXY"
+	SocksProxyEnvVar = "SOCKS_PROXY"
 )

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -253,7 +253,7 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 
 	// Use SOCKS proxy from environment as gRPC proxy dialer. Do not use
 	// if trying to connect to a local address.
-	if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" &&
+	if proxyAddr := os.Getenv(SocksProxyEnvVar); proxyAddr != "" &&
 		!(strings.HasPrefix(address, "[::]") || strings.HasPrefix(address, "localhost")) {
 		dialer, err := proxy.SOCKS5("tcp", proxyAddr, nil, proxy.Direct)
 		if err != nil {

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -85,7 +85,7 @@ func newWebRTCAPI(isClient bool, logger utils.ZapCompatibleLogger) (*webrtc.API,
 	})
 
 	// Use SOCKS proxy from environment as ICE proxy dialer and net transport.
-	if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" {
+	if proxyAddr := os.Getenv(SocksProxyEnvVar); proxyAddr != "" {
 		logger.Info("behind SOCKS proxy; setting ICE proxy dialer")
 		dialer, err := proxy.SOCKS5("tcp4", proxyAddr, nil, proxy.Direct)
 		if err != nil {

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -107,7 +107,7 @@ func (ans *webrtcSignalingAnswerer) Start() {
 			timeout := answererConnectTimeout
 			// Bump timeout from 10 seconds to 1 minute if behind a SOCKS proxy. It
 			// may take longer to connect to the signaling server in that case.
-			if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" {
+			if proxyAddr := os.Getenv(SocksProxyEnvVar); proxyAddr != "" {
 				timeout = answererConnectTimeoutBehindProxy
 			}
 			setupCtx, timeoutCancel := context.WithTimeout(ans.closeCtx, timeout)
@@ -321,7 +321,7 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 	// possible through extending the WebRTC config with a TURN URL (and
 	// associated username and password).
 	webrtcConfig := aa.webrtcConfig
-	if proxyAddr := os.Getenv(socksProxyEnvVar); proxyAddr != "" {
+	if proxyAddr := os.Getenv(SocksProxyEnvVar); proxyAddr != "" {
 		aa.logger.Info("behind SOCKS proxy; extending WebRTC config with TURN URL")
 		aa.connMu.Lock()
 		conn := aa.conn


### PR DESCRIPTION
`socksProxyEnvVar` -> `SocksProxyEnvVar`. Planning on accessing the value from `rdk` and `agent` to bump some networking timeouts when we are behind a SOCKS proxy.