### PR TITLE
RSDK-13164 Wait for answerer to be online is `testWebRTCSignaling`

### DIFF
--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -136,6 +136,7 @@ func testWebRTCSignaling(t *testing.T, signalingCallQueue WebRTCCallQueue, logge
 
 			for _, tc := range []bool{true, false} {
 				t.Run(fmt.Sprintf("with trickle disabled %t", tc), func(t *testing.T) {
+					waitForAnswererOnline(context.Background(), t, []string{host}, signalingCallQueue)
 					ch, dialErr := DialWebRTC(
 						context.Background(),
 						grpcListener.Addr().String(),
@@ -146,7 +147,6 @@ func testWebRTCSignaling(t *testing.T, signalingCallQueue WebRTCCallQueue, logge
 							DisableTrickleICE: tc,
 						}),
 					)
-					waitForAnswererOnline(context.Background(), t, []string{host}, signalingCallQueue)
 					test.That(t, dialErr, test.ShouldBeNil)
 					defer func() {
 						test.That(t, ch.Close(), test.ShouldBeNil)


### PR DESCRIPTION
RSDK-13164

## What

Moves `waitForAnswererOnline` to before `DialWebRTC` in `testWebRTCSignaling`.

## Why

The previous placement called `waitForAnswererOnline` after `DialWebRTC`, which is a race condition — the test was attempting to connect before confirming the answerer was ready to handle the call. This could cause flaky test failures, particularly when the MongoDB-backed call queue is slow to register the answerer. Moving the wait before the dial ensures the answerer is online before any connection attempt is made.

## Testing

The existing test `testWebRTCSignaling` exercises this code path; the fix corrects the ordering within it. No new tests were added — the change is a test correctness fix.