### PR TITLE
DATA-3594 Bump up StackDriver exporter TraceSpansBufferMaxBytes

### DIFF
--- a/perf/exporters.go
+++ b/perf/exporters.go
@@ -42,6 +42,8 @@ func NewCloudExporter(opts CloudOptions) (Exporter, error) {
 		// ReportingInterval sets the frequency of reporting metrics to stackdriver backend.
 		ReportingInterval: 60 * time.Second,
 		MetricPrefix:      opts.MetricPrefix,
+		// TraceSpansBufferMaxBytes sets the maximum buffer size to 50MB before spans are dropped.
+		TraceSpansBufferMaxBytes: 50 << 20,
 	}
 
 	// Allow a custom stackdriver project.


### PR DESCRIPTION
Will hopefully resolve the following [logs](https://console.cloud.google.com/logs/query;query=SEARCH%2528%22buffer%20full%22%2529;cursorTimestamp=2024-12-18T21:51:16.142767Z;duration=P7D?invt=AbkdmQ&project=web-app-304613): `OpenCensus Stackdriver exporter: failed to upload 10606 spans: buffer full`