### PR TITLE
Make clear AddFieldsToLogger only works for RDK loggers

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -83,10 +83,10 @@ func Sublogger(inp ZapCompatibleLogger, subname string) (loggerRet ZapCompatible
 	return loggerRet
 }
 
-// AddFieldsToLogger adds fields for logging to a given ZapCompatibleLogger instance.
+// AddFieldsToLogger attempts to add fields for logging to a given ZapCompatibleLogger instance.
 // This function uses reflection to dynamically add fields to the provided logger by
-// calling its `WithFields` method if it is an RDK logger, or its `With` method if it is a Zap logger.
-// If neither method is available, it logs a debug message and returns the original logger.
+// calling its `WithFields` method if it is an RDK logger. If the logger is not an RDK logger,
+// it logs a debug message and returns the original logger.
 func AddFieldsToLogger(inp ZapCompatibleLogger, args ...interface{}) (loggerRet ZapCompatibleLogger) {
 	loggerRet = inp //nolint:wastedassign
 
@@ -101,11 +101,8 @@ func AddFieldsToLogger(inp ZapCompatibleLogger, args ...interface{}) (loggerRet 
 	typ := reflect.TypeOf(inp)
 	with, ok := typ.MethodByName("WithFields")
 	if !ok {
-		with, ok = typ.MethodByName("With")
-		if !ok {
-			inp.Debugf("could not add fields to logger of type %s, returning self", typ.String())
-			return inp
-		}
+		inp.Debugf("could not add fields to logger of type %s, returning self", typ.String())
+		return inp
 	}
 
 	// When using reflection to call receiver methods, the first argument must be the object.

--- a/logger.go
+++ b/logger.go
@@ -87,6 +87,7 @@ func Sublogger(inp ZapCompatibleLogger, subname string) (loggerRet ZapCompatible
 // This function uses reflection to dynamically add fields to the provided logger by
 // calling its `WithFields` method if it is an RDK logger. If the logger is not an RDK logger,
 // it logs a debug message and returns the original logger.
+// Args is expected to be a list of key-value pair(s).
 func AddFieldsToLogger(inp ZapCompatibleLogger, args ...interface{}) (loggerRet ZapCompatibleLogger) {
 	loggerRet = inp //nolint:wastedassign
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -107,7 +107,7 @@ func TestLogWithZapLogger(t *testing.T) {
 	logger := golog.NewTestLogger(t)
 	loggerWith := AddFieldsToLogger(logger, "key", "value")
 	test.That(t, loggerWith, test.ShouldNotBeNil)
-	test.That(t, loggerWith, test.ShouldNotEqual, logger)
+	test.That(t, loggerWith, test.ShouldEqual, logger)
 	test.That(t, reflect.TypeOf(loggerWith), test.ShouldEqual, reflect.TypeOf(logger))
 }
 


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9159 is logged, I don't think it makes sense to give devs a false sense that zap loggers will work with the current implementation.