### PR TITLE
Add Claude CI workflows from rdk

### DIFF
--- a/.claude/settings.ci.json
+++ b/.claude/settings.ci.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "deny": [
+      "Edit(file_path=.github/**)",
+      "Write(file_path=.github/**)",
+      "Edit(file_path=**/*.pb.go)",
+      "Write(file_path=**/*.pb.go)",
+      "Edit(file_path=Makefile)",
+      "Write(file_path=Makefile)",
+      "Edit(file_path=mise.toml)",
+      "Write(file_path=mise.toml)",
+      "Edit(file_path=go.sum)",
+      "Write(file_path=go.sum)"
+    ]
+  }
+}

--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -1,0 +1,66 @@
+name: Check PR Approvals
+
+# Enforces a minimum approval count on PRs opened from `claude/**` branches.
+# To make this a required gate, add it as a required status check in the
+# branch-protection rule (or ruleset) that targets `main`.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [main]
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  check-approvals:
+    if: >-
+      github.repository_owner == 'viamrobotics' &&
+      startsWith(github.event.pull_request.head.ref, 'claude/')
+    runs-on: ubuntu-latest
+    permissions:
+      # write (not read) to post the "Review Required" comment: commenting on a
+      # PR needs pull-requests: write; issues: write does not cover PRs.
+      pull-requests: write
+    steps:
+      # Flaky-test fixes and dependabot bumps only require a single approval;
+      # everything else needs two. Title/branch are read via env (never interpolated
+      # into the script) to avoid injection.
+      - name: Determine required approvals
+        id: approvals
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          title_lc="${PR_TITLE,,}"
+          if [[ "$title_lc" == *flaky* ]]; then
+            echo "min_approvals=1" >> "$GITHUB_OUTPUT"
+            echo "Flaky-test PR detected; requiring 1 approval."
+          elif [[ "$HEAD_REF" == claude/dependabot* ]]; then
+            echo "min_approvals=1" >> "$GITHUB_OUTPUT"
+            echo "Dependabot PR detected; requiring 1 approval."
+          else
+            echo "min_approvals=2" >> "$GITHUB_OUTPUT"
+            echo "Requiring 2 approvals."
+          fi
+
+      # viamrobotics/claude-ci-workflows@v2.2.1
+      - name: Checkout claude-ci-workflows for composite action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: viamrobotics/claude-ci-workflows
+          ref: 5506bdaf04cc7d1adbd2df0f31f108834b01aea6
+          path: .claude-ci-workflows
+          sparse-checkout: |
+            .github/actions/check-approvals/
+          sparse-checkout-cone-mode: false
+
+      - name: Check approvals
+        uses: ./.claude-ci-workflows/.github/actions/check-approvals
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          min_approvals: ${{ steps.approvals.outputs.min_approvals }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -1,0 +1,55 @@
+name: Claude CI Fix
+
+on:
+  workflow_run:
+    workflows: ['Test']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Failed workflow run ID (from gh run list)'
+        required: true
+      branch:
+        description: 'PR branch name (e.g., claude/RSDK-123)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  call-ci-fix:
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      issues: write
+      id-token: write
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'failure' &&
+        startsWith(github.event.workflow_run.head_branch, 'claude/')
+      )
+    # viamrobotics/claude-ci-workflows@v2.2.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6
+    with:
+      container: ghcr.io/viamrobotics/rdk-devenv:amd64
+      run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
+      branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}
+      install_command: make tool-install
+      allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *)'
+      max_turns: 50
+      team_mention: '@viamrobotics/netcode'
+      extra_prompt: |
+        - Run only the verification commands relevant to the files you changed: `make lint-go` and `make test-go`.
+        - Do NOT run unrelated linters or test suites — they waste turns and time.
+        - If a test or lint command fails more than twice on the same issue, commit what you have, push, and note the unresolved issue in a PR comment.
+        - For Go test failures: read the failing test AND the function under test before making changes. Understand the data flow and what the test asserts, not just the error message.
+        - Before editing code, read 1-2 similar functions or tests in the same file to understand existing patterns and conventions.
+      extra_system_prompt: >-
+        This is a Go project (go.viam.com/utils).
+        Verify with `make lint-go` and `make test-go`. The rdk-devenv container has Go tooling pre-installed.
+        Do NOT modify generated protobuf code (files ending in `.pb.go` or under the `proto/` directory).
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -1,0 +1,130 @@
+name: Claude Jira Implementation
+
+# Triggered by Jira webhook via middleware that calls GitHub repository_dispatch API.
+# Expected payload:
+#   curl -X POST -H "Authorization: token $GITHUB_PAT" \
+#     https://api.github.com/repos/viamrobotics/goutils/dispatches \
+#     -d '{
+#       "event_type": "jira-ticket",
+#       "client_payload": {
+#         "ticket_id": "RSDK-123",
+#         "summary": "...",
+#         "description": "...",
+#         "task_complexity": "medium",
+#         "assignee": "John Doe",
+#         "assignee_email": "john@example.com"
+#       }
+#     }'
+
+on:
+  repository_dispatch:
+    types: [jira-ticket]
+  workflow_dispatch:
+    inputs:
+      ticket_id:
+        description: 'Jira ticket ID (e.g., RSDK-123)'
+        required: true
+      summary:
+        description: 'Ticket summary'
+        required: true
+      description:
+        description: 'Ticket description'
+        required: true
+      task_complexity:
+        description: 'Task complexity: small (100 turns), medium (150), large (200)'
+        required: false
+        default: 'small'
+        type: choice
+        options:
+          - small
+          - medium
+          - large
+      assignee:
+        description: 'Atlassian display name of the responsible engineer (e.g., "John Doe")'
+        required: false
+        default: ''
+      assignee_email:
+        description: 'Atlassian email of the responsible engineer'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  call-jira:
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+      id-token: write
+    # viamrobotics/claude-ci-workflows@v2.2.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6
+    with:
+      container: ghcr.io/viamrobotics/rdk-devenv:amd64
+      ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
+      summary: ${{ github.event.client_payload.summary || inputs.summary }}
+      description: ${{ github.event.client_payload.description || inputs.description }}
+      task_complexity: ${{ github.event.client_payload.task_complexity || inputs.task_complexity || 'small' }}
+      assignee: ${{ github.event.client_payload.assignee || inputs.assignee || '' }}
+      assignee_email: ${{ github.event.client_payload.assignee_email || inputs.assignee_email || '' }}
+      install_command: make tool-install
+      jira_base_url: ${{ vars.JIRA_BASE_URL }}
+      jira_user_email: ${{ vars.JIRA_USER_EMAIL }}
+      allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*),Bash(gh pr edit*),Bash(gh pr view*),Bash(gh pr diff*)'
+      extra_prompt: |
+        - Run `make lint-go` and `make test-go` to verify your changes before committing. Fix any errors.
+        - If a test or lint command fails more than twice on the same issue, commit what you have, create the PR, and note the unresolved issue in the PR description.
+        - Add the `safe to test` label to the PR after creation so CI can run: `gh pr edit <number> --add-label "safe to test"`.
+      extra_system_prompt: >-
+        This is a Go project (go.viam.com/utils).
+        Verify with `make lint-go` and `make test-go`. The rdk-devenv container has Go tooling pre-installed.
+        Do NOT modify generated protobuf code (files ending in `.pb.go` or under the `proto/` directory).
+        Jira ticket IDs use the RSDK prefix (e.g., RSDK-123). Use this in branch names: claude/RSDK-123.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI_GITHUB_APP_ID: ${{ secrets.CI_GITHUB_APP_ID }}
+      CI_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CI_GITHUB_APP_PRIVATE_KEY }}
+      SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL: ${{ secrets.SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+  # Comment this run's URL (the Claude output log) on the flaky-test PR just opened.
+  link-workflow-run:
+    needs: call-jira
+    if: always() && github.repository_owner == 'viamrobotics'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment workflow run link on the PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TICKET_ID: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # The reusable workflow enforces a "[<ticket_id>] ..." PR title.
+          pr="$(gh pr list --repo "$REPO" --state open --json number,title \
+            | jq -c --arg t "[${TICKET_ID}]" 'map(select(.title | startswith($t)))[0] // empty')"
+          if [[ -z "$pr" ]]; then
+            echo "No open PR found for $TICKET_ID; nothing to link."
+            exit 0
+          fi
+          pr_number="$(jq -r '.number' <<<"$pr")"
+          # Only flaky-test PRs, matching flaky-pr-reviewer.yml / check-approvals.yml.
+          if [[ "$(jq -r '.title' <<<"$pr" | tr '[:upper:]' '[:lower:]')" != *flaky* ]]; then
+            echo "PR #$pr_number is not a flaky-test PR; nothing to link."
+            exit 0
+          fi
+          marker="<!-- claude-workflow-run-link -->"
+          # Don't double-post on re-runs.
+          if gh pr view "$pr_number" --repo "$REPO" --json comments \
+              --jq '.comments[].body' | grep -qF "$marker"; then
+            echo "Run link already present on PR #$pr_number; skipping."
+            exit 0
+          fi
+          gh pr comment "$pr_number" --repo "$REPO" --body \
+            "${marker}"$'\n'"🤖 Opened by the Claude Jira workflow — [workflow run output / Claude log](${RUN_URL})."
+          echo "Linked ${RUN_URL} on PR #${pr_number}."

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -1,0 +1,51 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  on-demand:
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      issues: write
+      id-token: write
+    if: >-
+      github.repository_owner == 'viamrobotics' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && github.event.review.state != 'approved' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'claude/'))
+      )
+    # viamrobotics/claude-ci-workflows@v2.2.1
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6
+    with:
+      container: ghcr.io/viamrobotics/rdk-devenv:amd64
+      install_command: make tool-install
+      allowed_tools: 'Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr review*),Bash(gh pr comment*),Bash(gh pr view*),Bash(gh pr diff*)'
+      max_turns: 50
+      extra_review_instructions: |
+        - Ensure generated protobuf code (`.pb.go` files, `proto/` directory) was not manually modified.
+        - Only run verification commands relevant to the files you changed: `make lint-go` and `make test-go`.
+        - Do NOT run unrelated linters or test suites — they waste turns and time.
+        - If a test or lint command fails more than twice on the same issue, commit what you have, push, and note the unresolved issue in a PR comment.
+        - For Go test failures: read the failing test AND the function under test before making changes. Understand the data flow and what the test asserts, not just the error message.
+        - Before editing code, read 1-2 similar functions or tests in the same file to understand existing patterns and conventions.
+        - NEVER use curl, python3, or WebFetch to submit GitHub reviews. Use ONLY `gh pr review` and `gh pr comment`.
+      extra_system_prompt: >-
+        This is a Go project (go.viam.com/utils).
+        Verify with `make lint-go` and `make test-go`. The rdk-devenv container has Go tooling pre-installed.
+        Do NOT modify generated protobuf code (files ending in `.pb.go` or under the `proto/` directory).
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/flaky-pr-reviewer.yml
+++ b/.github/workflows/flaky-pr-reviewer.yml
@@ -1,0 +1,102 @@
+name: Assign Netcode Reviewer for Flaky PRs
+
+# Requests a round-robin review from a member of the @viamrobotics/netcode
+# team on flaky-test PRs opened from `claude/**` branches (e.g. the
+# claude-jira workflow). The team itself has no GitHub code-review-assignment
+# setting, so this workflow lists the team members (via a CI GitHub App token
+# with org member read) and picks one deterministically by PR number.
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  assign-netcode-reviewer:
+    # Only same-repo `claude/**` branches (never forks), so GITHUB_TOKEN has
+    # write access and these PRs are inherently trusted.
+    if: >-
+      github.repository_owner == 'viamrobotics' &&
+      startsWith(github.event.pull_request.head.ref, 'claude/')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write   # request reviewers on the PR
+    steps:
+      # Detect flaky-test PRs by title, matching check-approvals.yml. Title is
+      # read via env (never interpolated into the script) to avoid injection.
+      - name: Detect flaky-test PR
+        id: detect
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          title_lc="${PR_TITLE,,}"
+          if [[ "$title_lc" == *flaky* ]]; then
+            echo "is_flaky=true" >> "$GITHUB_OUTPUT"
+            echo "Flaky-test PR detected; will assign a netcode reviewer."
+          else
+            echo "is_flaky=false" >> "$GITHUB_OUTPUT"
+            echo "Not a flaky-test PR; nothing to do."
+          fi
+
+      # Token scoped to the org so we can read netcode team membership, which
+      # the default GITHUB_TOKEN cannot do. Requires the app installation to
+      # grant "Members: read".
+      - name: Mint org-scoped app token
+        id: app-token
+        if: steps.detect.outputs.is_flaky == 'true'
+        # actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.CI_GITHUB_APP_ID }}
+          private-key: ${{ secrets.CI_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Pick round-robin reviewer
+        id: pick
+        if: steps.detect.outputs.is_flaky == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Sort for a stable ordering so the selection is deterministic.
+          mapfile -t members < <(
+            gh api --paginate "orgs/${GITHUB_REPOSITORY_OWNER}/teams/netcode/members" --jq '.[].login' | sort
+          )
+          # Never request a review from the PR's own author.
+          filtered=()
+          for m in "${members[@]:-}"; do
+            [[ -n "$m" && "$m" != "$PR_AUTHOR" ]] && filtered+=("$m")
+          done
+          n=${#filtered[@]}
+          if (( n == 0 )); then
+            echo "No eligible netcode members found; skipping reviewer assignment."
+            echo "reviewer=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Derive the index from (PR number + head SHA) so the spread doesn't
+          # collide for PRs whose numbers are congruent mod n. Deterministic per
+          # PR: the head SHA is stable across opened/reopened/edited re-runs.
+          hash="$(printf '%s' "${PR_NUMBER}-${HEAD_SHA}" | sha256sum)"
+          idx=$(( 16#${hash:0:8} % n ))
+          reviewer="${filtered[$idx]}"
+          echo "reviewer=$reviewer" >> "$GITHUB_OUTPUT"
+          echo "Selected ${reviewer} (index ${idx} of ${n} eligible members)."
+
+      - name: Request review
+        if: steps.detect.outputs.is_flaky == 'true' && steps.pick.outputs.reviewer != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEWER: ${{ steps.pick.outputs.reviewer }}
+        run: |
+          # Requesting an already-requested reviewer is a no-op, so re-runs are safe.
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-reviewer "$REVIEWER"


### PR DESCRIPTION
Ports the Claude CI workflows from [`viamrobotics/rdk`](https://github.com/viamrobotics/rdk), adapted for goutils. All reference [`viamrobotics/claude-ci-workflows@v2.2.1`](https://github.com/viamrobotics/claude-ci-workflows) (SHA `5506bda`).

## Workflows added

| File | Purpose |
|---|---|
| `claude-ci-fix.yml` | Auto-fixes failing CI on `claude/**` branches (triggered when the `Test` workflow completes with a failure) |
| `claude-pr-assistant.yml` | Responds to `@claude` comments / reviews on PRs |
| `claude-jira.yml` | Implements a Jira ticket → PR via `repository_dispatch` |
| `check-approvals.yml` | Enforces a min approval count on `claude/**` PRs |
| `flaky-pr-reviewer.yml` | Round-robin-assigns a netcode reviewer to flaky-test PRs |
| `.claude/settings.ci.json` | Deny-list the workflows read at runtime |

## Adaptations vs rdk

- Module path `go.viam.com/rdk` → `go.viam.com/utils` in the system prompts
- Container `rdk-devenv:amd64-cache` → `rdk-devenv:amd64` (matches existing `license_finder.yml`)
- `claude-ci-fix` trigger workflow `Pull Request Update` → `Test` (same `pull_request_target` / `safe to test` pattern)
- Team mention → `@viamrobotics/netcode` (flaky-pr-reviewer already used netcode)
- Jira dispatch URL → `repos/viamrobotics/goutils/dispatches`
- `settings.ci.json` deny-list uses goutils build files (`mise.toml` instead of rdk's `android.make`/`packaging.make`/`etc/setup.sh`); protobuf guidance points at `proto/`

`check-approvals.yml` and `flaky-pr-reviewer.yml` are byte-identical to rdk's.

## Required before these run

These reference secrets/vars that must be provisioned in the goutils repo:

- **Secrets:** `ANTHROPIC_API_KEY` (all), `GIT_ACCESS_TOKEN` (ci-fix, pr-assistant), `CI_GITHUB_APP_ID` + `CI_GITHUB_APP_PRIVATE_KEY` (jira, flaky-pr-reviewer), `SLACK_AI_WORKFLOW_ALERT_WEBHOOK_URL` + `JIRA_API_TOKEN` (jira)
- **Vars:** `JIRA_BASE_URL`, `JIRA_USER_EMAIL` (jira)
- The CI GitHub App needs org **Members: read** for `flaky-pr-reviewer` to list netcode members
- To make `check-approvals` an actual gate, add it as a required status check on `main` branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)