### PR TITLE
RSDK-9591 - Add KillGroup to ManagedProcess

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -34,8 +34,7 @@ type ManagedProcess interface {
 
 	// KillGroup will attempt to kill the process group and not wait for completion. Only use this if
 	// comfortable with leaking resources (in cases where exiting the program as quickly as possible is desired).
-	// Returns kill process that can be waited on if desired.
-	KillGroup() (*exec.Cmd, error)
+	KillGroup()
 
 	// Status return nil when the process is both alive and owned.
 	// If err is non-nil, process may be a) alive but not owned or b) dead.
@@ -439,7 +438,7 @@ func (p *managedProcess) Stop() error {
 }
 
 // KillGroup kills the process group.
-func (p *managedProcess) KillGroup() (*exec.Cmd, error) {
+func (p *managedProcess) KillGroup() {
 	// Minimally hold a lock here so that we can signal the
 	// management goroutine to stop. We will attempt to kill the
 	// process even if p.stopped is true.
@@ -451,7 +450,7 @@ func (p *managedProcess) KillGroup() (*exec.Cmd, error) {
 
 	if p.cmd == nil {
 		p.mu.Unlock()
-		return nil, errAlreadyStopped
+		return
 	}
 	p.mu.Unlock()
 
@@ -461,5 +460,6 @@ func (p *managedProcess) KillGroup() (*exec.Cmd, error) {
 	// without a lock held.
 	// We are intentionally not checking the error here, we are already
 	// in a bad state.
-	return p.forceKillGroup()
+	//nolint:errcheck,gosec
+	p.forceKillGroup()
 }

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -32,6 +32,10 @@ type ManagedProcess interface {
 	// there's any system level issue stopping the process.
 	Stop() error
 
+	// Kill will attempt to kill the process group and not wait for completion. Only use this if
+	// comfortable with leaking resources (in cases where exiting the program as quickly as possible is desired).
+	Kill()
+
 	// Status return nil when the process is both alive and owned.
 	// If err is non-nil, process may be a) alive but not owned or b) dead.
 	Status() error
@@ -431,4 +435,30 @@ func (p *managedProcess) Stop() error {
 		return p.lastWaitErr
 	}
 	return errors.Errorf("non-successful exit code: %d", p.cmd.ProcessState.ExitCode())
+}
+
+func (p *managedProcess) Kill() {
+	// Minimally hold a lock here so that we can signal the
+	// management goroutine to stop. We will attempt to kill the
+	// process even if p.stopped is true.
+	p.mu.Lock()
+	if !p.stopped {
+		close(p.killCh)
+		p.stopped = true
+	}
+
+	if p.cmd == nil {
+		p.mu.Unlock()
+		return
+	}
+	p.mu.Unlock()
+
+	// Since p.cmd is mutex guarded and we just signaled the manage
+	// goroutine to stop, no new Start can happen and therefore
+	// p.cmd can no longer be modified rendering it safe to read
+	// without a lock held.
+	// We are intentionally not checking the error here, we are already
+	// in a bad state.
+	//nolint:errcheck,gosec
+	p.forceKill()
 }

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -34,7 +34,7 @@ type ManagedProcess interface {
 
 	// Kill will attempt to kill the process group and not wait for completion. Only use this if
 	// comfortable with leaking resources (in cases where exiting the program as quickly as possible is desired).
-	Kill()
+	KillGroup()
 
 	// Status return nil when the process is both alive and owned.
 	// If err is non-nil, process may be a) alive but not owned or b) dead.
@@ -437,7 +437,7 @@ func (p *managedProcess) Stop() error {
 	return errors.Errorf("non-successful exit code: %d", p.cmd.ProcessState.ExitCode())
 }
 
-func (p *managedProcess) Kill() {
+func (p *managedProcess) KillGroup() {
 	// Minimally hold a lock here so that we can signal the
 	// management goroutine to stop. We will attempt to kill the
 	// process even if p.stopped is true.
@@ -460,5 +460,5 @@ func (p *managedProcess) Kill() {
 	// We are intentionally not checking the error here, we are already
 	// in a bad state.
 	//nolint:errcheck,gosec
-	p.forceKill()
+	p.forceKillGroup()
 }

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -32,7 +32,7 @@ type ManagedProcess interface {
 	// there's any system level issue stopping the process.
 	Stop() error
 
-	// Kill will attempt to kill the process group and not wait for completion. Only use this if
+	// KillGroup will attempt to kill the process group and not wait for completion. Only use this if
 	// comfortable with leaking resources (in cases where exiting the program as quickly as possible is desired).
 	KillGroup()
 
@@ -437,6 +437,7 @@ func (p *managedProcess) Stop() error {
 	return errors.Errorf("non-successful exit code: %d", p.cmd.ProcessState.ExitCode())
 }
 
+// KillGroup kills the process group.
 func (p *managedProcess) KillGroup() {
 	// Minimally hold a lock here so that we can signal the
 	// management goroutine to stop. We will attempt to kill the

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -630,12 +630,22 @@ func TestManagedProcessStop(t *testing.T) {
 		test.That(t, file2SizeAfterKill, test.ShouldBeGreaterThan, file2SizeBeforeStart)
 		test.That(t, file3SizeAfterKill, test.ShouldBeGreaterThan, file3SizeBeforeStart)
 
-		// wait a short amount of time and check again - this time the size should not have increased.
-		time.Sleep(300 * time.Millisecond)
+		// since KillGroup does not wait, we might have to check file size a few times as the kill
+		// might take a little to propagate. We want to make sure that the file size stops increasing.
+		testutils.WaitForAssertionWithSleep(t, 300*time.Millisecond, 50, func(tb testing.TB) {
+			tempSize1 := getSize(tempFile1)
+			tempSize2 := getSize(tempFile2)
+			tempSize3 := getSize(tempFile3)
 
-		test.That(t, getSize(tempFile1), test.ShouldEqual, file1SizeAfterKill)
-		test.That(t, getSize(tempFile2), test.ShouldEqual, file2SizeAfterKill)
-		test.That(t, getSize(tempFile3), test.ShouldEqual, file3SizeAfterKill)
+			test.That(t, tempSize1, test.ShouldEqual, file1SizeAfterKill)
+			test.That(t, tempSize2, test.ShouldEqual, file2SizeAfterKill)
+			test.That(t, tempSize3, test.ShouldEqual, file3SizeAfterKill)
+
+			file1SizeAfterKill = tempSize1
+			file2SizeAfterKill = tempSize1
+			file3SizeAfterKill = tempSize1
+		})
+
 	})
 }
 

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -645,7 +645,6 @@ func TestManagedProcessStop(t *testing.T) {
 			file2SizeAfterKill = tempSize1
 			file3SizeAfterKill = tempSize1
 		})
-
 	})
 }
 

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -645,6 +645,9 @@ func TestManagedProcessStop(t *testing.T) {
 			file2SizeAfterKill = tempSize1
 			file3SizeAfterKill = tempSize1
 		})
+
+		// wait on the managingCh to close
+		<-proc.(*managedProcess).managingCh
 	})
 }
 

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -620,7 +620,9 @@ func TestManagedProcessStop(t *testing.T) {
 		<-watcher2.Events
 		<-watcher3.Events
 
-		proc.KillGroup()
+		cmd, err := proc.KillGroup()
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cmd.Wait(), test.ShouldBeNil)
 
 		file1SizeAfterKill := getSize(tempFile1)
 		file2SizeAfterKill := getSize(tempFile2)
@@ -630,21 +632,9 @@ func TestManagedProcessStop(t *testing.T) {
 		test.That(t, file2SizeAfterKill, test.ShouldBeGreaterThan, file2SizeBeforeStart)
 		test.That(t, file3SizeAfterKill, test.ShouldBeGreaterThan, file3SizeBeforeStart)
 
-		// since KillGroup does not wait, we might have to check file size a few times as the kill
-		// might take a little to propagate. We want to make sure that the file size stops increasing.
-		testutils.WaitForAssertionWithSleep(t, 300*time.Millisecond, 50, func(tb testing.TB) {
-			tempSize1 := getSize(tempFile1)
-			tempSize2 := getSize(tempFile2)
-			tempSize3 := getSize(tempFile3)
-
-			test.That(t, tempSize1, test.ShouldEqual, file1SizeAfterKill)
-			test.That(t, tempSize2, test.ShouldEqual, file2SizeAfterKill)
-			test.That(t, tempSize3, test.ShouldEqual, file3SizeAfterKill)
-
-			file1SizeAfterKill = tempSize1
-			file2SizeAfterKill = tempSize1
-			file3SizeAfterKill = tempSize1
-		})
+		test.That(t, getSize(tempFile1), test.ShouldEqual, file1SizeAfterKill)
+		test.That(t, getSize(tempFile2), test.ShouldEqual, file2SizeAfterKill)
+		test.That(t, getSize(tempFile3), test.ShouldEqual, file3SizeAfterKill)
 	})
 }
 
@@ -780,4 +770,4 @@ in reality tests should just depend on the methods they rely on. UnixPid is not 
 of those methods (for better or worse)`)
 }
 
-func (fp *fakeProcess) KillGroup() {}
+func (fp *fakeProcess) KillGroup() (*exec.Cmd, error) { return nil, errAlreadyStopped }

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -702,3 +702,5 @@ func (fp *fakeProcess) UnixPid() (int, error) {
 in reality tests should just depend on the methods they rely on. UnixPid is not one
 of those methods (for better or worse)`)
 }
+
+func (fp *fakeProcess) Kill() {}

--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -455,13 +455,13 @@ func TestManagedProcessStop(t *testing.T) {
 		watcher1, tempFile := testutils.WatchedFile(t)
 
 		bashScript1 := fmt.Sprintf(`
-				trap "echo SIGTERM >> '%s'" SIGTERM
-				echo hello >> '%s'
-				while true
-				do echo hey
-				sleep 1
-				done
-			`, tempFile.Name(), tempFile.Name())
+			trap "echo SIGTERM >> '%s'" SIGTERM
+			echo hello >> '%s'
+			while true
+			do echo hey
+			sleep 1
+			done
+		`, tempFile.Name(), tempFile.Name())
 
 		proc := NewManagedProcess(ProcessConfig{
 			Name:        "bash",
@@ -496,20 +496,20 @@ func TestManagedProcessStop(t *testing.T) {
 		watcher3, tempFile3 := testutils.WatchedFile(t)
 
 		trapScript := `
-				trap "echo SIGTERM >> '%s'" SIGTERM
-				echo hello >> '%s'
-				while true
-				do echo hey
-				sleep 1
-				done
-			`
+			trap "echo SIGTERM >> '%s'" SIGTERM
+			echo hello >> '%s'
+			while true
+			do echo hey
+			sleep 1
+			done
+		`
 
 		bashScript1 := fmt.Sprintf(trapScript, tempFile1.Name(), tempFile1.Name())
 		bashScript2 := fmt.Sprintf(trapScript, tempFile2.Name(), tempFile2.Name())
 		bashScriptParent := fmt.Sprintf(`
-				bash -c '%s' &
-				bash -c '%s' &
-				`+trapScript,
+			bash -c '%s' &
+			bash -c '%s' &
+			`+trapScript,
 			bashScript1,
 			bashScript2,
 			tempFile3.Name(),
@@ -602,6 +602,9 @@ func TestManagedProcessStop(t *testing.T) {
 		proc := NewManagedProcess(ProcessConfig{
 			Name: "bash",
 			Args: []string{"-c", bashScriptParent},
+			// have to set Log to false so that open file descriptors do not cause the test to hang
+			// https://github.com/golang/go/issues/18874
+			Log: false,
 		}, logger)
 
 		// To confirm that the processes have died, confirm that the size of the file stopped increasing

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -129,11 +129,15 @@ func (p *managedProcess) kill() (bool, error) {
 
 // forceKillGroup kills everything in the process group. This will not wait for completion and may result the
 // kill becoming a zombie process.
-func (p *managedProcess) forceKillGroup() error {
+func (p *managedProcess) forceKillGroup() (*exec.Cmd, error) {
 	pgidStr := strconv.Itoa(-p.cmd.Process.Pid)
 	p.logger.Infof("killing entire process group %d", p.cmd.Process.Pid)
 	//nolint:gosec
-	return exec.Command("kill", "-9", pgidStr).Start()
+	cmd := exec.Command("kill", "-9", pgidStr)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }
 
 func isWaitErrUnknown(err string, forceKilled bool) bool {

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -127,12 +127,13 @@ func (p *managedProcess) kill() (bool, error) {
 	return forceKilled, nil
 }
 
-// forceKill kills everything in the process group. This will not wait for completion and may result in a zombie process.
-func (p *managedProcess) forceKill() error {
-	pidStr := strconv.Itoa(-p.cmd.Process.Pid)
+// forceKill kills everything in the process group. This will not wait for completion and may result the
+// kill becoming a zombie process.
+func (p *managedProcess) forceKillGroup() error {
+	pgidStr := strconv.Itoa(-p.cmd.Process.Pid)
 	p.logger.Infof("killing entire process group %d", p.cmd.Process.Pid)
 	//nolint:gosec
-	return exec.Command("kill", "-9", pidStr).Start()
+	return exec.Command("kill", "-9", pgidStr).Start()
 }
 
 func isWaitErrUnknown(err string, forceKilled bool) bool {

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -127,7 +127,7 @@ func (p *managedProcess) kill() (bool, error) {
 	return forceKilled, nil
 }
 
-// forceKill kills everything in the process group. This will not wait for completion and may result the
+// forceKillGroup kills everything in the process group. This will not wait for completion and may result the
 // kill becoming a zombie process.
 func (p *managedProcess) forceKillGroup() error {
 	pgidStr := strconv.Itoa(-p.cmd.Process.Pid)

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -4,6 +4,7 @@ package pexec
 
 import (
 	"os"
+	"os/exec"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -124,6 +125,14 @@ func (p *managedProcess) kill() (bool, error) {
 	}
 
 	return forceKilled, nil
+}
+
+// forceKill kills everything in the process group. This will not wait for completion and may result in a zombie process.
+func (p *managedProcess) forceKill() error {
+	pidStr := strconv.Itoa(-p.cmd.Process.Pid)
+	p.logger.Infof("killing entire process group %d", p.cmd.Process.Pid)
+	//nolint:gosec
+	return exec.Command("kill", "-9", pidStr).Start()
 }
 
 func isWaitErrUnknown(err string, forceKilled bool) bool {

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -129,15 +129,11 @@ func (p *managedProcess) kill() (bool, error) {
 
 // forceKillGroup kills everything in the process group. This will not wait for completion and may result the
 // kill becoming a zombie process.
-func (p *managedProcess) forceKillGroup() (*exec.Cmd, error) {
+func (p *managedProcess) forceKillGroup() error {
 	pgidStr := strconv.Itoa(-p.cmd.Process.Pid)
 	p.logger.Infof("killing entire process group %d", p.cmd.Process.Pid)
 	//nolint:gosec
-	cmd := exec.Command("kill", "-9", pgidStr)
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-	return cmd, nil
+	return exec.Command("kill", "-9", pgidStr).Start()
 }
 
 func isWaitErrUnknown(err string, forceKilled bool) bool {

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -25,7 +25,6 @@ func parseSignal(sigStr, name string) (syscall.Signal, error) {
 	return 0, errors.New("signals not supported on Windows")
 }
 
-
 func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
 	ret := &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
@@ -105,6 +104,13 @@ func (p *managedProcess) kill() (bool, error) {
 	}
 
 	return forceKilled, nil
+}
+
+// forceKill kills everything in the process tree. This will not wait for completion and may result in a zombie process.
+func (p *managedProcess) forceKill() error {
+	pidStr := strconv.Itoa(p.cmd.Process.Pid)
+	p.logger.Infof("force killing entire process tree %d", p.cmd.Process.Pid)
+	return exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Start()
 }
 
 func isWaitErrUnknown(err string, forceKilled bool) bool {

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -89,7 +89,7 @@ func (p *managedProcess) kill() (bool, error) {
 		select {
 		case <-timer2.C:
 			p.logger.Infof("force killing entire process tree %d", p.cmd.Process.Pid)
-			if err := forceKillCmd(pidStr).Run(); err != nil {
+			if err := exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Run(); err != nil {
 				return false, errors.Wrapf(err, "error force killing process tree %d", p.cmd.Process.Pid)
 			}
 			forceKilled = true
@@ -97,7 +97,7 @@ func (p *managedProcess) kill() (bool, error) {
 			timer2.Stop()
 		}
 	} else {
-		if err := forceKillCmd(pidStr).Run(); err != nil {
+		if err := exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Run(); err != nil {
 			return false, errors.Wrapf(err, "error force killing process tree %d", p.cmd.Process.Pid)
 		}
 		forceKilled = true
@@ -106,20 +106,11 @@ func (p *managedProcess) kill() (bool, error) {
 	return forceKilled, nil
 }
 
-func forceKillCmd(pidStr string) *exec.Cmd {
-	return exec.Command("taskkill", "/t", "/f", "/pid", pidStr)
-}
-
-// forceKillGroup kills everything in the process group. This will not wait for completion and may result the
-// kill becoming a zombie process.
-func (p *managedProcess) forceKillGroup() (*exec.Cmd, error) {
-	pgidStr := strconv.Itoa(p.cmd.Process.Pid)
+// forceKillGroup kills everything in the process tree. This will not wait for completion and may result in a zombie process.
+func (p *managedProcess) forceKillGroup() error {
+	pidStr := strconv.Itoa(p.cmd.Process.Pid)
 	p.logger.Infof("force killing entire process tree %d", p.cmd.Process.Pid)
-	cmd := forceKillCmd(pgidStr)
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-	return cmd, nil
+	return exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Start()
 }
 
 func isWaitErrUnknown(err string, forceKilled bool) bool {

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -106,7 +106,7 @@ func (p *managedProcess) kill() (bool, error) {
 	return forceKilled, nil
 }
 
-// forceKill kills everything in the process tree. This will not wait for completion and may result in a zombie process.
+// forceKillGroup kills everything in the process tree. This will not wait for completion and may result in a zombie process.
 func (p *managedProcess) forceKillGroup() error {
 	pidStr := strconv.Itoa(p.cmd.Process.Pid)
 	p.logger.Infof("force killing entire process tree %d", p.cmd.Process.Pid)

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -107,7 +107,7 @@ func (p *managedProcess) kill() (bool, error) {
 }
 
 // forceKill kills everything in the process tree. This will not wait for completion and may result in a zombie process.
-func (p *managedProcess) forceKill() error {
+func (p *managedProcess) forceKillGroup() error {
 	pidStr := strconv.Itoa(p.cmd.Process.Pid)
 	p.logger.Infof("force killing entire process tree %d", p.cmd.Process.Pid)
 	return exec.Command("taskkill", "/t", "/f", "/pid", pidStr).Start()


### PR DESCRIPTION
This is part one of two PRs that will hopefully help with shutting down all module processes before viam-server exits. Part 2 is [here](https://github.com/viamrobotics/rdk/pull/4657)

This is still a draft as I'm looking for thoughts and ideas around making this better. 

The idea behind this is for a Kill() call to propagate from the viam-server, and we should not block on anything if possible. The `kill()`s here do not wait for the execed process to complete, and this is intentional - I couldn't find if syscall.Kill waits for completion, so did not use. I wasn't able to find documentation about whether `kill -9` blocks on the signal getting received or if it immediately returns, so opted for `.Start()` instead of `.Run()`, which means we do not `Wait()` for the process to return. This does mean that the assumption is that the viam-server ends immediately after and that the system will properly await the processes that we spawned to kill the managed process, otherwise those processes will be zombie'd. I can see changing it so that we do a `.Run()` instead, but might mean we would have to do the module process killing in parallel in viam-server.

There is a todo to add Kill to the processManager, but a quick glance at how Close works for processManager makes me think that it should be a followup task