### PR TITLE
RSDK-11434 Managed Process Status on Windows

### DIFF
--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -132,6 +132,10 @@ func (p *managedProcess) UnixPid() (int, error) {
 	return p.cmd.Process.Pid, nil
 }
 
+func (p *managedProcess) Status() error {
+	return p.status()
+}
+
 func (p *managedProcess) validateCWD() error {
 	if p.cwd == "" {
 		return nil

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -18,6 +18,18 @@ import (
 
 var errAlreadyStopped = errors.New("already stopped")
 
+type ErrProcessNotExist struct {
+	err error
+}
+
+func (e *ErrProcessNotExist) Error() string {
+	return fmt.Sprintf("process does not exist: %v", e.err)
+}
+
+func (e *ErrProcessNotExist) Unwrap() error {
+	return e.err
+}
+
 // UnexpectedExitHandler is the signature for functions that can optionally be
 // provided to run when a managed process unexpectedly exits. The return value
 // indicates whether pexec should continue with its own attempt to restart the

--- a/pexec/managed_process.go
+++ b/pexec/managed_process.go
@@ -132,12 +132,6 @@ func (p *managedProcess) UnixPid() (int, error) {
 	return p.cmd.Process.Pid, nil
 }
 
-func (p *managedProcess) Status() error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.cmd.Process.Signal(syscall.Signal(0))
-}
-
 func (p *managedProcess) validateCWD() error {
 	if p.cwd == "" {
 		return nil

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -87,7 +87,7 @@ func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
 	return attrs, nil
 }
 
-func (p *managedProcess) Status() error {
+func (p *managedProcess) status() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.cmd.Process.Signal(syscall.Signal(0))

--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -87,6 +87,12 @@ func (p *managedProcess) sysProcAttr() (*syscall.SysProcAttr, error) {
 	return attrs, nil
 }
 
+func (p *managedProcess) Status() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cmd.Process.Signal(syscall.Signal(0))
+}
+
 func (p *managedProcess) kill() (bool, error) {
 	p.logger.Infof("stopping process %d with signal %s", p.cmd.Process.Pid, p.stopSig)
 	// First let's try to directly signal the process.

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -117,7 +117,7 @@ func (p *managedProcess) forceKillGroup() error {
 
 // Status is a best effort method to return an os.ErrProcessDone in case the process no
 // longer exists.
-func (p *managedProcess) Status() error {
+func (p *managedProcess) status() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	pid, err := p.UnixPid()

--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -50,7 +50,7 @@ func (p *managedProcess) kill() (bool, error) {
 			p.logger.Debug("must force terminate process")
 			shouldJustForce = true
 		case strings.Contains(string(out), "not found"):
-			return false, nil
+			return false, &ErrProcessNotExist{err}
 		default:
 			return false, errors.Wrapf(err, "error killing process %d", p.cmd.Process.Pid)
 		}
@@ -70,7 +70,7 @@ func (p *managedProcess) kill() (bool, error) {
 					p.logger.Debug("must force terminate process tree")
 					shouldJustForce = true
 				case strings.Contains(string(out), "not found"):
-					return false, nil
+					return false, &ErrProcessNotExist{err}
 				default:
 					return false, errors.Wrapf(err, "error killing process tree %d", p.cmd.Process.Pid)
 				}


### PR DESCRIPTION
Implemented a `Status` method on windows, which is a best effort approach to translate the sate of the process on windows to the `os.ErrProcessDone` error that we are looking for. 

This have been discussed offline, but implementing this `Status` exposed an interesting code epath that lead to deadlock on Windows. In particular, these steps led to a deadlock: 
- When a module manager attempts to [add](https://github.com/viamrobotics/rdk/blob/1b7f3c914c1508dd6571a70bfae1c5bc345c64d3/module/modmanager/manager.go#L228) a module, it will acquire a lock. 
- When a module fails to start, [cleanupAfterStartupFailure()](https://github.com/viamrobotics/rdk/blob/1b7f3c914c1508dd6571a70bfae1c5bc345c64d3/module/modmanager/module.go#L383) is called, which will call `stopProcess()`
- Eventually, `Stop()` is called, and our line of interest is this call to [kill](https://github.com/viamrobotics/goutils/blob/bde94ecac9bc73d6c096e3f359a5089deb6a8559/pexec/managed_process.go#L475)
- The return value of this kill was different based on the architecture. On Unix, an attempt to send SIGTERM to the whole process group would result in an ESRCH, which is a "no such process" error. This error would be returned from kill, and then propagated to mod manager. The mod manager would special case this error message, and finish its execution normally
- On windows, "no such process" error is caught slightly differently, and instead returns without an error. This would cause `Stop()` to wait on the managing channel, which is usually closed by the `manage` go routine. However, this routine has a [callback](https://github.com/viamrobotics/goutils/blob/bde94ecac9bc73d6c096e3f359a5089deb6a8559/pexec/managed_process.go#L313) back into the module manager, which will _also_ try to acquire the same lock that `Add` is still holding. Therefore, the program enters a deadlock, with the modmanager lock being attempted by two places, as well as `Stop` waiting on the managing channel

In a best effort approach to unify Unix and Windows code paths for now, @jmatth offered to created a custom error that will be returned from both `kill` variants. So, to finish this PR, another change in the RDK needs to be made, which will special case check our new custom `ErrProcessNotExist` rather than a string match. While this patch fixes Status on windows and makes a way around this deadlock, a bigger rewrite of managed process (with it migrating to rdk) might be required to better handle these synchronization issues. 