### PR TITLE
Prettify connection establishment success and failure logs

### DIFF
--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -112,23 +112,20 @@ func newBaseChannel(
 			connIDMu.Lock()
 			connID = connInfo.ID
 			connIDMu.Unlock()
-			connectionStateChangedLogFields := []interface{}{
-				"conn_id", connInfo.ID,
-				"conn_local_candidates", connInfo.LocalCandidates,
-				"conn_remote_candidates", connInfo.RemoteCandidates,
-			}
 			if hasCandPair {
 				// Use info level when there is a selected candidate pair, as a
 				// connection has been established.
-				connectionStateChangedLogFields = append(connectionStateChangedLogFields,
-					"candidate_pair", candPair.String())
-				logger.Infow("Connection establishment succeeded", connectionStateChangedLogFields...)
+				logger.Infow("Connection establishment succeeded", "conn_id", connInfo.ID, "selected_pair", candPair.String())
+				logger.Infof("ICE Candidates:\n\tLocal:%v\n\tRemote:%v",
+					stringifyCandidates(connInfo.LocalCandidates),
+					stringifyCandidates(connInfo.RemoteCandidates))
 			} else {
 				// Use debug level when there is no selected candidate pair to avoid
 				// noise.
-				connectionStateChangedLogFields = append(connectionStateChangedLogFields,
-					"conn_state", connectionState.String())
-				logger.Debugw("Connection state changed", connectionStateChangedLogFields...)
+				logger.Debugw("Connection state changed", "conn_id", connInfo.ID, "state", connectionState.String())
+				logger.Debugf("ICE Candidates:\n\tLocal:%v\n\tRemote:%v",
+					stringifyCandidates(connInfo.LocalCandidates),
+					stringifyCandidates(connInfo.RemoteCandidates))
 			}
 		}
 	})

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -532,6 +533,23 @@ func ConfigureForRenegotiation(
 type webrtcPeerConnectionStats struct {
 	ID                                string
 	LocalCandidates, RemoteCandidates []iceCandidate
+}
+
+type iceCandidatesToSort []iceCandidate
+
+func (icts iceCandidatesToSort) Len() int           { return len(icts) }
+func (icts iceCandidatesToSort) Swap(i, j int)      { icts[i], icts[j] = icts[j], icts[i] }
+func (icts iceCandidatesToSort) Less(i, j int) bool { return icts[i].FoundAt.Before(icts[j].FoundAt) }
+
+func stringifyCandidates(iceCandidates []iceCandidate) string {
+	// Sort candidates by time found.
+	sort.Sort(iceCandidatesToSort(iceCandidates))
+
+	var ret string
+	for _, ic := range iceCandidates {
+		ret += fmt.Sprintf("\n\t\t%v %v %v", ic.FoundAt.Format(iso8601), ic.CandType, ic.IP)
+	}
+	return ret
 }
 
 type iceCandidate struct {

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -372,10 +372,11 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 				"conn_id", connInfo.ID,
 				"ice_connection_state", iceConnectionState,
 				"ice_gathering_state", iceGatheringState,
-				"conn_local_candidates", connInfo.LocalCandidates,
-				"conn_remote_candidates", connInfo.RemoteCandidates,
-				"candidate_pair", candPairStr,
+				"selected_pair", candPairStr,
 			)
+			aa.logger.Infof("ICE Candidates:\n\tLocal:%v\n\tRemote:%v",
+				stringifyCandidates(connInfo.LocalCandidates),
+				stringifyCandidates(connInfo.RemoteCandidates))
 
 			// Close unhealthy connection.
 			utils.UncheckedError(pc.GracefulClose())


### PR DESCRIPTION
Connection establishment success and failure logs are somewhat difficult to read. Basic indentation and a bit of sorting around the gathered and received candidates could be helpful.