### PR TITLE
RSDK-11434

### DIFF
--- a/pexec/managed_process_windows.go
+++ b/pexec/managed_process_windows.go
@@ -112,6 +112,7 @@ func (p *managedProcess) kill() (bool, error) {
 		}
 	case <-p.managingCh:
 		timer.Stop()
+		return false, nil
 	}
 
 	// Lastly, kill everything in the process tree that remains after a longer wait or now. This is


### PR DESCRIPTION
Adding a return statement when the managing channel is closed, so that we don't end up always attempting to force kill a process