### PR TITLE
RSDK-10906: Add ports to peer connection stats.

### DIFF
--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -539,6 +539,7 @@ type iceCandidate struct {
 	// the time the candidate was received for remote candidates.
 	FoundAt      time.Time
 	CandType, IP string
+	Port         int
 }
 
 // Find selected candidate pair.
@@ -602,6 +603,7 @@ func getWebRTCPeerConnectionStats(peerConnection *webrtc.PeerConnection) webrtcP
 			candidateStats.Timestamp.Time(),
 			candidateType,
 			candidateStats.IP,
+			int(candidateStats.Port),
 		}
 		if local {
 			localCands = append(localCands, cand)


### PR DESCRIPTION
Also with the updated ice, we now have real timestamps for candidate generation.
App View:
![image](https://github.com/user-attachments/assets/3d3dc17a-19bc-4258-9058-7b318c83f14d)
Terminal:
```
2025-06-11T18:03:05.694Z	INFO	rdk.networking	rpc/wrtc_base_channel.go:128	Connection establishment succeeded	{"conn_id":"PeerConnection-1749664985518031753","conn_local_candidates":[{"FoundAt":"2025-06-11T18:03:05.579000064Z","CandType":"server-reflexive","IP":"34.72.14.205","Port":50027},{"FoundAt":"2025-06-11T18:03:05.52Z","CandType":"host","IP":"10.128.0.3","Port":59271},{"FoundAt":"2025-06-11T18:03:05.52Z","CandType":"host","IP":"127.0.0.1","Port":46972}],"conn_remote_candidates":[{"FoundAt":"2025-06-11T18:03:05.608999936Z","CandType":"server-reflexive","IP":"71.183.14.3","Port":51655},{"FoundAt":"2025-06-11T18:03:05.612999936Z","CandType":"relay","IP":"34.203.251.165","Port":28501},{"FoundAt":"2025-06-11T18:03:05.632Z","CandType":"relay","IP":"34.123.161.254","Port":62675},{"FoundAt":"2025-06-11T18:03:05.607000064Z","CandType":"relay","IP":"34.203.251.149","Port":18807},{"FoundAt":"2025-06-11T18:03:05.612Z","CandType":"relay","IP":"34.123.161.254","Port":55652}],"candidate_pair":"(local) udp4 srflx 34.72.14.205:50027 related 0.0.0.0:50027 <-> (remote) udp4 relay 34.203.251.149:18807 related 71.183.14.3:51655"}
```