### PR TITLE
[RSDK-8293] Pass in Connection to Answerer in WebRTC Server

### DIFF
--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -66,7 +66,7 @@ type dialOptions struct {
 	streamInterceptor grpc.StreamClientInterceptor
 
 	// conn can be used to force the webrtcSignalingAnswerer to use a preexisting connection instead of dialing and managing its own.
-	externalSignalerConn ClientConn
+	externalSignalingConn ClientConn
 }
 
 // DialMulticastDNSOptions dictate any special settings to apply while dialing via mDNS.
@@ -284,9 +284,9 @@ func WithForceDirectGRPC() DialOption {
 	})
 }
 
-// WithConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage a connection.
-func WithConn(externalSignalerConn ClientConn) DialOption {
+// WithExternalSignalingConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage a connection.
+func WithExternalSignalingConn(externalSignalingConn ClientConn) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.externalSignalerConn = externalSignalerConn
+		o.externalSignalingConn = externalSignalingConn
 	})
 }

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -66,7 +66,7 @@ type dialOptions struct {
 	streamInterceptor grpc.StreamClientInterceptor
 
 	// conn can be used to force the webrtcSignalingAnswerer to use a preexisting connection instead of dialing and managing its own.
-	conn ClientConn
+	externalSignalerConn ClientConn
 }
 
 // DialMulticastDNSOptions dictate any special settings to apply while dialing via mDNS.
@@ -285,8 +285,8 @@ func WithForceDirectGRPC() DialOption {
 }
 
 // WithConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage a connection.
-func WithConn(conn ClientConn) DialOption {
+func WithConn(externalSignalerConn ClientConn) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.conn = conn
+		o.externalSignalerConn = externalSignalerConn
 	})
 }

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -66,7 +66,7 @@ type dialOptions struct {
 	streamInterceptor grpc.StreamClientInterceptor
 
 	// conn can be used to force the webrtcSignalingAnswerer to use a preexisting connection instead of dialing and managing its own.
-	externalSignalingConn ClientConn
+	signalingConn ClientConn
 }
 
 // DialMulticastDNSOptions dictate any special settings to apply while dialing via mDNS.
@@ -286,8 +286,8 @@ func WithForceDirectGRPC() DialOption {
 
 // WithExternalSignalingConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage
 // a connection.
-func WithExternalSignalingConn(externalSignalingConn ClientConn) DialOption {
+func withSignalingConn(signalingConn ClientConn) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.externalSignalingConn = externalSignalingConn
+		o.signalingConn = signalingConn
 	})
 }

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -65,7 +65,7 @@ type dialOptions struct {
 	unaryInterceptor  grpc.UnaryClientInterceptor
 	streamInterceptor grpc.StreamClientInterceptor
 
-	// conn can be used to force the webrtcSignalingAnswerer to use a preexisting connection instead of dialing and managing its own.
+	// signalingConn can be used to force the webrtcSignalingAnswerer to use a preexisting connection instead of dialing and managing its own.
 	signalingConn ClientConn
 }
 
@@ -268,7 +268,10 @@ func WithUnaryClientInterceptor(interceptor grpc.UnaryClientInterceptor) DialOpt
 func WithStreamClientInterceptor(interceptor grpc.StreamClientInterceptor) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		if o.streamInterceptor != nil {
-			o.streamInterceptor = grpc_middleware.ChainStreamClient(o.streamInterceptor, interceptor)
+			o.streamInterceptor = grpc_middleware.ChainStreamClient(
+				o.streamInterceptor,
+				interceptor,
+			)
 		} else {
 			o.streamInterceptor = interceptor
 		}

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -284,7 +284,8 @@ func WithForceDirectGRPC() DialOption {
 	})
 }
 
-// WithExternalSignalingConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage a connection.
+// WithExternalSignalingConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage
+// a connection.
 func WithExternalSignalingConn(externalSignalingConn ClientConn) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.externalSignalingConn = externalSignalingConn

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -64,6 +64,9 @@ type dialOptions struct {
 	// interceptors
 	unaryInterceptor  grpc.UnaryClientInterceptor
 	streamInterceptor grpc.StreamClientInterceptor
+
+	// conn can be used to force the webrtcSignalingAnswerer to use a preexisting connection instead of dialing and managing its own.
+	conn ClientConn
 }
 
 // DialMulticastDNSOptions dictate any special settings to apply while dialing via mDNS.

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -284,7 +284,7 @@ func WithForceDirectGRPC() DialOption {
 	})
 }
 
-// WithExternalSignalingConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage
+// WithSignalingConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage
 // a connection.
 func WithSignalingConn(signalingConn ClientConn) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -284,7 +284,7 @@ func WithForceDirectGRPC() DialOption {
 	})
 }
 
-// WithConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage a connection
+// WithConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage a connection.
 func WithConn(conn ClientConn) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.conn = conn

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -283,3 +283,10 @@ func WithForceDirectGRPC() DialOption {
 		o.disableDirect = false
 	})
 }
+
+// WithConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage a connection
+func WithConn(conn ClientConn) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.conn = conn
+	})
+}

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -286,7 +286,7 @@ func WithForceDirectGRPC() DialOption {
 
 // WithExternalSignalingConn provides a preexisting connection to use. This option forces the webrtcSignalingAnswerer to not dial or manage
 // a connection.
-func withSignalingConn(signalingConn ClientConn) DialOption {
+func WithSignalingConn(signalingConn ClientConn) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.signalingConn = signalingConn
 	})

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -656,6 +656,8 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 			if !sOpts.unauthenticated {
 				answererDialOpts = append(answererDialOpts, WithEntityCredentials(server.internalUUID, server.internalCreds))
 			}
+			// this answerer uses an internal signaling server that runs locally as a separate process and so does not get a shared
+			// connection to App as a dial option
 			server.webrtcAnswerers = append(server.webrtcAnswerers, newWebRTCSignalingAnswerer(
 				address,
 				internalSignalingHosts,

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -270,9 +270,11 @@ func (ans *webrtcSignalingAnswerer) Stop() {
 	ans.connMu.Lock()
 	defer ans.connMu.Unlock()
 	if ans.conn != nil {
-		err := ans.conn.Close()
-		if isNetworkError(err) {
-			ans.logger.Errorw("error closing signaling connection", "error", err)
+		if !ans.sharedConn {
+			err := ans.conn.Close()
+			if isNetworkError(err) {
+				ans.logger.Errorw("error closing signaling connection", "error", err)
+			}
 		}
 		ans.conn = nil
 	}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -80,8 +80,8 @@ func newWebRTCSignalingAnswerer(
 		bgWorkers:    bgWorkers,
 		logger:       logger,
 	}
-	if options.externalSignalingConn != nil {
-		ans.conn = options.externalSignalingConn
+	if options.signalingConn != nil {
+		ans.conn = options.signalingConn
 		ans.sharedConn = true
 	}
 	return ans

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -42,7 +42,7 @@ type webrtcSignalingAnswerer struct {
 	// to realize it's been disconnected quickly and start reconnecting. conn can be set to a pre-existing gRPC connection that's used by
 	// other consumers via a dial option. In this scenario, sharedConn will be true, and the answerer will not attempt to establish a new
 	// connection to the signaling server. If this option is not set, the answerer will oversee the lifecycle of its own connection by
-	// continuosly dialing in the background until a successful connection emerges and closing said connection when done. In the shared
+	// continuously dialing in the background until a successful connection emerges and closing said connection when done. In the shared
 	// connection case, the answerer will not close the connection.	connMu     sync.Mutex
 	connMu     sync.Mutex
 	conn       ClientConn

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -79,8 +79,8 @@ func newWebRTCSignalingAnswerer(
 		bgWorkers:    bgWorkers,
 		logger:       logger,
 	}
-	if options.externalSignalingConn != nil {
-		ans.conn = options.externalSignalingConn
+	if options.signalingConn != nil {
+		ans.conn = options.signalingConn
 		ans.sharedConn = true
 	}
 	return ans

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -76,8 +76,8 @@ func newWebRTCSignalingAnswerer(
 		bgWorkers:    bgWorkers,
 		logger:       logger,
 	}
-	if options.conn != nil {
-		ans.conn = options.conn
+	if options.externalSignalingConn != nil {
+		ans.conn = options.externalSignalingConn
 		ans.sharedConn = true
 	}
 	return ans

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -44,6 +44,7 @@ type webrtcSignalingAnswerer struct {
 	// connection to the signaling server. If this option is not set, the answerer will oversee the lifecycle of its own connection by
 	// continuosly dialing in the background until a successful connection emerges and closing said connection when done. In the shared
 	// connection case, the answerer will not close the connection.	connMu     sync.Mutex
+	connMu     sync.Mutex
 	conn       ClientConn
 	sharedConn bool
 


### PR DESCRIPTION
This PR allows for a preexisting connection to be passed to the constructor for our WebRTC signaling answerer to use via a dial option.

**Testing**

4 cases:

@cheukt and I ran the first tests by running viam-server on my laptop while connected to the Viam-Guest WiFi. He ran a client Go script on his laptop connected to the Viam WiFi. The client was able to connect to the robot via WebRTC both times.

1. client on different network can connect if rdk starts up offline then online (force webrtc option)
2. client on different network can connect if rdk starts up online then goes offline then online (force webrtc option)
3. client on same network can connect if rdk starts up offline then online (force webrtc option, but using the internal signaler)
<img width="1470" alt="offline-online-internal" src="https://github.com/user-attachments/assets/ba3c682c-b6a5-4f5e-b2e5-dd12138d4c72" />
4. client on same network can connect if rdk starts up online then goes offline then online (force webrtc option, but using the internal signaler)
<img width="1470" alt="online-offline-internal" src="https://github.com/user-attachments/assets/c6e60826-713e-42c1-bec1-e1eba6536388" />