### PR TITLE
RSDK-10229 Add extra context check to RetryNTimes

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -44,6 +44,10 @@ func RetryNTimesWithSleep[T any](
 
 		lastError = err
 
+		if ctx.Err() != nil {
+			return emptyT, ctx.Err()
+		}
+
 		select {
 		case <-ctx.Done():
 			return emptyT, ctx.Err()


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-10229

`TestRetryNTimes/retry_with_context_cancelation` relied on `context.Canceled` consistently bubbling up as the error on the Nth retry when the N-1th caused a context cancelation. Without the check I added, the select on (now) L51 could randomly select `<-time.After(retryDelay)` despite `<-ctx.Done()` also being ready. Caused the test to fail ~10% of the time.

Mostly a testing fix, but _slightly_ better to return a context error without starting the loop again whenever one is available _before_ the `select`.