### PR TITLE
[RSDK-8666] Use Stoppable Workers

### DIFF
--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -1,5 +1,6 @@
-// TODO(RSDK-8666): use stoppable workers
 package rpc
+
+// TODO(RSDK-8666): use stoppable workers
 
 import (
 	"context"

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -114,7 +114,7 @@ func (queue *memoryWebRTCCallQueue) SendOfferInit(
 	hostQueueForSend.activeOffers[offer.uuid] = exchange
 	hostQueueForSend.mu.Unlock()
 
-	queue.activeBackgroundWorkers.Add(func(ctx context.Context) {
+	queue.activeBackgroundWorkers.Add(func(_ context.Context) {
 		select {
 		case <-sendCtx.Done():
 		case <-ctx.Done():

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -49,6 +49,7 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 				return
 			}
 			now := time.Now()
+			queue.mu.Lock()
 			for _, hostQueue := range queue.hostQueues {
 				hostQueue.mu.Lock()
 				for offerID, offer := range hostQueue.activeOffers {
@@ -58,6 +59,7 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 				}
 				hostQueue.mu.Unlock()
 			}
+			queue.mu.Unlock()
 		}
 	})
 	return queue

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -44,9 +44,6 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 		logger:            logger,
 	}
 	queue.activeBackgroundWorkers = utils.NewStoppableWorkerWithTicker(5*time.Second, func(ctx context.Context) {
-		if ctx.Err() != nil {
-			return
-		}
 		now := time.Now()
 		queue.mu.Lock()
 		for _, hostQueue := range queue.hostQueues {

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -128,9 +128,7 @@ func (queue *memoryWebRTCCallQueue) SendOfferInit(
 	hostQueueForSend.activeOffers[offer.uuid] = exchange
 	hostQueueForSend.mu.Unlock()
 
-	queue.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(func() {
-		queue.activeBackgroundWorkers.Done()
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 		select {
 		case <-sendCtx.Done():
 		case <-ctx.Done():

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -49,7 +49,6 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 				return
 			}
 			now := time.Now()
-			queue.mu.Lock()
 			for _, hostQueue := range queue.hostQueues {
 				hostQueue.mu.Lock()
 				for offerID, offer := range hostQueue.activeOffers {
@@ -59,7 +58,6 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 				}
 				hostQueue.mu.Unlock()
 			}
-			queue.mu.Unlock()
 		}
 	})
 	return queue

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -44,23 +44,21 @@ func newMemoryWebRTCCallQueue(uuidDeterministic bool, logger utils.ZapCompatible
 		logger:            logger,
 	}
 	queue.activeBackgroundWorkers = utils.NewStoppableWorkerWithTicker(5*time.Second, func(ctx context.Context) {
-		for {
-			if ctx.Err() != nil {
-				return
-			}
-			now := time.Now()
-			queue.mu.Lock()
-			for _, hostQueue := range queue.hostQueues {
-				hostQueue.mu.Lock()
-				for offerID, offer := range hostQueue.activeOffers {
-					if d, ok := offer.offer.answererDoneCtx.Deadline(); ok && d.Before(now) {
-						delete(hostQueue.activeOffers, offerID)
-					}
-				}
-				hostQueue.mu.Unlock()
-			}
-			queue.mu.Unlock()
+		if ctx.Err() != nil {
+			return
 		}
+		now := time.Now()
+		queue.mu.Lock()
+		for _, hostQueue := range queue.hostQueues {
+			hostQueue.mu.Lock()
+			for offerID, offer := range hostQueue.activeOffers {
+				if d, ok := offer.offer.answererDoneCtx.Deadline(); ok && d.Before(now) {
+					delete(hostQueue.activeOffers, offerID)
+				}
+			}
+			hostQueue.mu.Unlock()
+		}
+		queue.mu.Unlock()
 	})
 	return queue
 }

--- a/rpc/wrtc_call_queue_memory.go
+++ b/rpc/wrtc_call_queue_memory.go
@@ -1,3 +1,4 @@
+// TODO(RSDK-8666): use stoppable workers
 package rpc
 
 import (

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1,5 +1,6 @@
-// TODO(RSDK-8666): use stoppable workers
 package rpc
+
+// TODO(RSDK-8666): use stoppable workers
 
 import (
 	"context"

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -227,9 +227,7 @@ func NewMongoDBWebRTCCallQueue(
 	startOnce := make(chan struct{})
 	var startOnceSync sync.Once
 
-	queue.activeBackgroundWorkers.Add(1) // TODO(RSDK-866): remove
-	utils.ManagedGo(func() {             // TODO(RSDK-866): remove
-		// queue.activeStoppableWorkers.Add(func(ctx context.Context) {
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 		defer queue.csManagerSeq.Add(1) // helpful on panicked restart
 		select {
 		case <-queue.cancelCtx.Done():
@@ -241,7 +239,7 @@ func NewMongoDBWebRTCCallQueue(
 			})
 			queue.subscriptionManager(newState.ChangeStream)
 		}
-	}, queue.activeBackgroundWorkers.Done)
+	})
 
 	select {
 	case <-queue.cancelCtx.Done():

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -215,11 +215,11 @@ func NewMongoDBWebRTCCallQueue(
 		activeAnswerersfunc:   &activeAnswerersfunc,
 	}
 
-	queue.activeBackgroundWorkers.Add(2)                                            // TODO(RSDK-866): remove
+	queue.activeBackgroundWorkers.Add(1)                                            // TODO(RSDK-866): remove
 	utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done) // TODO(RSDK-866): remove
-	utils.ManagedGo(queue.changeStreamManager, queue.activeBackgroundWorkers.Done)  // TODO(RSDK-866): remove
+	//utils.ManagedGo(queue.changeStreamManager, queue.activeBackgroundWorkers.Done)  // TODO(RSDK-866): remove
 	// queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
-	// queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
 
 	// wait for change stream to startup once before we start processing anything
 	// since we need good track of resume tokens / cluster times initially

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -229,7 +229,7 @@ func NewMongoDBWebRTCCallQueue(
 
 	queue.activeBackgroundWorkers.Add(1) // TODO(RSDK-866): remove
 	utils.ManagedGo(func() {             // TODO(RSDK-866): remove
-		//queue.activeStoppableWorkers.Add(func(ctx context.Context) {
+		// queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 		defer queue.csManagerSeq.Add(1) // helpful on panicked restart
 		select {
 		case <-queue.cancelCtx.Done():

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -191,6 +191,7 @@ func NewMongoDBWebRTCCallQueue(
 	}
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
+	activeStoppableWorkers := utils.NewStoppableWorkers(cancelCtx)
 	queue := &mongoDBWebRTCCallQueue{
 		operatorID: operatorID,
 		hostCallerQueueSizeMatchAggStage: bson.D{{"$match", bson.D{
@@ -201,11 +202,12 @@ func NewMongoDBWebRTCCallQueue(
 		hostAnswererQueueSizeMatchAggStage: bson.D{{"$match", bson.D{
 			{"answerer_size", bson.D{{"$gte", maxHostAnswerersSize * 2}}},
 		}}},
-		callsColl:     callsColl,
-		operatorsColl: operatorsColl,
-		cancelCtx:     cancelCtx,
-		cancelFunc:    cancelFunc,
-		logger:        utils.AddFieldsToLogger(logger, "operator_id", operatorID),
+		activeStoppableWorkers: activeStoppableWorkers,
+		callsColl:              callsColl,
+		operatorsColl:          operatorsColl,
+		cancelCtx:              cancelCtx,
+		cancelFunc:             cancelFunc,
+		logger:                 utils.AddFieldsToLogger(logger, "operator_id", operatorID),
 
 		csStateUpdates:        make(chan changeStreamStateUpdate),
 		callExchangeSubs:      map[string]map[*mongodbCallExchange]struct{}{},

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -226,8 +226,7 @@ func NewMongoDBWebRTCCallQueue(
 	startOnce := make(chan struct{})
 	var startOnceSync sync.Once
 
-	queue.activeBackgroundWorkers.Add(1)
-	utils.ManagedGo(func() {
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 		defer queue.csManagerSeq.Add(1) // helpful on panicked restart
 		select {
 		case <-queue.cancelCtx.Done():
@@ -239,7 +238,7 @@ func NewMongoDBWebRTCCallQueue(
 			})
 			queue.subscriptionManager(newState.ChangeStream)
 		}
-	}, queue.activeBackgroundWorkers.Done)
+	})
 
 	select {
 	case <-queue.cancelCtx.Done():

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -215,10 +215,9 @@ func NewMongoDBWebRTCCallQueue(
 		activeAnswerersfunc:   &activeAnswerersfunc,
 	}
 
-	queue.activeBackgroundWorkers.Add(1)                                            // TODO(RSDK-8666): remove
-	utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done) // TODO(RSDK-8666): remove
-	// utils.ManagedGo(queue.changeStreamManager, queue.activeBackgroundWorkers.Done)  // TODO(RSDK-8666): remove
-	// queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
+	// queue.activeBackgroundWorkers.Add(1)                                            // TODO(RSDK-8666): remove
+	// utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done) // TODO(RSDK-8666): remove
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
 	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
 
 	// wait for change stream to startup once before we start processing anything

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -385,15 +385,16 @@ func (queue *mongoDBWebRTCCallQueue) operatorLivenessLoop() {
 			})
 		}
 
-		if _, err := queue.operatorsColl.UpdateOne(queue.activeStoppableWorkers.Context(), bson.D{{webrtcOperatorIDField, queue.operatorID}}, bson.D{
-			{
-				"$set",
-				bson.D{
-					{webrtcOperatorExpireAtField, time.Now().Add(operatorHeartbeatWindow)},
-					{webrtcOperatorHostsField, hostSizes},
+		if _, err := queue.operatorsColl.UpdateOne(queue.activeStoppableWorkers.Context(), bson.D{{webrtcOperatorIDField, queue.operatorID}},
+			bson.D{
+				{
+					"$set",
+					bson.D{
+						{webrtcOperatorExpireAtField, time.Now().Add(operatorHeartbeatWindow)},
+						{webrtcOperatorHostsField, hostSizes},
+					},
 				},
-			},
-		}); err != nil {
+			}); err != nil {
 			if !errors.Is(err, context.Canceled) {
 				queue.logger.Errorw("failed to update operator document for self", "error", err)
 			}

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -215,8 +215,8 @@ func NewMongoDBWebRTCCallQueue(
 		activeAnswerersfunc:   &activeAnswerersfunc,
 	}
 
-	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
-	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
+	queue.activeStoppableWorkers.Add(queue.operatorLivenessLoop)
+	queue.activeStoppableWorkers.Add(queue.changeStreamManager)
 
 	// wait for change stream to startup once before we start processing anything
 	// since we need good track of resume tokens / cluster times initially
@@ -341,7 +341,7 @@ const (
 // The operatorLivenessLoop keeps the distributed queue aware of this operator's existence, in
 // addition to the hosts its listening to calls for, in order to keep track of eventually
 // consistent queue maximums.
-func (queue *mongoDBWebRTCCallQueue) operatorLivenessLoop() {
+func (queue *mongoDBWebRTCCallQueue) operatorLivenessLoop(ctx context.Context) {
 	ticker := time.NewTicker(operatorStateUpdateInterval)
 	defer ticker.Stop()
 	for {
@@ -415,7 +415,7 @@ func (queue *mongoDBWebRTCCallQueue) operatorLivenessLoop() {
 // its query in response to new answerers making themselves available for calls. It helps
 // efficiently swap out new change streams while an old one may still be in use by the subscriptionManager.
 // It also is resilient to crashes so long as the idempotency principles of the queue stay in place.
-func (queue *mongoDBWebRTCCallQueue) changeStreamManager() {
+func (queue *mongoDBWebRTCCallQueue) changeStreamManager(ctx context.Context) {
 	ticker := time.NewTicker(operatorStateUpdateInterval)
 	defer ticker.Stop()
 	defer func() {

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -215,9 +215,9 @@ func NewMongoDBWebRTCCallQueue(
 		activeAnswerersfunc:   &activeAnswerersfunc,
 	}
 
-	queue.activeBackgroundWorkers.Add(1)                                            // TODO(RSDK-866): remove
-	utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done) // TODO(RSDK-866): remove
-	//utils.ManagedGo(queue.changeStreamManager, queue.activeBackgroundWorkers.Done)  // TODO(RSDK-866): remove
+	queue.activeBackgroundWorkers.Add(1)                                            // TODO(RSDK-8666): remove
+	utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done) // TODO(RSDK-8666): remove
+	// utils.ManagedGo(queue.changeStreamManager, queue.activeBackgroundWorkers.Done)  // TODO(RSDK-8666): remove
 	// queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
 	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
 

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -216,9 +216,9 @@ func NewMongoDBWebRTCCallQueue(
 	}
 
 	// TODO(RSDK-8666): using StoppableWorkers is causing a data race
-	// queue.activeBackgroundWorkers.Add(1)
-	// utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done)
-	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
+	queue.activeBackgroundWorkers.Add(1)
+	utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done)
+	// queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
 	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
 
 	// wait for change stream to startup once before we start processing anything

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -216,9 +216,9 @@ func NewMongoDBWebRTCCallQueue(
 	}
 
 	// TODO(RSDK-8666): using StoppableWorkers is causing a data race
-	queue.activeBackgroundWorkers.Add(1)
-	utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done)
-	// queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
+	// queue.activeBackgroundWorkers.Add(1)
+	// utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done)
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
 	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
 
 	// wait for change stream to startup once before we start processing anything

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -926,9 +926,7 @@ func (queue *mongoDBWebRTCCallQueue) SendOfferInit(
 			return true
 		}
 	}
-	queue.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(func() {
-		defer queue.activeBackgroundWorkers.Done()
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 		defer cleanup()
 		defer close(answererResponses)
 

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1256,9 +1256,7 @@ func (queue *mongoDBWebRTCCallQueue) RecvOffer(ctx context.Context, hosts []stri
 	// and trying to connect to each other
 	// as both are doing trickle ice and generating new candidates with SDPs that are being updated in the
 	// table we try each of them as they come in to make a match
-	queue.activeBackgroundWorkers.Add(1)
-	utils.PanicCapturingGo(func() {
-		defer queue.activeBackgroundWorkers.Done()
+	queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 		defer callerDoneCancel()
 		defer cleanup()
 

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -215,9 +215,10 @@ func NewMongoDBWebRTCCallQueue(
 		activeAnswerersfunc:   &activeAnswerersfunc,
 	}
 
-	// queue.activeBackgroundWorkers.Add(1)                                            // TODO(RSDK-8666): remove
-	// utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done) // TODO(RSDK-8666): remove
-	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
+	// TODO(RSDK-8666): using StoppableWorkers is causing a data race
+	queue.activeBackgroundWorkers.Add(1)
+	utils.ManagedGo(queue.operatorLivenessLoop, queue.activeBackgroundWorkers.Done)
+	// queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.operatorLivenessLoop() })
 	queue.activeStoppableWorkers.Add(func(ctx context.Context) { queue.changeStreamManager() })
 
 	// wait for change stream to startup once before we start processing anything

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1217,9 +1217,7 @@ func (queue *mongoDBWebRTCCallQueue) RecvOffer(ctx context.Context, hosts []stri
 			queue.logger.Errorw("error in RecvOffer", "error", errToSet, "id", callReq.ID)
 		}
 		// we assume the number of goroutines is bounded by the gRPC server invoking this method.
-		queue.activeBackgroundWorkers.Add(1)
-		utils.PanicCapturingGo(func() {
-			queue.activeBackgroundWorkers.Done()
+		queue.activeStoppableWorkers.Add(func(ctx context.Context) {
 
 			// we need a dedicated timeout since even if the server is shutting down,
 			// we want to notify other servers immediately, instead of waiting for a timeout.

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -71,6 +71,7 @@ type mongoDBWebRTCCallQueue struct {
 	hostCallerQueueSizeMatchAggStage   bson.D
 	hostAnswererQueueSizeMatchAggStage bson.D
 	activeBackgroundWorkers            sync.WaitGroup
+	activeStoppableWorkers             *utils.StoppableWorkers
 	callsColl                          *mongo.Collection
 	operatorsColl                      *mongo.Collection
 	logger                             utils.ZapCompatibleLogger
@@ -1360,6 +1361,7 @@ func iceCandidateToMongo(i *webrtc.ICECandidateInit) mongodbICECandidate {
 func (queue *mongoDBWebRTCCallQueue) Close() error {
 	queue.cancelFunc()
 	queue.activeBackgroundWorkers.Wait()
+	queue.activeStoppableWorkers.Stop()
 	return nil
 }
 

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1218,7 +1218,6 @@ func (queue *mongoDBWebRTCCallQueue) RecvOffer(ctx context.Context, hosts []stri
 		}
 		// we assume the number of goroutines is bounded by the gRPC server invoking this method.
 		queue.activeStoppableWorkers.Add(func(ctx context.Context) {
-
 			// we need a dedicated timeout since even if the server is shutting down,
 			// we want to notify other servers immediately, instead of waiting for a timeout.
 			updateCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1,3 +1,4 @@
+// TODO(RSDK-8666): use stoppable workers
 package rpc
 
 import (

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -1,5 +1,6 @@
-// TODO(RSDK-8666): use stoppable workers
 package rpc
+
+// TODO(RSDK-8666): use stoppable workers
 
 import (
 	"context"

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -22,8 +22,6 @@ var DefaultWebRTCMaxGRPCCalls = 256
 
 // A webrtcServer translates gRPC frames over WebRTC data channels into gRPC calls.
 type webrtcServer struct {
-	// ctx      context.Context
-	// cancel   context.CancelFunc
 	handlers map[string]handlerFunc
 	services map[string]*serviceInfo
 	logger   utils.ZapCompatibleLogger

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -1,7 +1,5 @@
 package rpc
 
-// TODO(RSDK-8666): use stoppable workers
-
 import (
 	"context"
 	"errors"

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -22,8 +22,8 @@ var DefaultWebRTCMaxGRPCCalls = 256
 
 // A webrtcServer translates gRPC frames over WebRTC data channels into gRPC calls.
 type webrtcServer struct {
-	ctx      context.Context
-	cancel   context.CancelFunc
+	// ctx      context.Context
+	// cancel   context.CancelFunc
 	handlers map[string]handlerFunc
 	services map[string]*serviceInfo
 	logger   utils.ZapCompatibleLogger
@@ -126,15 +126,13 @@ func newWebRTCServerWithInterceptorsAndUnknownStreamHandler(
 		streamInt:         streamInt,
 		unknownStreamDesc: unknownStreamDesc,
 	}
-	srv.ctx, srv.cancel = context.WithCancel(context.Background())
-	srv.processHeadersWorkers = utils.NewStoppableWorkers(srv.ctx)
+	srv.processHeadersWorkers = utils.NewBackgroundStoppableWorkers()
 	return srv
 }
 
 // Stop instructs the server and all handlers to stop. It returns when all handlers
 // are done executing.
 func (srv *webrtcServer) Stop() {
-	srv.cancel()
 	srv.logger.Info("waiting for handlers to complete")
 	srv.processHeadersWorkers.Stop()
 	srv.logger.Info("handlers complete")

--- a/rpc/wrtc_server.go
+++ b/rpc/wrtc_server.go
@@ -1,3 +1,4 @@
+// TODO(RSDK-8666): use stoppable workers
 package rpc
 
 import (

--- a/rpc/wrtc_server_channel.go
+++ b/rpc/wrtc_server_channel.go
@@ -37,7 +37,7 @@ func newWebRTCServerChannel(
 	logger utils.ZapCompatibleLogger,
 ) *webrtcServerChannel {
 	base := newBaseChannel(
-		server.ctx,
+		server.processHeadersWorkers.Context(),
 		peerConn,
 		dataChannel,
 		func() { server.removePeer(peerConn) },

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -272,7 +272,7 @@ func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 
 	// Check if context has errored: underlying server may have been `Stop`ped,
 	// in which case we return.
-	if err := s.ch.server.ctx.Err(); err != nil {
+	if err := s.ch.server.processHeadersWorkers.Context().Err(); err != nil {
 		return
 	}
 

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -285,7 +285,7 @@ func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 	}
 
 	s.headersReceived = true
-	utils.PanicCapturingGo(func() {
+	s.ch.server.processHeadersWorkers.Add(func(ctx context.Context) {
 		defer func() {
 			<-s.ch.server.callTickets // return a ticket
 		}()

--- a/rpc/wrtc_server_stream.go
+++ b/rpc/wrtc_server_stream.go
@@ -270,12 +270,6 @@ func (s *webrtcServerStream) processHeaders(headers *webrtcpb.RequestHeaders) {
 
 	s.ch.server.counters.HeadersProcessed.Add(1)
 
-	// Check if context has errored: underlying server may have been `Stop`ped,
-	// in which case we return.
-	if err := s.ch.server.processHeadersWorkers.Context().Err(); err != nil {
-		return
-	}
-
 	// take a ticket
 	select {
 	case s.ch.server.callTickets <- struct{}{}:


### PR DESCRIPTION
_**WIP**_

This PR is a continuation of #402 re: [this](https://github.com/viamrobotics/goutils/pull/402#pullrequestreview-2553454718) comment from @benjirewis (i.e., it updates `rpc/wrtc_server.go`, `rpc/wrtc_call_queue_memory.go`, and `rpc/wrtc_call_queue_mongodb.go` to use `StoppableWorkers` - and some other files as a side effect).

- [x] rpc/wrtc_server.go
- [x] rpc/wrtc_call_queue_memory.go
- [x] rpc/wrtc_call_queue_mongodb.go