### PR TITLE
RSDK-10611 - Downgrade error log levels

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -152,13 +152,14 @@ func LogFinalLine(logger ZapCompatibleLogger, startTime time.Time, err error, ms
 	}
 	fields = append(fields, "grpc.code", code.String(), "grpc.time_ms", duration)
 	// grpc_zap.DefaultCodeToLevel will only return zap.DebugLevel, zap.InfoLevel, zap.ErrorLevel, zap.WarnLevel
+	// log everything but Warn at Debug level, errors are propagated to callers so not necessary to log.
 	switch level {
 	case zap.DebugLevel:
 		logger.Debugw(msg, fields...)
 	case zap.InfoLevel:
-		logger.Infow(msg, fields...)
+		logger.Debugw(msg, fields...)
 	case zap.ErrorLevel:
-		logger.Errorw(msg, fields...)
+		logger.Debugw(msg, fields...)
 	case zap.WarnLevel, zap.DPanicLevel, zap.PanicLevel, zap.FatalLevel, zapcore.InvalidLevel:
 		logger.Warnw(msg, fields...)
 	}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -117,7 +117,7 @@ func (ans *webrtcSignalingAnswerer) Start() {
 			conn, err := Dial(setupCtx, ans.address, ans.logger, ans.dialOpts...)
 			timeoutCancel()
 			if err != nil {
-				ans.logger.Errorw("error connecting answer client", "error", err)
+				ans.logger.Warnw("error connecting answer client", "error", err)
 				utils.SelectContextOrWait(ctx, answererReconnectWait)
 				continue
 			}
@@ -190,7 +190,7 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 				return
 			}
 			if err := client.CloseSend(); err != nil {
-				ans.logger.Errorw("error closing send side of answering client", "error", err)
+				ans.logger.Warnf("error closing send side of answering client", "error", err)
 			}
 		}()
 		for {
@@ -268,7 +268,7 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 			if err = aa.connect(answerCtx); err != nil {
 				answerCtxCancel()
 				// We received an error while trying to connect to a caller/peer.
-				ans.logger.Errorw(
+				ans.logger.Warnw(
 					"error connecting to peer",
 					"error",
 					err,
@@ -297,7 +297,7 @@ func (ans *webrtcSignalingAnswerer) Stop() {
 		if !ans.sharedConn {
 			err := ans.conn.Close()
 			if isNetworkError(err) {
-				ans.logger.Errorw("error closing signaling connection", "error", err)
+				ans.logger.Warnw("error closing signaling connection", "error", err)
 			}
 		}
 		ans.conn = nil


### PR DESCRIPTION
log grpc completion at debug level and `error connecting to peer` at warn

also preemptively downgraded other logs in rpc/wrtc_signaling_answerer.go