### PR TITLE
APP-16300: Implement rate limit sampling on a per root span name basis

### DIFF
--- a/perf/exporters.go
+++ b/perf/exporters.go
@@ -41,6 +41,7 @@ func NewCloudExporter(opts CloudOptions) (Exporter, error) {
 		NumberOfWorkers          int           `env:"OCSD_WORKERS"`
 		TraceSpansBufferMaxBytes int           `env:"OCSD_BUFFER_MAX_BYTES"       envDefault:"52428800"`
 		BundleCountThreshold     int           `env:"OCSD_BUNDLE_COUNT_THRESHOLD"`
+		SamplingByNamePerSec     float64       `env:"OC_SAMPLING_BY_NAME_PER_SEC" envDefault:"0"`
 		SamplingProbability      float64       `env:"OC_SAMPLING_PROB"            envDefault:"1"`
 	}]()
 	if err != nil {
@@ -129,7 +130,9 @@ func NewCloudExporter(opts CloudOptions) (Exporter, error) {
 	}
 
 	e.sampler = trace.AlwaysSample()
-	if envOpts.SamplingProbability != 0 {
+	if envOpts.SamplingByNamePerSec != 0 {
+		e.sampler = NewRouteRateLimitingSampler(envOpts.SamplingByNamePerSec)
+	} else if envOpts.SamplingProbability != 0 {
 		e.sampler = trace.ProbabilitySampler(envOpts.SamplingProbability)
 	}
 

--- a/perf/exporters.go
+++ b/perf/exporters.go
@@ -131,7 +131,7 @@ func NewCloudExporter(opts CloudOptions) (Exporter, error) {
 
 	e.sampler = trace.AlwaysSample()
 	if envOpts.SamplingByNamePerSec != 0 {
-		e.sampler = NewRouteRateLimitingSampler(envOpts.SamplingByNamePerSec)
+		e.sampler = NewRootNameRateLimitingSampler(envOpts.SamplingByNamePerSec)
 	} else if envOpts.SamplingProbability != 0 {
 		e.sampler = trace.ProbabilitySampler(envOpts.SamplingProbability)
 	}

--- a/perf/root_name_ratelimit_sampler.go
+++ b/perf/root_name_ratelimit_sampler.go
@@ -9,10 +9,10 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// NewRouteRateLimitingSampler creates a [trace.Sampler] that samples x spans
+// NewRootNameRateLimitingSampler creates a [trace.Sampler] that samples x spans
 // per second per root span name. The first encountered root span of each name
 // is always sampled.
-func NewRouteRateLimitingSampler(perSec float64) trace.Sampler {
+func NewRootNameRateLimitingSampler(perSec float64) trace.Sampler {
 	if perSec <= 0 {
 		return trace.NeverSample()
 	}

--- a/perf/route_ratelimit_sampler.go
+++ b/perf/route_ratelimit_sampler.go
@@ -17,6 +17,12 @@ func NewRouteRateLimitingSampler(perSec float64) trace.Sampler {
 		return trace.NeverSample()
 	}
 
+	// - [sync.Map] is optimized for a write-once-read-many access pattern, so
+	//   just storing timestamps directly in the values would work but likely lead
+	//   to suboptimal performance
+	// - [sync.Pointer] could be used to hold a pointer to a [time.Time] but
+	//   would add GC pressure on some code paths that can otherwise pass by value
+	//   by using an int64
 	lastSampledMicrosByName := &smap[string, *atomic.Int64]{}
 	return func(sp trace.SamplingParameters) trace.SamplingDecision {
 		// Only apply to root spans, otherwise defer to the parent's decision.
@@ -28,14 +34,14 @@ func NewRouteRateLimitingSampler(perSec float64) trace.Sampler {
 		// Try to load first and only allocate a new sync.Int64 if we miss to avoid
 		// generating GC pressure on every request.
 		lastSampleAtomic, present := lastSampledMicrosByName.Load(sp.Name)
-		now := time.Now()
+		nowNanos := time.Now().UnixNano()
 		var sample bool
 		if present {
 			// Compute the sampling probability based on the seconds since the last
 			// time we sampled as detailed here:
 			// https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md#when-does-opencensus-sample-traces
 			lastSample := lastSampleAtomic.Load()
-			elapsedSec := max(now.Sub(time.Unix(0, lastSample)).Seconds(), 0)
+			elapsedSec := max(float64(nowNanos-lastSample)/1e9, 0)
 			samplingProb := min(elapsedSec*perSec, 1)
 
 			// Use the trace id as the random seed to check if we should sample
@@ -47,13 +53,13 @@ func NewRouteRateLimitingSampler(perSec float64) trace.Sampler {
 				// If we decided to sample there's still a chance we lost the race w/
 				// another goroutine. Discard our positive result if something else has
 				// already overwritten the atomic.
-				sample = lastSampleAtomic.CompareAndSwap(lastSample, now.UnixNano())
+				sample = lastSampleAtomic.CompareAndSwap(lastSample, nowNanos)
 			}
 		} else {
 			// This is our first time seeing a root span with this particular name.
 			// Assume we should sample.
 			nowPtr := &atomic.Int64{}
-			nowPtr.Store(now.UnixNano())
+			nowPtr.Store(nowNanos)
 			// If another goroutine beat us to the first sampling, discard our
 			// positive result.
 			_, lostRace := lastSampledMicrosByName.LoadOrStore(sp.Name, nowPtr)

--- a/perf/route_ratelimit_sampler.go
+++ b/perf/route_ratelimit_sampler.go
@@ -1,0 +1,88 @@
+package perf
+
+import (
+	"encoding/binary"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opencensus.io/trace"
+)
+
+// NewRouteRateLimitingSampler creates a [trace.Sampler] that samples x spans
+// per second per root span name. The first encountered root span of each name
+// is always sampled.
+func NewRouteRateLimitingSampler(perSec float64) trace.Sampler {
+	if perSec <= 0 {
+		return trace.NeverSample()
+	}
+
+	lastSampledMicrosByName := &smap[string, *atomic.Int64]{}
+	return func(sp trace.SamplingParameters) trace.SamplingDecision {
+		// Only apply to root spans, otherwise defer to the parent's decision.
+		var zeroSpanID trace.SpanID
+		if sp.ParentContext.SpanID != zeroSpanID {
+			return trace.SamplingDecision{Sample: sp.ParentContext.IsSampled()}
+		}
+
+		// Try to load first and only allocate a new sync.Int64 if we miss to avoid
+		// generating GC pressure on every request.
+		lastSampleAtomic, present := lastSampledMicrosByName.Load(sp.Name)
+		now := time.Now()
+		var sample bool
+		if present {
+			// Compute the sampling probability based on the seconds since the last
+			// time we sampled as detailed here:
+			// https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md#when-does-opencensus-sample-traces
+			lastSample := lastSampleAtomic.Load()
+			elapsedSec := max(now.Sub(time.Unix(0, lastSample)).Seconds(), 0)
+			samplingProb := min(elapsedSec*perSec, 1)
+
+			// Use the trace id as the random seed to check if we should sample
+			// according to our computed probability. This is copied from
+			// [trace.ProbabilitySampler].
+			traceIDUpperBound := uint64(samplingProb * (1 << 63))
+			sample = (binary.BigEndian.Uint64(sp.TraceID[0:8]) >> 1) < traceIDUpperBound
+			if sample {
+				// If we decided to sample there's still a chance we lost the race w/
+				// another goroutine. Discard our positive result if something else has
+				// already overwritten the atomic.
+				sample = lastSampleAtomic.CompareAndSwap(lastSample, now.UnixNano())
+			}
+		} else {
+			// This is our first time seeing a root span with this particular name.
+			// Assume we should sample.
+			nowPtr := &atomic.Int64{}
+			nowPtr.Store(now.UnixNano())
+			// If another goroutine beat us to the first sampling, discard our
+			// positive result.
+			_, lostRace := lastSampledMicrosByName.LoadOrStore(sp.Name, nowPtr)
+			sample = !lostRace
+		}
+		return trace.SamplingDecision{Sample: sample}
+	}
+}
+
+// smap is an alias to [sync.Map] with generic type parameters.
+type smap[K comparable, V any] sync.Map
+
+// CompareAndSwap is an alias to [sync.Map.CompareAndSwap].
+func (m *smap[K, V]) CompareAndSwap(key K, oldVal, newVal V) bool {
+	return (*sync.Map)(m).CompareAndSwap(key, oldVal, newVal)
+}
+
+// Load is an alias to [sync.Map.Load].
+func (m *smap[K, V]) Load(key K) (V, bool) {
+	v, ok := (*sync.Map)(m).Load(key)
+	if !ok {
+		var zero V
+		return zero, ok
+	}
+	return v.(V), ok
+}
+
+// LoadOrStore is an alias to [sync.Map.LoadOrStore].
+func (m *smap[K, V]) LoadOrStore(key K, value V) (V, bool) {
+	v, stored := (*sync.Map)(m).LoadOrStore(key, value)
+	return v.(V), stored
+}

--- a/perf/route_ratelimit_sampler_test.go
+++ b/perf/route_ratelimit_sampler_test.go
@@ -1,0 +1,85 @@
+package perf
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"go.opencensus.io/trace"
+	"go.viam.com/test"
+)
+
+func TestRouteRateLimitingSampler(t *testing.T) {
+	rootParams := func(name string, traceIDByte byte) trace.SamplingParameters {
+		var traceID trace.TraceID
+		for i := range traceID {
+			traceID[i] = traceIDByte
+		}
+		return trace.SamplingParameters{
+			TraceID: traceID,
+			Name:    name,
+		}
+	}
+
+	t.Run("never samples when perSec <= 0", func(t *testing.T) {
+		for _, perSec := range []float64{0, -0.0001, -1, -1e9} {
+			sampler := NewRouteRateLimitingSampler(perSec)
+			for i := range 100 {
+				dec := sampler(rootParams("foo", byte(i)))
+				test.That(t, dec.Sample, test.ShouldBeFalse)
+			}
+		}
+	})
+
+	t.Run("defers to parent context for non-root spans", func(t *testing.T) {
+		// Use a high perSec so the sampler would otherwise sample root spans.
+		sampler := NewRouteRateLimitingSampler(1e6)
+		nonZeroSpanID := trace.SpanID{1}
+
+		params := trace.SamplingParameters{
+			ParentContext: trace.SpanContext{
+				SpanID:       nonZeroSpanID,
+				TraceOptions: 1, // sampled bit set
+			},
+			Name: "foo",
+		}
+		test.That(t, sampler(params).Sample, test.ShouldBeTrue)
+
+		params.ParentContext.TraceOptions = 0
+		test.That(t, sampler(params).Sample, test.ShouldBeFalse)
+
+		// Name has never been seen as a root before — should still defer to parent.
+		params.Name = "never-seen-as-root"
+		params.ParentContext.TraceOptions = 0
+		test.That(t, sampler(params).Sample, test.ShouldBeFalse)
+
+		params.ParentContext.TraceOptions = 1
+		test.That(t, sampler(params).Sample, test.ShouldBeTrue)
+	})
+
+	t.Run("first root span for each unique name is always sampled", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// Use a tiny perSec so any subsequent call within fake-time would have
+			// near-zero sampling probability and trace IDs of all 0xff would
+			// otherwise be rejected.
+			sampler := NewRouteRateLimitingSampler(1e-12)
+
+			for _, name := range []string{"a", "b", "c", "d", "/foo/bar", ""} {
+				dec := sampler(rootParams(name, 0xff))
+				test.That(t, dec.Sample, test.ShouldBeTrue)
+
+				// Second call for the same name at the same instant should not
+				// sample given the tiny perSec — sanity-checks that the
+				// "always sample" only applies to the first occurrence.
+				dec = sampler(rootParams(name, 0xff))
+				test.That(t, dec.Sample, test.ShouldBeFalse)
+			}
+
+			// Advancing fake time past 1/perSec brings sampling probability back
+			// to 1, so the next call samples again.
+			time.Sleep(10 * time.Second)
+			dec := sampler(rootParams("a", 0))
+			test.That(t, dec.Sample, test.ShouldBeTrue)
+		})
+	})
+}

--- a/perf/route_ratelimit_sampler_test.go
+++ b/perf/route_ratelimit_sampler_test.go
@@ -23,7 +23,7 @@ func TestRouteRateLimitingSampler(t *testing.T) {
 
 	t.Run("never samples when perSec <= 0", func(t *testing.T) {
 		for _, perSec := range []float64{0, -0.0001, -1, -1e9} {
-			sampler := NewRouteRateLimitingSampler(perSec)
+			sampler := NewRootNameRateLimitingSampler(perSec)
 			for i := range 100 {
 				dec := sampler(rootParams("foo", byte(i)))
 				test.That(t, dec.Sample, test.ShouldBeFalse)
@@ -33,7 +33,7 @@ func TestRouteRateLimitingSampler(t *testing.T) {
 
 	t.Run("defers to parent context for non-root spans", func(t *testing.T) {
 		// Use a high perSec so the sampler would otherwise sample root spans.
-		sampler := NewRouteRateLimitingSampler(1e6)
+		sampler := NewRootNameRateLimitingSampler(1e6)
 		nonZeroSpanID := trace.SpanID{1}
 
 		params := trace.SamplingParameters{
@@ -62,7 +62,7 @@ func TestRouteRateLimitingSampler(t *testing.T) {
 			// Use a tiny perSec so any subsequent call within fake-time would have
 			// near-zero sampling probability and trace IDs of all 0xff would
 			// otherwise be rejected.
-			sampler := NewRouteRateLimitingSampler(1e-12)
+			sampler := NewRootNameRateLimitingSampler(1e-12)
 
 			for _, name := range []string{"a", "b", "c", "d", "/foo/bar", ""} {
 				dec := sampler(rootParams(name, 0xff))


### PR DESCRIPTION
This adds a new sampler implementation for OpenCensus tracing. It is based on [rate limiting sampling][1] with the added complexity of performing the sampling on a per root span name basis. For example, consider a server that

- Receives 8 requests to `/a` per second
- Receives 2 requests to `/b` per second
- Is configured to sample one span per second

With simple rate limit sampling, only 1 of the 10 total requests per second would be sampled. With this implementation it will sample 2, one from each route. This will ensure we have some minimum level of coverage for each code path at the cost of increasing the total number of sampled spans as a function of the number of total root span names across the application.

On web servers like app most root span names will be based on the route a request was sent to.

This behavior is off by default but can be configured with a new environment variable.

[1]: https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md#ratelimiting-sampler-implementation-details