### PR TITLE
RSDK-10711: Allow for true TCP relay candidates when `transport=tcp` exists in a turn ICEServer config string.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pseudomuto/protoc-gen-doc v1.3.2
 	github.com/rs/cors v1.11.1
 	github.com/viamrobotics/ice/v2 v2.3.37
-	github.com/viamrobotics/webrtc/v3 v3.99.12
+	github.com/viamrobotics/webrtc/v3 v3.99.13
 	github.com/viamrobotics/zeroconf v1.0.12
 	github.com/zitadel/oidc/v3 v3.37.0
 	go.mongodb.org/mongo-driver v1.11.6

--- a/go.sum
+++ b/go.sum
@@ -1207,8 +1207,8 @@ github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinC
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/viamrobotics/ice/v2 v2.3.37 h1:6vkWVOlDoc7WFUre98c3Xj64r2y8eGZbR/d1wra5YRI=
 github.com/viamrobotics/ice/v2 v2.3.37/go.mod h1:MFqB81U1pliDKaXJx2hGHvYKg1PepyEYwEY10828Ve0=
-github.com/viamrobotics/webrtc/v3 v3.99.12 h1:FXnqyMhDEJkDVSjsNGf136VZhOL2bxBtKxMNwaUw7Y0=
-github.com/viamrobotics/webrtc/v3 v3.99.12/go.mod h1:ppSvgs7raAcfkYpXdS6t7lI/6OSg+mgvaPOXU5uq3r8=
+github.com/viamrobotics/webrtc/v3 v3.99.13 h1:BnHaQY7bsss9iaCgPsGH3Frs4OaY41Riz2ocIa8asSg=
+github.com/viamrobotics/webrtc/v3 v3.99.13/go.mod h1:ppSvgs7raAcfkYpXdS6t7lI/6OSg+mgvaPOXU5uq3r8=
 github.com/viamrobotics/zeroconf v1.0.12 h1:y0AaDnBmELvtKKzJlnRBivZ4KWYXWXyGv73SY16sXUw=
 github.com/viamrobotics/zeroconf v1.0.12/go.mod h1:6qNiiR//WWB7n2c6syvOl0rAGltrcyNW4KonC6OBkPM=
 github.com/wlynxg/anet v0.0.3 h1:PvR53psxFXstc12jelG6f1Lv4MWqE0tI76/hHGjh9rg=

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -99,6 +99,13 @@ func newWebRTCAPI(logger utils.ZapCompatibleLogger) (*webrtc.API, error) {
 		return false
 	})
 
+	// When an `ICEServer` is configured with a `turn:...?transport=tcp` string, we will generate
+	// "true" passive TCP local candidates. It's not clear how close to spec we are here, so it's
+	// recommended to also have a UDP turn ICEServer (simply omit `transport=tcp`). When both exist
+	// and are result in useable candidate pairs, the UDP one ought to be preferred using ICE
+	// candidate priorities.
+	settingEngine.SetUseTCPAllocationsForLocalRelayCandidates(true)
+
 	// Use SOCKS proxy from environment as ICE proxy dialer and net transport.
 	if proxyAddr := os.Getenv(SocksProxyEnvVar); proxyAddr != "" {
 		logger.Info("behind SOCKS proxy; setting ICE proxy dialer")

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -102,7 +102,7 @@ func newWebRTCAPI(logger utils.ZapCompatibleLogger) (*webrtc.API, error) {
 	// When an `ICEServer` is configured with a `turn:...?transport=tcp` string, we will generate
 	// "true" passive TCP local candidates. It's not clear how close to spec we are here, so it's
 	// recommended to also have a UDP turn ICEServer (simply omit `transport=tcp`). When both exist
-	// and are result in useable candidate pairs, the UDP one ought to be preferred using ICE
+	// and result in useable candidate pairs, the UDP one ought to be preferred using ICE
 	// candidate priorities.
 	settingEngine.SetUseTCPAllocationsForLocalRelayCandidates(true)
 


### PR DESCRIPTION
~last one I promise~

I forgot RDK