### PR TITLE
fix-artifact-size-limit

### DIFF
--- a/artifact/config.go
+++ b/artifact/config.go
@@ -21,7 +21,7 @@ var (
 // DefaultSourcePullSizeLimitBytes is the limit where if a normal pull happens,
 // a file larger than this size will not be pulled down from source
 // unless pull with ignoring the limit is used.
-const DefaultSourcePullSizeLimitBytes = 1 << 22
+const DefaultSourcePullSizeLimitBytes = 1 << 30
 
 // A Config describes how artifact should function.
 type Config struct {


### PR DESCRIPTION
this is blocking the sanding team from downloading files we have uploaded to gcp

prior to this change, this is the problem that was blocking us:
```
➜  sanding git:(main) ✗ artifact pull
2025-10-22T19:05:30.475-0400    INFO    artifact        artifact/cache.go:271   too large to load from source   {"path": "/Users/nicksanford/code/sanding/.artifact/data/sanding_plan_requests/October_14_2025_11_41_22_lobes_separate.json", "hash": "42b81026797718157a3d4a7129ecab0c", "size": 28455569}
2025-10-22T19:05:30.477-0400    INFO    artifact        artifact/cache.go:271   too large to load from source   {"path": "/Users/nicksanford/code/sanding/.artifact/data/sanding_plan_requests/October_14_2025_11_42_02_lobes_selected.json", "hash": "42b81026797718157a3d4a7129ecab0c", "size": 28455569}
2025-10-22T19:05:30.480-0400    INFO    artifact        artifact/cache.go:271   too large to load from source   {"path": "/Users/nicksanford/code/sanding/.artifact/data/sanding_plan_requests/plan_910db039-5b47-410a-ac1b-4968649c564f.json", "hash": "5fc6c224157f5b34904b4328f0d6c5eb", "size": 41752874}
2025-10-22T19:05:30.481-0400    INFO    artifact        artifact/cache.go:271   too large to load from source   {"path": "/Users/nicksanford/code/sanding/.artifact/data/sanding_plan_requests/plan-joint-discontinuity.json", "hash": "8623050c0293ba84450bdf664813e489", "size": 14779604}
```

after this we wouldn't see any files on disk and the files we needed wouldn't be downloaded during tests