### PR TITLE
RSDK-9990- Expose SOCKS proxy as fallback dialer

### DIFF
--- a/rpc/const.go
+++ b/rpc/const.go
@@ -13,4 +13,8 @@ var (
 	// proxies to indicate the address through which to route all network traffic
 	// via SOCKS5.
 	SocksProxyEnvVar = "SOCKS_PROXY"
+
+	// OnlySocksProxyEnvVar is the name of an environment variable used if all network
+	// traffic should be done through SOCKS5.
+	OnlySocksProxyEnvVar = "ONLY_SOCKS_PROXY"
 )

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -282,6 +282,7 @@ func SocksProxyFallbackDialContext(
 			return conn, err
 		}
 
+		// the block below heavily references https://go.dev/src/net/dial.go#L585
 		type dialResult struct {
 			net.Conn
 			error
@@ -316,6 +317,7 @@ func SocksProxyFallbackDialContext(
 		defer primaryCancel()
 		wg.Add(1)
 		primaryDial := func(ctx context.Context) (net.Conn, error) {
+			// create a zero-valued net.Dialer to use net.Dialer's default DialContext method
 			var zeroDialer net.Dialer
 			return zeroDialer.DialContext(ctx, network, addr)
 		}
@@ -356,6 +358,8 @@ func SocksProxyFallbackDialContext(
 				} else {
 					fallback = res
 				}
+				// if both primary and fallback are done with errors, this means neither connection attempt succeeded.
+				// return the error from the primary dial attempt in that case.
 				if primary.done && fallback.done {
 					return nil, primary.error
 				}

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -254,9 +254,7 @@ func socksProxyDialContext(ctx context.Context, network, proxyAddr, addr string)
 // which will allow dialers to use the default DialContext.
 // If SocksProxyEnvVar is set, it will prioritize a connection made without a proxy but will fall back to a SOCKS proxy connection.
 func SocksProxyFallbackDialContext(
-	ctx context.Context,
-	network, addr string,
-	logger utils.ZapCompatibleLogger,
+	addr string, logger utils.ZapCompatibleLogger,
 ) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	// Use SOCKS proxy from environment as gRPC proxy dialer. Do not use SOCKS proxy if trying to connect to a local address.
 	localAddr := strings.HasPrefix(addr, "[::]") || strings.HasPrefix(addr, "localhost") || strings.HasPrefix(addr, "unix")
@@ -386,10 +384,10 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 	// if the returned function is not nil.
 	//
 	// use "tcp" since gRPC uses HTTP/2, which is built on top of TCP.
-	socksProxydialContext := SocksProxyFallbackDialContext(ctx, "tcp", address, logger)
-	if socksProxydialContext != nil {
+	socksProxyDialContext := SocksProxyFallbackDialContext(address, logger)
+	if socksProxyDialContext != nil {
 		dialOpts = append(dialOpts, grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-			return socksProxydialContext(ctx, "tcp", addr)
+			return socksProxyDialContext(ctx, "tcp", addr)
 		}))
 	}
 

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -345,7 +345,7 @@ func SocksProxyFallbackDialContext(
 			case res := <-results:
 				if res.error == nil {
 					if res.primary {
-						logger.Infow("connected without SOCKS proxy")
+						logger.Infow("connected with ethernet/wifi")
 					} else {
 						logger.Infow("connected with SOCKS proxy")
 					}

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -329,6 +329,11 @@ func SocksProxyFallbackDialContext(
 		// to be called as this function exits, which will cancel the ongoing SOCKS proxy if it is still running.
 		fallbackCtx, fallbackCancel := context.WithCancel(ctx)
 		defer fallbackCancel()
+
+		// a for loop is used here so that we wait on both results and the fallback timer at the same time.
+		// if the timer expires, we should start the fallback dial and then wait for results.
+		// if the results channel receives a message, the message should be processed and either return
+		// or continue waiting (and reset the timer if it hasn't already expired).
 		for {
 			select {
 			case <-fallbackTimer.C:


### PR DESCRIPTION
this change will make SOCKS proxy a fallback option (if SocksProxyEnvVar is specified), but will not actively replace a connection if it is already established. If OnlySocksProxyEnvVar is specified, only the SOCKS connection is used.

It adds a small delay to the SOCKs dialer as a way to prioritize a connection made without the SOCKS dialer.

Conceptually, pretty similar to our Dial code and it borrows heavily from the net.DialContext code.

tested a few scenarios:
* only SOCKS initially, then a network blip and turn on both phone proxy and wifi (wifi connected in the end)
* only wifi initially, then a network blip and turn on both phone proxy  and wifi (wifi connected in the end)
* wifi and SOCKS initially, then a network blip and only turn on phone proxy (SOCKS connected in the end)
* wifi and SOCKS initially, then a network blip and only turn on wifi (wifi connected in the end)

cc: @dgottlieb if interested