### PR TITLE
RSDK-10615 - extendWebRTCConfig should not return extra empty ICE servers

### DIFF
--- a/rpc/wrtc_signaling.go
+++ b/rpc/wrtc_signaling.go
@@ -51,7 +51,7 @@ func extendWebRTCConfig(original *webrtc.Configuration, optional *webrtcpb.WebRT
 		return configCopy
 	}
 	if len(optional.GetAdditionalIceServers()) > 0 {
-		iceServers := make([]webrtc.ICEServer, len(original.ICEServers)+len(optional.GetAdditionalIceServers()))
+		iceServers := make([]webrtc.ICEServer, len(original.ICEServers), len(original.ICEServers)+len(optional.GetAdditionalIceServers()))
 		copy(iceServers, original.ICEServers)
 		for _, server := range optional.GetAdditionalIceServers() {
 			urls := server.GetUrls()


### PR DESCRIPTION
we were creating the slice at full length and then appending to it, but we should've allocated enough space for all elements but then only created the slice with length of the original list of ICE servers