### PR TITLE
DATA-2663 - Reduce goroutine leaks while running local tests

### DIFF
--- a/testutils/ext/verify.go
+++ b/testutils/ext/verify.go
@@ -3,45 +3,19 @@
 package testutilsext
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 	"os"
-	"runtime"
-	"time"
 
 	"github.com/edaniels/golog"
 	"go.uber.org/goleak"
-	"google.golang.org/api/option"
-	"google.golang.org/api/transport"
 
 	"go.viam.com/utils"
 	"go.viam.com/utils/artifact"
 	"go.viam.com/utils/testutils"
 )
 
-// VerifyTestMain preforms various runtime checks on code that tests run.
+// VerifyTestMain performs various runtime checks on code that tests run.
 func VerifyTestMain(m goleak.TestingM) {
-	func() {
-		// workaround https://github.com/googleapis/google-cloud-go/issues/5430
-		httpClient := &http.Client{Transport: http.DefaultTransport.(*http.Transport).Clone()}
-		defer httpClient.CloseIdleConnections()
-
-		//nolint:errcheck
-		_, _ = transport.Creds(context.Background(), option.WithHTTPClient(httpClient))
-
-		t := time.NewTimer(100 * time.Millisecond)
-		defer t.Stop()
-		for {
-			select {
-			case <-t.C:
-				return
-			default:
-				runtime.Gosched()
-			}
-		}
-	}()
-
 	currentGoroutines := goleak.IgnoreCurrent()
 
 	cache, err := artifact.GlobalCache()

--- a/testutils/ext/verify.go
+++ b/testutils/ext/verify.go
@@ -14,14 +14,13 @@ import (
 	"go.viam.com/utils/testutils"
 )
 
-// VerifyTestMain performs various runtime checks on code that tests run.
+// VerifyTestMain preforms various runtime checks on code that tests run.
 func VerifyTestMain(m goleak.TestingM) {
-	currentGoroutines := goleak.IgnoreCurrent()
-
 	cache, err := artifact.GlobalCache()
 	if err != nil {
 		golog.Global().Fatalw("error opening artifact", "error", err)
 	}
+	currentGoroutines := goleak.IgnoreCurrent()
 	//nolint:ifshort
 	exitCode := m.Run()
 	testutils.Teardown()


### PR DESCRIPTION
I was getting errors like this pretty often:

```bash
> go test -tags=cse -run=TestTabularDataCaptureUploadS3 -race
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 5 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
internal/poll.runtime_pollWait(0x104594ca0, 0x77)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/runtime/netpoll.go:345 +0xa0
internal/poll.(*pollDesc).wait(0xc0000e69a0, 0x77, 0x0)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/internal/poll/fd_poll_runtime.go:84 +0xb8
internal/poll.(*pollDesc).waitWrite(...)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/internal/poll/fd_poll_runtime.go:93
internal/poll.(*FD).WaitWrite(...)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/internal/poll/fd_unix.go:683
net.(*netFD).connect(0xc0000e6980, {0x1020f9580, 0xc000166bd0}, {0xc0000e6980?, 0x6?}, {0x1020e4480, 0xc0001c4020})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:141 +0x884
net.(*netFD).dial(0xc0000e6980, {0x1020f9580, 0xc000166bd0}, {0x1020fd158, 0x0}, {0x1020fd158, 0xc0000e2e40}, 0x0)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:124 +0x3ac
net.socket({0x1020f9580, 0xc000166bd0}, {0x101901f82, 0x3}, 0x2, 0x1, 0x0, 0x0, {0x1020fd158, 0x0}, ...)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/sock_posix.go:70 +0x304
net.internetSocket({0x1020f9580, 0xc000166bd0}, {0x101901f82, 0x3}, {0x1020fd158, 0x0}, {0x1020fd158, 0xc0000e2e40}, 0x1, 0x0, ...)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/ipsock_posix.go:154 +0xb4
net.(*sysDialer).doDialTCPProto(0xc0005217c0, {0x1020f9580, 0xc000166bd0}, 0x0, 0xc0000e2e40, 0x0)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:85 +0xf8
net.(*sysDialer).doDialTCP(...)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:75
net.(*sysDialer).dialTCP(0xc0005217c0, {0x1020f9580, 0xc000166bd0}, 0x0, 0xc0000e2e40)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/tcpsock_posix.go:71 +0xf4
net.(*sysDialer).dialSingle(0xc0005217c0, {0x1020f9580, 0xc000166bd0}, {0x1020f39f8, 0xc0000e2e40})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:651 +0x270
net.(*sysDialer).dialSerial(0xc0005217c0, {0x1020f9580, 0xc000166bd0}, {0xc00056d2f0, 0x1, 0x1?})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:616 +0x1c0
net.(*sysDialer).dialParallel(0xc0005217c0, {0x1020f9580, 0xc000166bd0}, {0xc00056d2f0, 0x1, 0x1}, {0x0, 0x0, 0x0})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:517 +0x490
net.(*Dialer).DialContext(0xc000166af0, {0x1020f9430, 0x103c15540}, {0x101901f82, 0x3}, {0xc000047a40, 0x12})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:508 +0x87c
net.(*Dialer).Dial(...)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/dial.go:434
net/http.(*Transport).dial(0xc000586640, {0x1020f9580, 0xc000166b60}, {0x101901f82, 0x3}, {0xc000047a40, 0x12})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/http/transport.go:1194 +0x164
net/http.(*Transport).dialConn(0xc000586640, {0x1020f9580, 0xc000166b60}, {{}, 0x0, {0x10191c4f9, 0x4}, {0xc000047a40, 0x12}, 0x0})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/http/transport.go:1648 +0xa40
net/http.(*Transport).dialConnFor(0xc000586640, 0xc0000e4370)
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/http/transport.go:1485 +0xc0
created by net/http.(*Transport).queueForDial in goroutine 67
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/http/transport.go:1449 +0x114
 Goroutine 6 in state select, with net.(*netFD).connect.func2 on top of the stack:
net.(*netFD).connect.func2()
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:118 +0x98
created by net.(*netFD).connect in goroutine 5
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/net/fd_unix.go:117 +0x434
]
exit status 1
FAIL	github.com/viamrobotics/app/datasync	2.764s
```

With @edaniels' help, I tracked the error down to `testutils/ext/verify.go` in goutils. Eric suggested removing this code that exists only as a workaround to prevent these goroutine leaks and errors. At least on my laptop, I am seeing lots of goroutine leaks without the changes in this PR, but none with the change, so I think we should go ahead with this.