### PR TITLE
Set OTel service name in trace spans exported to Cloud Trace

### DIFF
--- a/perf/exporters.go
+++ b/perf/exporters.go
@@ -82,6 +82,10 @@ func NewCloudExporter(opts CloudOptions) (Exporter, error) {
 		version = os.Getenv("CRWP_VERSION")
 	}
 	if module != "" {
+		sdOpts.DefaultTraceAttributes = map[string]any{
+			// OTel convention for service name, allows for easy filtering in GCP Cloud Trace.
+			"service.name": module,
+		}
 		// Allow for local testing with GCP_COMPUTE_ZONE
 		var err error
 		zone := os.Getenv("GCP_COMPUTE_ZONE")


### PR DESCRIPTION
Sets the `service.name` attribute on all spans exported to GCP Cloud Trace. This will allow us to use a very convenient checkbox to filter spans in the Trace Explorer UI.