### PR TITLE
RSDK-10618: fixing deadlock in managedProcess when Stop is called before Start

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -450,7 +450,12 @@ func (p *managedProcess) Stop() error {
 	select {
 	case <-p.killCh:
 		p.mu.Unlock()
-		<-p.managingCh
+		if p.cmd != nil {
+			// Avoid deadlocking if Stop was called before Start while blocking all
+			// calls to Stop that follow Start until the management goroutine shuts
+			// down.
+			<-p.managingCh
+		}
 		return nil
 	default:
 	}


### PR DESCRIPTION
The previous PR for this ticket (#432) changed the behavior of `managedProcess.Stop` so that all calls to `Stop` would block on the management channel closing instead of just the fist one. Unfortunately this causes a deadlock if `Stop` is called before `Start`. We have a test for this but for some reason it did not cause the CI runs on the PR to fail and instead only failed when the PR was merged. I'll dig into that later but for now this hotfix adds a check to make sure the process was started before blocking on the management channel in `Stop`.