### PR TITLE
RSDK-10618: Fix race contition in managedProcess

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -143,8 +143,8 @@ func PanicCapturingGoWithCallback(f func(), callback func(err interface{})) {
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
-				debug.PrintStack()
 				golog.Global().Errorw("panic while running function", "error", err)
+				debug.PrintStack()
 				if callback == nil {
 					return
 				}
@@ -161,15 +161,10 @@ func PanicCapturingGoWithCallback(f func(), callback func(err interface{})) {
 // it terminates normally.
 func ManagedGo(f, onComplete func()) {
 	PanicCapturingGoWithCallback(func() {
-		defer func() {
-			if err := recover(); err == nil && onComplete != nil {
-				onComplete()
-			} else if err != nil {
-				// re-panic
-				panic(err)
-			}
-		}()
 		f()
+		if onComplete != nil {
+			onComplete()
+		}
 	}, func(_ interface{}) {
 		ManagedGo(f, onComplete)
 	})


### PR DESCRIPTION
This PR fixes an issue where a race could occur between calls to `managedProcess.Stop` and parts of `managedProcess.manage` if the process crashed just before the call to `Stop`. This will have a matching change on the rdk side where the race caused duplicate module processes to be created during reconfiguration.

One thing worth noting: this change has the potential to create a deadlock if calling code tries to hold the same lock goroutines calling `Stop` and in their restart callback. This was an issue I fixed in my rdk modmanager changes but there may be other places this code is used that need to be audited for potential deadlocks.