### PR TITLE
RSDK-10407: Only send raw IP addresses for ICE host candidates.

### DIFF
--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -45,7 +45,7 @@ var DefaultWebRTCConfiguration = webrtc.Configuration{
 	ICEServers: DefaultICEServers,
 }
 
-func newWebRTCAPI(isClient bool, logger utils.ZapCompatibleLogger) (*webrtc.API, error) {
+func newWebRTCAPI(logger utils.ZapCompatibleLogger) (*webrtc.API, error) {
 	m := webrtc.MediaEngine{}
 	if err := m.RegisterDefaultCodecs(); err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func newWebRTCAPI(isClient bool, logger utils.ZapCompatibleLogger) (*webrtc.API,
 	//
 	// However, we prefer to send a LAN IP as a candidate rather than `<uuid>.local`. When using the
 	// ICE mdns "gather" option, it can generate candidates multiple `host` candidates. For example,
-	// each a machine may have a network interace associated with each of the following IPs:
+	// each a machine may have a network interacted associated with each of the following IPs:
 	// - 127.0.0.1
 	// - 192.168.2.1
 	// - 10.1.4.100
@@ -207,7 +207,7 @@ func newPeerConnectionForClient(
 	disableTrickle bool,
 	logger utils.ZapCompatibleLogger,
 ) (*webrtc.PeerConnection, *webrtc.DataChannel, error) {
-	webAPI, err := newWebRTCAPI(true, logger)
+	webAPI, err := newWebRTCAPI(logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -279,7 +279,7 @@ func newPeerConnectionForServer(
 	disableTrickle bool,
 	logger utils.ZapCompatibleLogger,
 ) (*webrtc.PeerConnection, *webrtc.DataChannel, error) {
-	webAPI, err := newWebRTCAPI(false, logger)
+	webAPI, err := newWebRTCAPI(logger)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Rather than having clients generate an mdns mapping.

I think this a good change (remove non-default behaviors for things we can't justify) in general. I believe* this will also solve the user problem, but I expect that will need more field testing. Which I think will be easier with an official release.

This patch certainly fixed the symptom where before we'd have multiple candidate pair options:
```
udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:47022 <-> (remote) udp4 host 192.168.2.4:57604
udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:50598 <-> (remote) udp4 host 192.168.2.4:57604
udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:51948 <-> (remote) udp4 host 192.168.2.4:57604
udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:50677 <-> (remote) udp4 host 192.168.2.4:57604
```

where each of those hosts (from the client perspective) were actually:
```
udp4 host 127.0.0.1:47022 <-> (remote) udp4 host 192.168.2.4:57604
udp4 host 192.168.2.1:50598 <-> (remote) udp4 host 192.168.2.4:57604
udp4 host 10.1.8.60:51948 <-> (remote) udp4 host 192.168.2.4:57604
udp4 host 169.254.14.173:50677 <-> (remote) udp4 host 192.168.2.4:57604
```

But from the "server" perspective, it would get:
```
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:47022
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:50598
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:51948
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host aa8f9b3e-ebac-4d2f-89ba-18b1b3b366f5.local:50677
```

Which would be fine if it resolved that to:
```
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 127.0.0.1:47022
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 192.168.2.1:50598
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 10.1.8.60:51948
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 169.254.14.173:50677
```

But in reality, it's only getting one IP from the mdns resolution and (in the bad case) can be trying:
```
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 169.254.14.173:47022
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 169.254.14.173:50598
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 169.254.14.173:51948
udp4 host 192.168.2.4:57604 <-> (remote) udp4 host 169.254.14.173:50677
```
where the 169 address is (in the bad case) unreachable from the 192 interface.