### PR TITLE
RSDK-10183: Track PeerConnection disconnects in addition to active clients in FTDC.

### DIFF
--- a/rpc/wrtc_base_channel.go
+++ b/rpc/wrtc_base_channel.go
@@ -145,9 +145,6 @@ func newBaseChannel(
 // RSDK-8941: The above is a statement of expectations from existing code. Not a claim it is
 // factually correct.
 func (ch *webrtcBaseChannel) Close() {
-	// RSDK-8941: Having this instead early return when `closed` is set will result in `TestServer`
-	// to leak goroutines created by `dialWebRTC`.
-
 	ch.mu.Lock()
 	firstCallToClose := ch.closed.CompareAndSwap(false, true)
 	if !firstCallToClose {

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -400,6 +400,9 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 		}
 	}()
 
+	// `NewChannel` instantiates our webrtc wrapper around DataChannels. This includes callback
+	// handlers for transitioning to the open/closed/error states. As well as backpressure when the
+	// amount of data to send gets high.
 	serverChannel := aa.server.NewChannel(pc, dc, aa.hosts)
 
 	initSent := make(chan struct{})
@@ -552,7 +555,7 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 	case <-serverChannel.Ready():
 		// Happy path
 		successful = true
-		aa.server.counters.PeersConnected.Add(1)
+		aa.server.counters.PeerConnectionSuccesses.Add(1)
 		aa.server.counters.TotalTimeConnectingMillis.Add(time.Since(connectionStartTime).Milliseconds())
 	case <-ctx.Done():
 		// Timed out or signaling server was closed.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc69a75b-2640-4dcd-bb4e-2931a5364022)
