### PR TITLE
Add back missing fields in server logs and remove double log

### DIFF
--- a/rpc/server_interceptors.go
+++ b/rpc/server_interceptors.go
@@ -11,7 +11,6 @@ import (
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -157,7 +156,7 @@ func serverCallFields(ctx context.Context, fullMethodString string, start time.T
 	var f []any
 	f = append(f, "grpc.start_time", start.UTC().Format(iso8601))
 	if d, ok := ctx.Deadline(); ok {
-		f = append(f, zap.String("grpc.request.deadline", d.UTC().Format(iso8601)))
+		f = append(f, "grpc.request.deadline", d.UTC().Format(iso8601))
 	}
 	service := path.Dir(fullMethodString)[1:]
 	method := path.Base(fullMethodString)
@@ -166,5 +165,5 @@ func serverCallFields(ctx context.Context, fullMethodString string, start time.T
 		"system", "grpc",
 		"grpc.service", service,
 		"grpc.method", method,
-	})
+	}...)
 }


### PR DESCRIPTION
used to look like

```
2025-01-24T17:53:02.436Z        ERROR   rdk.networking  goutils-cheuk/logger.go:161  finished unary call with code InvalidArgument   {"error":"rpc error: code = InvalidArgument desc = host not preconfigured","grpc.code":"InvalidArgument","grpc.time_ms":0.078,"grpc.start_time":"2025-01-24T17:53:02.436Z"}
```
and now it looks like
```
2025-01-24T17:57:09.728Z        ERROR   rdk.networking  goutils-cheuk/logger.go:161  finished unary call with code InvalidArgument   {"error":"rpc error: code = InvalidArgument desc = host not preconfigured","grpc.code":"InvalidArgument","grpc.time_ms":0.091,"grpc.start_time":"2025-01-24T17:57:09.727Z","grpc.request.deadline":"2025-01-24T17:57:19.722Z","span.kind":"server","system":"grpc","grpc.service":"proto.rpc.webrtc.v1.SignalingService","grpc.method":"OptionalWebRTCConfig"}
```

also removed the double logs. We can consider shifting context.Canceled/io.ClosedPipe errors down to debug to mimic the existing filtering, but we can decide on that later