### PR TITLE
RSDK-11955 - Revert interface change

### DIFF
--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/net/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
@@ -62,9 +61,6 @@ type Dialer interface {
 	Close() error
 }
 
-// Unknown indicates an unknown connectivity state.
-const Unknown connectivity.State = 5
-
 // A ClientConn is a wrapper around the gRPC client connection interface but ensures
 // there is a way to close the connection.
 type ClientConn interface {
@@ -74,8 +70,6 @@ type ClientConn interface {
 	// a PeerConnection.
 	PeerConn() *webrtc.PeerConnection
 	Close() error
-
-	GetState() connectivity.State
 }
 
 // A ClientConnAuthenticator supports instructing a connection to authenticate now.

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -648,6 +648,8 @@ func (cc clientConnRPCAuthenticator) Authenticate(ctx context.Context) (string, 
 
 // GetState is exposed if it is available on the underlying type.
 func (cc clientConnRPCAuthenticator) GetState() connectivity.State {
+	// GetState is only expected to be called on connections to app,
+	// which we assume will always be GrpcOverHTTPClientConn.
 	checker, ok := cc.ClientConn.(GrpcOverHTTPClientConn)
 	if !ok {
 		return connectivity.Idle

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/net/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
@@ -643,6 +644,15 @@ type clientConnRPCAuthenticator struct {
 
 func (cc clientConnRPCAuthenticator) Authenticate(ctx context.Context) (string, error) {
 	return cc.rpcCreds.authenticate(ctx)
+}
+
+// GetState is exposed if it is available on the underlying type.
+func (cc clientConnRPCAuthenticator) GetState() connectivity.State {
+	checker, ok := cc.ClientConn.(GrpcOverHTTPClientConn)
+	if !ok {
+		return connectivity.Idle
+	}
+	return checker.GetState()
 }
 
 type staticPerRPCJWTCredentials struct {

--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -336,7 +336,6 @@ func (ch *webrtcClientChannel) writeReset(stream *webrtcpb.Stream) error {
 
 // GetState returns the current connectivity state of the channel.
 func (ch *webrtcClientChannel) GetState() connectivity.State {
-	// TODO: RSDK-11841 - Add connectivity state checking to WebRTC connections
 	return Unknown
 }
 

--- a/rpc/wrtc_client_channel.go
+++ b/rpc/wrtc_client_channel.go
@@ -10,7 +10,6 @@ import (
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	"github.com/viamrobotics/webrtc/v3"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -332,11 +331,6 @@ func (ch *webrtcClientChannel) writeReset(stream *webrtcpb.Stream) error {
 			RstStream: true,
 		},
 	})
-}
-
-// GetState returns the current connectivity state of the channel.
-func (ch *webrtcClientChannel) GetState() connectivity.State {
-	return Unknown
 }
 
 func newClientLoggerFields(fullMethodString string) []any {


### PR DESCRIPTION
pretty annoying. main blocker here is that the connection made using golang's grpc Dial is wrapped in a myriad of different structs depending on how it was called, which in our case ends up in a `clientConnRPCAuthenticator` which does not expose `grpc.ClientConn`. Doing a type check for `GrpcOverHTTPClientConn` suffices for now, however.

I imagine at some point we may want to fully move off of using dial in goutils for app connections, but tough to do that right now when there are so many utilities that we do rely on inside that function

this should be merged after rdk v0.94.0 is out