### PR TITLE
[RSDK-11800] Change activeHosts to track unique hosts

### DIFF
--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -491,8 +491,7 @@ func (queue *mongoDBWebRTCCallQueue) changeStreamManager() {
 		}
 
 		queue.csStateMu.RLock()
-		hosts := make([]string, 0, len(queue.waitingForNewCallSubs))
-		activeHosts.Set(queue.operatorID, int64(len(hosts)))
+		activeHosts.Set(queue.operatorID, int64(len(queue.waitingForNewCallSubs)))
 		queue.csStateMu.RUnlock()
 
 		currSeq := queue.csManagerSeq.Load()
@@ -503,6 +502,7 @@ func (queue *mongoDBWebRTCCallQueue) changeStreamManager() {
 		isInitialized = true
 
 		queue.csStateMu.Lock()
+		hosts := make([]string, 0, len(queue.waitingForNewCallSubs))
 		for host := range queue.waitingForNewCallSubs {
 			hosts = append(hosts, host)
 		}


### PR DESCRIPTION
### Description
[RSDK-11800](https://viam.atlassian.net/browse/RSDK-11800?actionerId=615b581da7071000698f89c8&sourceType=assign) `activeHosts` don't seem to update correctly
* During server redeploys, the `activeHosts` metric on old signaling instances would remain constant despite answerers clearly migrating to new instances. This led to inflated host counts in monitoring dashboards during ~1 hour shutdown period where old and new instances were both up.
* The changeStreamManager is responsible for updating the `activeHosts` metric when `csManagerSeq` changes. `csManagerSeq` is only incremented when:
    * New answerers subscribe to previously untracked hosts
    * Change stream errors occur
* On a server redeploy, answerers are still subscribed to new call offers on old signaling instances. After new calls come in and those connections are established, answerers unsubscribe from old instance, create new signaling clients subscribing on new instances, but because no answerer would ever subscribe to an old signaling instance at this point,  `csManagerSeq` increment never occurs, and we never update `activeHosts` again explaining the constant value.
* This PR makes it so that on every ticker of `changeStreamManager` we update `activeHosts` so that we always have an accurate metric.  


[RSDK-11800]: https://viam.atlassian.net/browse/RSDK-11800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ