### PR TITLE
Change default listen host to 127.0.0.1 instead of localhost

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -208,7 +208,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 	grpcBindAddr := sOpts.bindAddress
 	if grpcBindAddr == "" {
 		if sOpts.tlsConfig == nil || sOpts.unauthenticated {
-			grpcBindAddr = "localhost:0"
+			grpcBindAddr = "127.0.0.1:0"
 		} else {
 			grpcBindAddr = ":0"
 		}


### PR DESCRIPTION
during windows testing, was getting lookup errors for localhost.

there is a similar change here https://github.com/viamrobotics/rdk/pull/4791/files so I don't think this is very risky