### PR TITLE
RSDK-13822 Add stun:turn.viam.com:443 to default ICE servers

### DIFF
--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -38,6 +38,9 @@ var DefaultICEServers = []webrtc.ICEServer{
 	{
 		URLs: []string{"stun:global.stun.twilio.com:3478"},
 	},
+	{
+		URLs: []string{"stun:turn.viam.com:443"},
+	},
 }
 
 // DefaultWebRTCConfiguration is the standard configuration used for WebRTC peers.


### PR DESCRIPTION
RSDK-13822

## What

Adds `stun:turn.viam.com:443` to the list of default ICE servers.

## Why

Adding that extra default ICE server will let `viam-server` and Golang SDK clients (e.g. `viam-server` connections to remote) gather STUN candidates from `turn.viam.com:443`. This is especially useful when STUN candidates _cannot_ be gathered from the other default ICE server: `stun:global.stun.twilio.com:3478`. We have found firewalls in the wild that disallow STUN traffic to the Twilio URL but allow it to our TURN server.

**There is a notable side-effect of this change:**

`viam-server` and Golang SDK clients will gather an "extra" STUN candidate in the event that both `global.stun.twilio.com` and `turn.viam.com` are reachable (this is most of the time). That extra STUN candidate _will_ be transmitted through MongoDB for signaling and _will_ be used in connectivity checks by the remote. The two candidates may look something like:

```
{"FoundAt":"2026-05-15T18:50:23.360999936Z","CandType":"server-reflexive","IP":"73.47.51.100","Port":53533},
{"FoundAt":"2026-05-15T18:50:23.359000064Z","CandType":"server-reflexive","IP":"73.47.51.100","Port":63389}
```

You'll see that the IPs are identical but the ports are _not_. IIUC this is because pion creates two distinct `net.Conn`s: one to Twilio and one to our Viam TURN server. Since these are distinct outgoing connections, NAT will assign them two different ports. I was tempted to add some logic to only submit one of two STUN candidates with identical IPs ("dedupe"), but I don't know what effect that will have in "weird" network topologies. Maybe there _is_ a case where a STUN candidate with address 73.47.51.100:53533 is unreachable but a STUN candidate with 73.47.51.100:63389 is reachable? Since my change does not seem to slow connection establishment times in my testing, I'm tempted to do the "simple" thing here, and add deduping if we find connection times to be slow later on.

## Testing

I ensured that if I drop gathered host candidates and STUN candidates gathered from Twilio, `viam-server` and a Golang SDK instance can connect solely based on the STUN candidates gathered from turn.viam.com. `viam-server` and the Golang SDK instance could _not_ connect in that case without this change. Furthermore, I connected 100 times with this change and without it, and found an almost identical average connection establishment time (~1.2 seconds in my testing).