### PR TITLE
RSDK-9665: Bump MaxRecvMsgSize to MaxMessageSize

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -220,6 +220,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 	}
 
 	serverOpts := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(MaxMessageSize),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             keepAliveTime / 2, // a little extra buffer to try to avoid ENHANCE_YOUR_CALM
 			PermitWithoutStream: true,


### PR DESCRIPTION
Bump from 4MB to MaxMessageSize (1<<25 or 33.55 MB)