### PR TITLE
RSDK-13933 - Ratelimiter docs are sometimes persisted with unevaluated expressions

### DIFF
--- a/rpc/wrtc_rate_limiter.go
+++ b/rpc/wrtc_rate_limiter.go
@@ -94,20 +94,27 @@ func NewMongoDBRateLimiter(
 // The update creates a new array that adds the current timestamp and removes old timestamps outside the window.
 // This prevents race conditions and keeps the requests array bounded.
 func (rl *MongoDBRateLimiter) Allow(ctx context.Context, key string) error {
+	freshExpiresAt := bson.M{
+		"$dateAdd": bson.M{
+			"startDate": "$$NOW",
+			"unit":      "second",
+			"amount":    rl.config.Window.Seconds(),
+		},
+	}
+
 	// Ensure a document for the key exists or create one to handle first request case since a $expr filter
-	// can't check for non-existence and create the document if it doesn't exist
+	// can't check for non-existence and create the document if it doesn't exist. Use a pipeline (rather
+	// than $setOnInsert) so $dateAdd and $$NOW are evaluated server-side instead of stored as literals.
 	_, err := rl.rateLimitColl.UpdateOne(ctx,
 		bson.M{"_id": key},
-		bson.M{"$setOnInsert": bson.M{
-			"requests": bson.A{},
-			"expires_at": bson.M{
-				"$dateAdd": bson.M{
-					"startDate": "$$NOW",
-					"unit":      "second",
-					"amount":    rl.config.Window.Seconds(),
+		bson.A{
+			bson.M{
+				"$set": bson.M{
+					"requests":   bson.M{"$ifNull": bson.A{"$requests", bson.A{}}},
+					"expires_at": bson.M{"$ifNull": bson.A{"$expires_at", freshExpiresAt}},
 				},
 			},
-		}},
+		},
 		options.Update().SetUpsert(true))
 	if err != nil {
 		// to not erroneously rate limit requests, we log the error but do not return the error.
@@ -173,13 +180,7 @@ func (rl *MongoDBRateLimiter) Allow(ctx context.Context, key string) error {
 						bson.A{"$$NOW"},
 					},
 				},
-				"expires_at": bson.M{
-					"$dateAdd": bson.M{
-						"startDate": "$$NOW",
-						"unit":      "second",
-						"amount":    rl.config.Window.Seconds(),
-					},
-				},
+				"expires_at": freshExpiresAt,
 			},
 		},
 	}

--- a/rpc/wrtc_rate_limiter_test.go
+++ b/rpc/wrtc_rate_limiter_test.go
@@ -180,6 +180,30 @@ func TestMongoDBRateLimiter(t *testing.T) {
 		test.That(t, denied, test.ShouldEqual, config.MaxRequests)
 	})
 
+	t.Run("upsert stores expires_at as a Date", func(t *testing.T) {
+		ctx := context.Background()
+		key := "test"
+
+		// MaxRequests=0 makes the second UpdateOne never match, so expires_at is whatever
+		// the upsert wrote. If $dateAdd/$$NOW weren't evaluated server-side, expires_at
+		// would be a literal sub-document and the DateTime decode below would fail.
+		zeroConfig := RateLimitConfig{MaxRequests: 0, Window: time.Second}
+		test.That(t, client.Database(mongodbWebRTCCallQueueDBName).Drop(ctx), test.ShouldBeNil)
+		limiter, err := NewMongoDBRateLimiter(ctx, client, zeroConfig, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		err = limiter.Allow(ctx, key)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, status.Convert(err).Code(), test.ShouldEqual, codes.ResourceExhausted)
+
+		var doc struct {
+			ExpiresAt primitive.DateTime `bson:"expires_at"`
+		}
+		err = limiter.rateLimitColl.FindOne(ctx, bson.M{"_id": key}).Decode(&doc)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, doc.ExpiresAt.Time().After(time.Now()), test.ShouldBeTrue)
+	})
+
 	t.Run("handles concurrent requests from different keys", func(t *testing.T) {
 		ctx := context.Background()
 		limiter := setUpLimiter(t, ctx)


### PR DESCRIPTION
The bug: In MongoDB, regular update operators like $setOnInsert don't evaluate aggregation expressions — they store the BSON they receive verbatim. So this:

```
bson.M{"$setOnInsert": bson.M{
    "expires_at": bson.M{
        "$dateAdd": bson.M{"startDate": "$$NOW", "unit": "second", "amount": 60.0},
    },
}}
```
doesn't compute a future timestamp. It writes expires_at as the literal sub-document `{"$dateAdd": {"startDate": "$$NOW", "unit": "second", "amount": {"$numberDouble": "60.0"}}}`. Aggregation operators like `$dateAdd` and system variables like `$$NOW` are only evaluated inside aggregation contexts (pipelines, $expr, etc.), not inside regular update operators.

Issue:

A sub-document is invisible to TTL, so any document that ended up with the literal would never get cleaned up.

tested that the test failed without the fix and succeeds with