### PR TITLE
adjust deadline forward when system clock is off

### DIFF
--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -250,7 +250,13 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 			var answerCtx context.Context
 			var answerCtxCancel func()
 			if deadline := initStage.Init.GetDeadline(); deadline != nil {
-				answerCtx, answerCtxCancel = context.WithDeadline(ctx, deadline.AsTime())
+				asTime := deadline.AsTime()
+				earliestDeadline := time.Now().Add(5 * time.Second)
+				if asTime.Before(earliestDeadline) {
+					ans.logger.Warnw("updating deadline from received %s to earliest %s", "received", asTime, "earliest", earliestDeadline)
+					asTime = earliestDeadline
+				}
+				answerCtx, answerCtxCancel = context.WithDeadline(ctx, asTime)
 			} else {
 				answerCtx, answerCtxCancel = context.WithTimeout(ctx, getDefaultOfferDeadline())
 			}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -151,7 +151,7 @@ func isNetworkError(err error) bool {
 	return true
 }
 
-// logic for computing actual deadline from server-provided deadline
+// logic for computing actual deadline from server-provided deadline.
 func getDeadline(ctx context.Context, logger utils.ZapCompatibleLogger, initStage *webrtcpb.AnswerRequest_Init) (context.Context, func()) {
 	if deadline := initStage.Init.GetDeadline(); deadline != nil {
 		asTime := deadline.AsTime()

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -255,7 +255,7 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 				answerCtx, answerCtxCancel = context.WithTimeout(ctx, getDefaultOfferDeadline())
 			}
 
-			deadline, _ := ctx.Deadline() // there will always be a deadline
+			deadline, _ := answerCtx.Deadline() // there will always be a deadline
 			connectionStartTime := time.Now()
 			if err = aa.connect(answerCtx); err != nil {
 				answerCtxCancel()

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -253,7 +253,7 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 				asTime := deadline.AsTime()
 				earliestDeadline := time.Now().Add(5 * time.Second)
 				if asTime.Before(earliestDeadline) {
-					ans.logger.Warnw("updating deadline from received %s to earliest %s", "received", asTime.String(), "earliest", earliestDeadline.String())
+					ans.logger.Warnw("updating deadline to be ahead of system clock", "received", asTime.String(), "adjusted", earliestDeadline.String())
 					asTime = earliestDeadline
 				}
 				answerCtx, answerCtxCancel = context.WithDeadline(ctx, asTime)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -255,10 +255,20 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 				answerCtx, answerCtxCancel = context.WithTimeout(ctx, getDefaultOfferDeadline())
 			}
 
+			deadline, _ := ctx.Deadline() // there will always be a deadline
+			connectionStartTime := time.Now()
 			if err = aa.connect(answerCtx); err != nil {
 				answerCtxCancel()
 				// We received an error while trying to connect to a caller/peer.
-				ans.logger.Errorw("error connecting to peer", "error", err)
+				ans.logger.Errorw(
+					"error connecting to peer",
+					"error",
+					err,
+					"connection start time",
+					connectionStartTime.String(),
+					"deadline",
+					deadline.String(),
+				)
 				utils.SelectContextOrWait(ctx, answererReconnectWait)
 			}
 			answerCtxCancel()

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -253,7 +253,7 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 				asTime := deadline.AsTime()
 				earliestDeadline := time.Now().Add(5 * time.Second)
 				if asTime.Before(earliestDeadline) {
-					ans.logger.Warnw("updating deadline from received %s to earliest %s", "received", asTime, "earliest", earliestDeadline)
+					ans.logger.Warnw("updating deadline from received %s to earliest %s", "received", asTime.String(), "earliest", earliestDeadline.String())
 					asTime = earliestDeadline
 				}
 				answerCtx, answerCtxCancel = context.WithDeadline(ctx, asTime)

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -251,7 +251,7 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 			var answerCtxCancel func()
 			if deadline := initStage.Init.GetDeadline(); deadline != nil {
 				asTime := deadline.AsTime()
-				earliestDeadline := time.Now().Add(5 * time.Second)
+				earliestDeadline := time.Now().Add(_defaultOfferDeadline)
 				if asTime.Before(earliestDeadline) {
 					ans.logger.Warnw("updating deadline to be ahead of system clock", "received", asTime.String(), "adjusted", earliestDeadline.String())
 					asTime = earliestDeadline

--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -280,11 +280,11 @@ func TestGetDeadline(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var cancel func()
 			initStage.Init.Deadline = timestamppb.New(time.Now().Add(tc.delta))
-			ctx, cancel = getDeadline(ctx, logger, initStage)
+			ctx, cancel = getDeadline(ctx, logger, initStage) //nolint:fatcontext
 			defer cancel()
 			deadline, ok := ctx.Deadline()
 			test.That(t, ok, test.ShouldBeTrue)
-			test.That(t, deadline.Sub(time.Now()), test.ShouldBeGreaterThan, time.Second*4)
+			test.That(t, time.Until(deadline), test.ShouldBeGreaterThan, time.Second*4)
 		})
 	}
 }

--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -274,7 +274,7 @@ func TestGetDeadline(t *testing.T) {
 	for _, tc := range []testcase{
 		// case 1: default offer deadline
 		{"default", _defaultOfferDeadline},
-		// case 2: simulate a machine with bad system clock, deadline is in the past
+		// case 2: simulate a machine with bad system clock, deadline is less than 5 seconds
 		{"too-soon", time.Second},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What changed
- factor out deadline logic to `getDeadline`, add test
- more detailed logging
## Why
Necessary to establish a connection on a machine with an unsynchronized clock
## Notes
We talked about using default offer deadline -- realized afterwards that because of network latency, we'd seldom be within this threshold. Sticking with 5 seconds for now. I think this logic needs redesign, but for now publishing as-is to patch.