### PR TITLE
Add non-blocking govulncheck CI workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,8 +14,6 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
-    # Non-blocking: surface vulnerabilities without failing required status checks.
-    continue-on-error: true
     timeout-minutes: 15
     steps:
       # actions/checkout@v6.0.2
@@ -28,9 +26,13 @@ jobs:
           cache: true
 
       # golang/govulncheck-action@v1.0.4
-      # repo-checkout: false avoids a duplicate-Authorization-header HTTP 400
-      # caused by the action running its own actions/checkout after ours.
+      # - repo-checkout: false avoids a duplicate-Authorization-header HTTP 400
+      #   caused by the action running its own actions/checkout after ours.
+      # - continue-on-error at the step level keeps the job green when findings
+      #   are reported so the PR check shows as pass. Review the step's log to
+      #   see any vulnerabilities detected.
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
+        continue-on-error: true
         with:
           go-version-file: go.mod
           go-package: ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -28,7 +28,10 @@ jobs:
           cache: true
 
       # golang/govulncheck-action@v1.0.4
+      # repo-checkout: false avoids a duplicate-Authorization-header HTTP 400
+      # caused by the action running its own actions/checkout after ours.
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
           go-version-file: go.mod
           go-package: ./...
+          repo-checkout: false

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,34 @@
+name: Govulncheck
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    # Non-blocking: surface vulnerabilities without failing required status checks.
+    continue-on-error: true
+    timeout-minutes: 15
+    steps:
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # golang/govulncheck-action@v1.0.4
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
+        with:
+          go-version-file: go.mod
+          go-package: ./...


### PR DESCRIPTION
## Summary

Add a govulncheck job to CI that runs on push to `main` and on every pull request. Marked `continue-on-error: true` so findings are surfaced in CI without blocking merges while we triage and upgrade dependencies.

## Changes

- **.github/workflows/govulncheck.yml**: New workflow — checks out code, installs the Go version from `go.mod`, runs `golang/govulncheck-action`. Pinned to commit SHAs, read-only workflow permissions, uses `pull_request` (not `pull_request_target`) so no secrets are exposed to forked PRs.

## Testing

- Workflow will execute on this PR itself — verify the job runs, reports vulnerabilities (expected: ~21 symbol-level findings on current tree), and does not fail the required status checks.
- Confirm branch protection on `main` is NOT configured to require the `govulncheck` check, otherwise it would still effectively block merges.

## Follow-ups

- Separate PRs will clear the findings: Go 1.25.9 + `otel/sdk` v1.40.0 (biggest win), then `lestrrat-go/jwx` v1.2.29, then an investigation of `pion/dtls` and `aws-sdk-go`.

## Claude Code Prompts Used

- "Add govulncheck to CI. It should be not blocking for now; assess the dependencies we can upgrade in this repo, focus on security risks"
- "Proceed with the 3 PRs and the investigation"