### PR TITLE
Use unix: instead of unix:// for socket paths in gRPC

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -114,7 +114,7 @@ func dial(
 
 	var isJustDomain bool
 	switch {
-	case strings.HasPrefix(address, "unix://"):
+	case strings.HasPrefix(address, "unix:"):
 		dOpts.mdnsOptions.Disable = true
 		dOpts.webrtcOpts.Disable = true
 		dOpts.insecure = true

--- a/rpc/dial_test.go
+++ b/rpc/dial_test.go
@@ -1615,7 +1615,7 @@ func TestDialUnix(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
-	conn, err := Dial(ctx, "unix://"+socketPath, logger)
+	conn, err := Dial(ctx, "unix:"+socketPath, logger)
 	cancel()
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, conn.Close(), test.ShouldBeNil)


### PR DESCRIPTION
Partner to https://github.com/viamrobotics/rdk/pull/5920