### PR TITLE
[RSDK-8666] Use Stoppable Workers

### DIFF
--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -1,5 +1,6 @@
-// TODO(RSDK-8666): use stoppable workers
 package rpc
+
+// TODO(RSDK-8666): use stoppable workers
 
 import (
 	"context"

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -128,9 +128,7 @@ func (queue *memoryWebRTCCallQueue) SendOfferInit(
 	hostQueueForSend.activeOffers[offer.uuid] = exchange
 	hostQueueForSend.mu.Unlock()
 
-	queue.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(func() {
-		queue.activeBackgroundWorkers.Done()
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 		select {
 		case <-sendCtx.Done():
 		case <-ctx.Done():

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -49,7 +49,6 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 				return
 			}
 			now := time.Now()
-			queue.mu.Lock()
 			for _, hostQueue := range queue.hostQueues {
 				hostQueue.mu.Lock()
 				for offerID, offer := range hostQueue.activeOffers {
@@ -59,7 +58,6 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 				}
 				hostQueue.mu.Unlock()
 			}
-			queue.mu.Unlock()
 		}
 	})
 	return queue

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -1,3 +1,4 @@
+// TODO(RSDK-8666): use stoppable workers
 package rpc
 
 import (

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1,5 +1,6 @@
-// TODO(RSDK-8666): use stoppable workers
 package rpc
+
+// TODO(RSDK-8666): use stoppable workers
 
 import (
 	"context"

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1,3 +1,4 @@
+// TODO(RSDK-8666): use stoppable workers
 package rpc
 
 import (

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -1,5 +1,6 @@
-// TODO(RSDK-8666): use stoppable workers
 package rpc
+
+// TODO(RSDK-8666): use stoppable workers
 
 import (
 	"context"

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -22,8 +22,8 @@ var DefaultWebRTCMaxGRPCCalls = 256
 
 // A webrtcServer translates gRPC frames over WebRTC data channels into gRPC calls.
 type webrtcServer struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
+	// ctx      context.Context
+	// cancel   context.CancelFunc
 	handlers map[string]handlerFunc
 	services map[string]*serviceInfo
 	logger   utils.ZapCompatibleLogger
@@ -126,15 +126,13 @@ func newWebRTCServerWithInterceptorsAndUnknownStreamHandler(
 		streamInt:         streamInt,
 		unknownStreamDesc: unknownStreamDesc,
 	}
-	srv.ctx, srv.cancel = context.WithCancel(context.Background())
-	srv.processHeadersWorkers = utils.NewStoppableWorkers(srv.ctx)
+	srv.processHeadersWorkers = utils.NewBackgroundStoppableWorkers()
 	return srv
 }
 
 // Stop instructs the server and all handlers to stop. It returns when all handlers
 // are done executing.
 func (srv *webrtcServer) Stop() {
-	srv.cancel()
 	srv.logger.Info("waiting for handlers to complete")
 	srv.processHeadersWorkers.Stop()
 	srv.logger.Info("handlers complete")

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -1,3 +1,4 @@
+// TODO(RSDK-8666): use stoppable workers
 package rpc
 
 import (

--- a/rpc/wrtc_server_channel.go
+++ b/rpc/wrtc_server_channel.go
@@ -37,7 +37,7 @@ func newWebRTCServerChannel(
 	logger utils.ZapCompatibleLogger,
 ) *webrtcServerChannel {
 	base := newBaseChannel(
-		server.ctx,
+		server.processHeadersWorkers.Context(),
 		peerConn,
 		dataChannel,
 		func() { server.removePeer(peerConn) },

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -272,7 +272,7 @@ func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 
 	// Check if context has errored: underlying server may have been `Stop`ped,
 	// in which case we return.
-	if err := s.ch.server.ctx.Err(); err != nil {
+	if err := s.ch.server.processHeadersWorkers.Context().Err(); err != nil {
 		return
 	}
 


### PR DESCRIPTION
This PR is a continuation of #402 re: [this](https://github.com/viamrobotics/goutils/pull/402#pullrequestreview-2553454718) comment from @benjirewis (i.e., it updates `rpc/wrtc_server.go`, `rpc/wrtc_call_queue_memory.go`, and `rpc/wrtc_call_queue_mongodb.go` to use `StoppableWorkers`).