### PR TITLE
rpc: disable mDNS when force_relay or force_p2p is set

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -135,6 +135,14 @@ func dial(
 		ctxParallel, cancelParallel = context.WithCancelCause(ctx)
 	)
 	defer cancelParallel(nil)
+	// force-relay and force-p2p exist to exercise a specific WebRTC transport
+	// (relay-only TURN candidates, or host/srflx-only). An mDNS connection
+	// short-circuits to a local gRPC connection that bypasses WebRTC/ICE
+	// entirely, silently defeating either flag, so disable mDNS whenever one
+	// is set.
+	if dOpts.webrtcOpts.ForceRelay || dOpts.webrtcOpts.ForceP2P {
+		dOpts.mdnsOptions.Disable = true
+	}
 	if !dOpts.mdnsOptions.Disable && tryLocal && isJustDomain {
 		wg.Add(1)
 		go func(dOpts dialOptions) {


### PR DESCRIPTION
## Problem
`force_relay` / `force_p2p` exist to force a connection through a specific WebRTC transport (relay-only TURN, or host/srflx-only). But `dial()` races mDNS local discovery against WebRTC and takes whichever connects first. When the target machine is reachable on the LAN/loopback, the mDNS path wins and connects via plain gRPC — bypassing WebRTC/ICE entirely and silently ignoring `force_relay`/`force_p2p`.

This breaks relay/p2p testing: a `force_relay` connection that should route through TURN instead connects locally, and a `force_relay` connection with a deliberately-invalid TURN URI (which must fail) succeeds over mDNS.

## Fix
Disable mDNS whenever `force_relay` or `force_p2p` is set — these flags are explicitly about exercising a specific WebRTC transport, so the mDNS short-circuit is never wanted alongside them. Today callers must do this manually (e.g. the dial-options integration tests pass `WithDialMulticastDNSOptions{Disable: true}`); this makes it automatic.

Draft for review/discussion.