### PR TITLE
Add error-retrying wrapper, RetryNTimes

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -24,7 +24,7 @@ func (e *RetryError) Unwrap() error {
 
 // RetryNTimesWithSleep will run `fallibleFunc` `retryAttempts` times before failing with the last error it got from the function.
 // If `retryableErrors` is supplied, only those errors will be retried.
-// It will wait for `retryDelay` between attempts
+// It will wait for `retryDelay` between attempts.
 func RetryNTimesWithSleep[T any](
 	ctx context.Context,
 	fallibleFunc func() (T, error),

--- a/retry.go
+++ b/retry.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 )
 
 // RetryError is emitted by RetryNTimes if all the attempts fail. It unwraps to the last error from retrying.
@@ -22,8 +24,16 @@ func (e *RetryError) Unwrap() error {
 
 // RetryNTimes will run `fallibleFunc` `retryAttempts` times before failing with the last error it got from the function.
 // If `retryableErrors` is supplied, only those errors will be retried.
-func RetryNTimes[T any](fallibleFunc func() (T, error), retryAttempts int, retryableErrors ...error) (T, error) {
+// It will wait for `retryDelay` between attempts
+func RetryNTimesWithSleep[T any](
+	ctx context.Context,
+	fallibleFunc func() (T, error),
+	retryAttempts int,
+	retryDelay time.Duration,
+	retryableErrors ...error,
+) (T, error) {
 	var lastError error
+	var emptyT T
 
 	for numRetries := 0; numRetries < retryAttempts; numRetries++ {
 		val, err := fallibleFunc()
@@ -31,9 +41,33 @@ func RetryNTimes[T any](fallibleFunc func() (T, error), retryAttempts int, retry
 			!slices.ContainsFunc(retryableErrors, func(target error) bool { return errors.Is(err, target) })) {
 			return val, err
 		}
+
 		lastError = err
+
+		select {
+		case <-ctx.Done():
+			return emptyT, ctx.Err()
+		case <-time.After(retryDelay):
+		}
 	}
 
-	var emptyT T
 	return emptyT, &RetryError{attempts: retryAttempts, inner: lastError}
+}
+
+// RetryNTimes will run `fallibleFunc` `retryAttempts` times before failing with the last error it got from the function.
+// If `retryableErrors` is supplied, only those errors will be retried.
+// It will wait 1 second between attempts. Use RetryNTimesWithSleep to change this.
+func RetryNTimes[T any](
+	ctx context.Context,
+	fallibleFunc func() (T, error),
+	retryAttempts int,
+	retryableErrors ...error,
+) (T, error) {
+	return RetryNTimesWithSleep(
+		ctx,
+		fallibleFunc,
+		retryAttempts,
+		time.Second,
+		retryableErrors...,
+	)
 }

--- a/retry.go
+++ b/retry.go
@@ -27,8 +27,8 @@ func RetryNTimes[T any](fallibleFunc func() (T, error), retryAttempts int, retry
 
 	for numRetries := 0; numRetries < retryAttempts; numRetries++ {
 		val, err := fallibleFunc()
-		if err == nil || len(retryableErrors) != 0 &&
-			!slices.ContainsFunc(retryableErrors, func(target error) bool { return errors.Is(err, target) }) {
+		if err == nil || (len(retryableErrors) != 0 &&
+			!slices.ContainsFunc(retryableErrors, func(target error) bool { return errors.Is(err, target) })) {
 			return val, err
 		}
 		lastError = err

--- a/retry.go
+++ b/retry.go
@@ -22,7 +22,7 @@ func (e *RetryError) Unwrap() error {
 	return e.inner
 }
 
-// RetryNTimes will run `fallibleFunc` `retryAttempts` times before failing with the last error it got from the function.
+// RetryNTimesWithSleep will run `fallibleFunc` `retryAttempts` times before failing with the last error it got from the function.
 // If `retryableErrors` is supplied, only those errors will be retried.
 // It will wait for `retryDelay` between attempts
 func RetryNTimesWithSleep[T any](

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+)
+
+type RetryError struct {
+	inner    error
+	attempts int
+}
+
+func (e *RetryError) Error() string {
+	return fmt.Sprintf("failed after %d retry attempts: %v", e.attempts, e.inner)
+}
+
+func (e *RetryError) Unwrap() error {
+	return e.inner
+}
+
+// RetryNTimes will run `toRun` `retryAttempts` times before failing with the last error it got from the function.
+// If `retryableErrors` is supplied, only those errors will be retried.
+func RetryNTimes[T any](toRun func() (T, error), retryAttempts int, retryableErrors ...error) (T, error) {
+	var lastError error
+
+	for numRetries := 0; numRetries < retryAttempts; numRetries++ {
+		val, err := toRun()
+		if err == nil || len(retryableErrors) != 0 &&
+			!slices.ContainsFunc(retryableErrors, func(target error) bool { return errors.Is(err, target) }) {
+			return val, err
+		}
+		lastError = err
+	}
+
+	var emptyT T
+	return emptyT, &RetryError{attempts: retryAttempts, inner: lastError}
+}

--- a/retry.go
+++ b/retry.go
@@ -35,7 +35,7 @@ func RetryNTimesWithSleep[T any](
 	var lastError error
 	var emptyT T
 
-	for numRetries := 0; numRetries < retryAttempts; numRetries++ {
+	for range retryAttempts {
 		val, err := fallibleFunc()
 		if err == nil || (len(retryableErrors) != 0 &&
 			!slices.ContainsFunc(retryableErrors, func(target error) bool { return errors.Is(err, target) })) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestRetryNTimes(t *testing.T) {
+	t.Run("success on first try", func(t *testing.T) {
+		attempts := 0
+		result, err := RetryNTimes(func() (string, error) {
+			attempts++
+			return "success", nil
+		}, 3)
+
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, result, test.ShouldEqual, "success")
+		test.That(t, attempts, test.ShouldEqual, 1)
+	})
+
+	t.Run("success after retries", func(t *testing.T) {
+		attempts := 0
+		result, err := RetryNTimes(func() (string, error) {
+			attempts++
+			if attempts < 3 {
+				return "", errors.New("temporary error")
+			}
+			return "success", nil
+		}, 3)
+
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, result, test.ShouldEqual, "success")
+		test.That(t, attempts, test.ShouldEqual, 3)
+	})
+
+	t.Run("failure after all retries", func(t *testing.T) {
+		attempts := 0
+		result, err := RetryNTimes(func() (string, error) {
+			attempts++
+			return "", errors.New("persistent error")
+		}, 3)
+
+		test.That(t, err, test.ShouldNotBeNil)
+		var retryErr *RetryError
+		test.That(t, errors.As(err, &retryErr), test.ShouldBeTrue)
+		test.That(t, retryErr.Error(), test.ShouldContainSubstring, "failed after 3 retry attempts")
+		test.That(t, retryErr.Unwrap().Error(), test.ShouldEqual, "persistent error")
+		test.That(t, result, test.ShouldEqual, "")
+		test.That(t, attempts, test.ShouldEqual, 3)
+	})
+
+	t.Run("retry only specified errors", func(t *testing.T) {
+		retryableErr := errors.New("retryable")
+		nonRetryableErr := errors.New("non-retryable")
+
+		attempts := 0
+		result, err := RetryNTimes(func() (string, error) {
+			attempts++
+			if attempts == 1 {
+				return "", retryableErr
+			}
+			return "", nonRetryableErr
+		}, 3, retryableErr)
+
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, errors.Is(err, nonRetryableErr), test.ShouldBeTrue)
+		test.That(t, result, test.ShouldEqual, "")
+		test.That(t, attempts, test.ShouldEqual, 2)
+	})
+
+	t.Run("multiple retryable errors", func(t *testing.T) {
+		err1 := errors.New("error1")
+		err2 := errors.New("error2")
+		nonRetryableErr := errors.New("non-retryable")
+
+		attempts := 0
+		result, err := RetryNTimes(func() (string, error) {
+			attempts++
+			switch attempts {
+			case 1:
+				return "", err1
+			case 2:
+				return "", err2
+			default:
+				return "", nonRetryableErr
+			}
+		}, 3, err1, err2)
+
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, errors.Is(err, nonRetryableErr), test.ShouldBeTrue)
+		test.That(t, result, test.ShouldEqual, "")
+		test.That(t, attempts, test.ShouldEqual, 3)
+	})
+
+	t.Run("zero retries", func(t *testing.T) {
+		attempts := 0
+		result, err := RetryNTimes(func() (string, error) {
+			attempts++
+			return "", errors.New("error")
+		}, 0)
+
+		test.That(t, err, test.ShouldNotBeNil)
+		var retryErr *RetryError
+		test.That(t, errors.As(err, &retryErr), test.ShouldBeTrue)
+		test.That(t, retryErr.Error(), test.ShouldContainSubstring, "failed after 0 retry attempts")
+		test.That(t, result, test.ShouldEqual, "")
+		test.That(t, attempts, test.ShouldEqual, 0)
+	})
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -45,7 +45,6 @@ func TestRetryNTimes(t *testing.T) {
 			return "", errors.New("persistent error")
 		}, 3, 0)
 
-		test.That(t, err, test.ShouldNotBeNil)
 		var retryErr *RetryError
 		test.That(t, errors.As(err, &retryErr), test.ShouldBeTrue)
 		test.That(t, retryErr.Error(), test.ShouldContainSubstring, "failed after 3 retry attempts")
@@ -59,7 +58,7 @@ func TestRetryNTimes(t *testing.T) {
 		nonRetryableErr := errors.New("non-retryable")
 
 		attempts := 0
-		result, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
+		_, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
 			attempts++
 			if attempts == 1 {
 				return "", retryableErr
@@ -67,9 +66,7 @@ func TestRetryNTimes(t *testing.T) {
 			return "", nonRetryableErr
 		}, 3, 0, retryableErr)
 
-		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, errors.Is(err, nonRetryableErr), test.ShouldBeTrue)
-		test.That(t, result, test.ShouldEqual, "")
 		test.That(t, attempts, test.ShouldEqual, 2)
 	})
 
@@ -79,7 +76,7 @@ func TestRetryNTimes(t *testing.T) {
 		nonRetryableErr := errors.New("non-retryable")
 
 		attempts := 0
-		result, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
+		_, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
 			attempts++
 			switch attempts {
 			case 1:
@@ -91,40 +88,34 @@ func TestRetryNTimes(t *testing.T) {
 			}
 		}, 3, 0, err1, err2)
 
-		test.That(t, err, test.ShouldNotBeNil)
 		test.That(t, errors.Is(err, nonRetryableErr), test.ShouldBeTrue)
-		test.That(t, result, test.ShouldEqual, "")
 		test.That(t, attempts, test.ShouldEqual, 3)
 	})
 
 	t.Run("zero retries", func(t *testing.T) {
 		attempts := 0
-		result, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
+		_, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
 			attempts++
 			return "", errors.New("error")
 		}, 0, 0)
 
-		test.That(t, err, test.ShouldNotBeNil)
 		var retryErr *RetryError
 		test.That(t, errors.As(err, &retryErr), test.ShouldBeTrue)
 		test.That(t, retryErr.Error(), test.ShouldContainSubstring, "failed after 0 retry attempts")
-		test.That(t, result, test.ShouldEqual, "")
 		test.That(t, attempts, test.ShouldEqual, 0)
 	})
 
 	t.Run("retry with sleep", func(t *testing.T) {
 		startTime := time.Now()
 		attempts := 0
-		result, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
+		_, err := RetryNTimesWithSleep(ctxBg, func() (string, error) {
 			attempts++
 			return "", errors.New("error")
 		}, 3, 500*time.Millisecond)
 
-		test.That(t, err, test.ShouldNotBeNil)
 		var retryErr *RetryError
 		test.That(t, errors.As(err, &retryErr), test.ShouldBeTrue)
 		test.That(t, retryErr.Error(), test.ShouldContainSubstring, "failed after 3 retry attempts")
-		test.That(t, result, test.ShouldEqual, "")
 		test.That(t, time.Since(startTime), test.ShouldBeGreaterThan, 1400*time.Millisecond)
 	})
 


### PR DESCRIPTION
Talked with Benji offline -- he did not know of any wrapper that does this. I suspect we have duplicates of this littered around our codebase.

Needs tests. Will add tests after I confirm that:
a) We want to do this
b) This doesn't already exist somewhere in our codebase or in golang

I didn't put too much time into this. If we don't like this, I'll just implement retires as a one-off around my function in app.