### PR TITLE
RSDK-13164 Retry DialWebRTC in yeehaw/woah_there tests

### DIFF
--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -140,11 +140,11 @@ func testWebRTCSignaling(t *testing.T, signalingCallQueue WebRTCCallQueue, logge
 						ch      ClientConn
 						dialErr error
 					)
-					// waitForAnswererOnline at this point _sometimes_ gets a stale "the machine is
-					// online" value, and DialWebRTC can still fail, so we add a hacky retry here.
-					// There's no perfect way to fix the race between waitForAnswererOnline,
-					// operatorLivenessLoop, and the answerer reconnect goroutines (which have a
-					// 2-second delay).
+					// After waitForAnswererOnline returns, operatorLivenessLoop can run before the
+					// DialWebRTC and update the DB state to reflect no online answerers causing the
+					// dial to fail. The ideal solution would be to spawn answerer threads as call
+					// requests come in, rather than hardcoding a limit of 2. For the sake of this
+					// test, we just add a couple retries here (hacky).
 					for range 3 {
 						waitForAnswererOnline(context.Background(), t, []string{host}, signalingCallQueue)
 						ch, dialErr = DialWebRTC(

--- a/rpc/wrtc_signaling_test.go
+++ b/rpc/wrtc_signaling_test.go
@@ -136,18 +136,33 @@ func testWebRTCSignaling(t *testing.T, signalingCallQueue WebRTCCallQueue, logge
 
 			for _, tc := range []bool{true, false} {
 				t.Run(fmt.Sprintf("with trickle disabled %t", tc), func(t *testing.T) {
-					waitForAnswererOnline(context.Background(), t, []string{host}, signalingCallQueue)
-					ch, dialErr := DialWebRTC(
-						context.Background(),
-						grpcListener.Addr().String(),
-						host,
-						logger,
-						WithWebRTCOptions(DialWebRTCOptions{
-							SignalingInsecure: true,
-							DisableTrickleICE: tc,
-						}),
+					var (
+						ch      ClientConn
+						dialErr error
 					)
+					// waitForAnswererOnline at this point _sometimes_ gets a stale "the machine is
+					// online" value, and DialWebRTC can still fail, so we add a hacky retry here.
+					// There's no perfect way to fix the race between waitForAnswererOnline,
+					// operatorLivenessLoop, and the answerer reconnect goroutines (which have a
+					// 2-second delay).
+					for range 3 {
+						waitForAnswererOnline(context.Background(), t, []string{host}, signalingCallQueue)
+						ch, dialErr = DialWebRTC(
+							context.Background(),
+							grpcListener.Addr().String(),
+							host,
+							logger,
+							WithWebRTCOptions(DialWebRTCOptions{
+								SignalingInsecure: true,
+								DisableTrickleICE: tc,
+							}),
+						)
+						if dialErr == nil {
+							break
+						}
+					}
 					test.That(t, dialErr, test.ShouldBeNil)
+
 					defer func() {
 						test.That(t, ch.Close(), test.ShouldBeNil)
 					}()


### PR DESCRIPTION
RSDK-13164

## What

Adds a retry loop around `waitForAnswererOnline` and `DialWebRTC` in `testWebRTCSignaling` to make the yeehaw/woah_there tests more resilient.

## Why
 
`waitForAnswererOnline` occasionally returns a stale "the machine is online" value, causing a subsequent `DialWebRTC` call to fail. This is a race between `waitForAnswererOnline`, `operatorLivenessLoop`, and the answerer reconnect goroutines (which have a built-in 2-second delay). There is no clean/easy way to eliminate this race, so the test retries the check-and-dial sequence up to 3 times before failing.

## Testing

  - Existing `testWebRTCSignaling` tests cover the signaling behavior; this change only affects retry logic around the dial, not the test assertions themselves.
  - The retry was added specifically to fix flaky failures in the yeehaw/woah_there test variants — manual observation of CI runs motivated this change

 [Generated by Claude 🤖]