### PR TITLE
SEC-53 don't backto to external urls

### DIFF
--- a/web/auth.go
+++ b/web/auth.go
@@ -527,8 +527,14 @@ func (h *loginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if r.FormValue("backto") != "" {
-		session.Data["backto"] = r.FormValue("backto")
+		backto := r.FormValue("backto")
+
+		_, err := url.ParseRequestURI(backto)
+		if err == nil {
+			session.Data["backto"] = backto
+		}
 	}
+
 	if session.Data["backto"] == "" {
 		session.Data["backto"] = r.Header.Get("Referer")
 	}


### PR DESCRIPTION
Critical security fix, but double-check my logic. See: https://viam.atlassian.net/browse/SEC-53

Would love help testing this.