### PR TITLE
[RSDK-9149] Default gRPC Server to 'Wait For Handlers'

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -856,7 +856,7 @@ func (ss *simpleServer) Stop() error {
 		err = multierr.Combine(err, ss.signalingCallQueue.Close())
 	}
 	ss.logger.Debug("stopping gRPC server")
-	defer ss.grpcServer.GracefulStop()
+	defer ss.grpcServer.Stop()
 	ss.logger.Debug("canceling service servers for gateway")
 	for _, cancel := range ss.serviceServerCancels {
 		cancel()

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -397,7 +397,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 		serverOpts = append(serverOpts, grpc.StatsHandler(sOpts.statsHandler))
 	}
 
-	serverOpts = append(serverOpts, grpc.WaitForHandlers(sOpts.waitForHandlers))
+	serverOpts = append(serverOpts, grpc.WaitForHandlers(true))
 
 	grpcServer := grpc.NewServer(
 		serverOpts...,

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -397,6 +397,8 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 		serverOpts = append(serverOpts, grpc.StatsHandler(sOpts.statsHandler))
 	}
 
+	serverOpts = append(serverOpts, grpc.WaitForHandlers(sOpts.waitForHandlers))
+
 	grpcServer := grpc.NewServer(
 		serverOpts...,
 	)

--- a/rpc/server_options.go
+++ b/rpc/server_options.go
@@ -72,8 +72,6 @@ type serverOptions struct {
 	ensureAuthedHandler func(ctx context.Context) (context.Context, error)
 
 	unknownStreamDesc *grpc.StreamDesc
-
-	waitForHandlers bool
 }
 
 type authKeyData struct {
@@ -534,14 +532,6 @@ func WithAllowUnauthenticatedHealthCheck() ServerOption {
 func WithPublicMethods(fullMethods []string) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) error {
 		o.publicMethods = fullMethods
-		return nil
-	})
-}
-
-// WaitForHandlers returns a ServerOption that ensures the graceful exit of a server.
-func WaitForHandlers(w bool) ServerOption {
-	return newFuncServerOption(func(o *serverOptions) error {
-		o.waitForHandlers = w
 		return nil
 	})
 }

--- a/rpc/server_options.go
+++ b/rpc/server_options.go
@@ -72,6 +72,8 @@ type serverOptions struct {
 	ensureAuthedHandler func(ctx context.Context) (context.Context, error)
 
 	unknownStreamDesc *grpc.StreamDesc
+
+	waitForHandlers bool
 }
 
 type authKeyData struct {
@@ -532,6 +534,14 @@ func WithAllowUnauthenticatedHealthCheck() ServerOption {
 func WithPublicMethods(fullMethods []string) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) error {
 		o.publicMethods = fullMethods
+		return nil
+	})
+}
+
+// WaitForHandlers returns a ServerOption that ensures the graceful exit of a server.
+func WaitForHandlers(w bool) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) error {
+		o.waitForHandlers = w
 		return nil
 	})
 }


### PR DESCRIPTION
#405 Previously introduced  a test failure in RDK due to a leaked Goroutine. The fix - put up in the same PR - was to _always_ use GracefulStop() when closing the gRPC server. [This](https://github.com/viamrobotics/rdk/actions/runs/12893598036/job/35950351518) is causing other tests (see the output logs [here](https://productionresultssa11.blob.core.windows.net/actions-results/69f42cfc-c1a1-452c-8d3c-9af145d8ca2a/workflow-job-run-73abc5b6-187b-537c-12c8-c5e31d8f6e33/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-01-21T19%3A24%3A16Z&sig=MY4emUZn%2BpWjmGM%2BrQ3fARPQcaqLgQOqJaah6ZbsmlQ%3D&ske=2025-01-22T05%3A45%3A19Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-01-21T17%3A45%3A19Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-11-04&sp=r&spr=https&sr=b&st=2025-01-21T19%3A14%3A11Z&sv=2024-11-04)) to fail :/ As an alternative, _this_ PR introduces the option to have a web server gracefully (or not) stop a gRPC server. This PR goes with [this](https://github.com/viamrobotics/rdk/pull/4723) one, which will actually use said option in the initial tests that failed to avoid the leaked Goroutines. Once this merges, we should make a release and create a PR in RDK to run our CI tests.