### PR TITLE
Fix backto check

### DIFF
--- a/web/auth.go
+++ b/web/auth.go
@@ -529,9 +529,11 @@ func (h *loginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("backto") != "" {
 		backto := r.FormValue("backto")
 
-		// to prevent redirecting to an external URL we only set the session data when we fail to parse backto
-		_, err := url.ParseRequestURI(backto)
-		if err != nil {
+		// to prevent redirecting to an external URL we only set the session data when:
+		// 1. we fail to parse backto
+		// 2. backto does not include a hostname
+		parsed, err := url.ParseRequestURI(backto)
+		if err != nil || parsed.Hostname() == "" {
 			session.Data["backto"] = backto
 		}
 	}


### PR DESCRIPTION
Quick fix: It looks like paths were not throwing an error, so I added a check to ensure a valid URL does not have a hostname. This should restrict it to just internal paths. Tested and this resolves the issue we were seeing with e2e tests in app trying to bump the goutils version.