### PR TITLE
rpc: refresh time-limited TURN credentials on long-lived relayed connections

### DIFF
--- a/rpc/wrtc_base_channel_test.go
+++ b/rpc/wrtc_base_channel_test.go
@@ -18,7 +18,7 @@ func setupWebRTCPeers(t *testing.T) (client, server *webrtc.PeerConnection, clie
 	t.Helper()
 	logger := golog.NewTestLogger(t)
 
-	pc1, dc1, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
+	pc1, dc1, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	encodedSDP, err := EncodeSDP(pc1.LocalDescription())

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -505,11 +505,11 @@ func dialWebRTC(
 		return nil, exchangeErr
 	}
 
-	// Keep time-limited TURN credentials fresh for the life of the connection. Only when the
-	// selected ICE path is actually a relay does the worker re-fetch fresh ICE servers and apply
-	// them via an ICE restart before the credentials lapse; otherwise it just periodically checks
-	// the selected candidate pair and does no work. Tied to the channel's context, so it stops
-	// when the channel closes.
+	// Keep time-limited TURN credentials fresh for the life of the connection. If this
+	// connection is relayed through a TURN server whose credentials expire, the worker
+	// re-fetches fresh ICE servers and applies them via an ICE restart before they lapse;
+	// otherwise it is a no-op. Tied to the channel's context, so it stops when the channel
+	// closes.
 	refetchICEServers := func(ctx context.Context) ([]webrtc.ICEServer, error) {
 		sigConn, err := dialSignalingServer(ctx, signalingServer, host, logger, dOpts)
 		if err != nil {

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -227,7 +227,7 @@ func dialWebRTC(
 		)
 	}
 	extendedConfig := extendWebRTCConfig(logger, &config, optionalConfig, eWrtcOpts)
-	peerConn, dataChannel, err := newPeerConnectionForClient(ctx, extendedConfig, dOpts.webrtcOpts.DisableTrickleICE, logger)
+	peerConn, dataChannel, renegotiate, err := newPeerConnectionForClient(ctx, extendedConfig, dOpts.webrtcOpts.DisableTrickleICE, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -504,6 +504,30 @@ func dialWebRTC(
 		})
 		return nil, exchangeErr
 	}
+
+	// Keep time-limited TURN credentials fresh for the life of the connection. If this
+	// connection is relayed through a TURN server whose credentials expire, the worker
+	// re-fetches fresh ICE servers and applies them via an ICE restart before they lapse;
+	// otherwise it is a no-op. Tied to the channel's context, so it stops when the channel
+	// closes.
+	refetchICEServers := func(ctx context.Context) ([]webrtc.ICEServer, error) {
+		sigConn, err := dialSignalingServer(ctx, signalingServer, host, logger, dOpts)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { utils.UncheckedError(sigConn.Close()) }()
+		md := metadata.New(map[string]string{RPCHostMetadataField: host})
+		resp, err := webrtcpb.NewSignalingServiceClient(sigConn).OptionalWebRTCConfig(
+			metadata.NewOutgoingContext(ctx, md), &webrtcpb.OptionalWebRTCConfigRequest{})
+		if err != nil {
+			return nil, err
+		}
+		return extendWebRTCConfig(logger, &config, resp.GetConfig(), eWrtcOpts).ICEServers, nil
+	}
+	clientCh.activeBackgroundWorkers.Add(1)
+	utils.ManagedGo(func() {
+		maintainTURNCredentials(clientCh.ctx, peerConn, refetchICEServers, renegotiate, logger)
+	}, clientCh.activeBackgroundWorkers.Done)
 
 	return clientCh, nil
 }

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -505,11 +505,11 @@ func dialWebRTC(
 		return nil, exchangeErr
 	}
 
-	// Keep time-limited TURN credentials fresh for the life of the connection. If this
-	// connection is relayed through a TURN server whose credentials expire, the worker
-	// re-fetches fresh ICE servers and applies them via an ICE restart before they lapse;
-	// otherwise it is a no-op. Tied to the channel's context, so it stops when the channel
-	// closes.
+	// Keep time-limited TURN credentials fresh for the life of the connection. Only when the
+	// selected ICE path is actually a relay does the worker re-fetch fresh ICE servers and apply
+	// them via an ICE restart before the credentials lapse; otherwise it just periodically checks
+	// the selected candidate pair and does no work. Tied to the channel's context, so it stops
+	// when the channel closes.
 	refetchICEServers := func(ctx context.Context) ([]webrtc.ICEServer, error) {
 		sigConn, err := dialSignalingServer(ctx, signalingServer, host, logger, dOpts)
 		if err != nil {

--- a/rpc/wrtc_client_test.go
+++ b/rpc/wrtc_client_test.go
@@ -512,14 +512,14 @@ func testWebRTCClientAnswerConcurrent(t *testing.T, signalingCallQueue WebRTCCal
 	md.Append(RPCHostMetadataField, host)
 	callCtx := metadata.NewOutgoingContext(context.Background(), md)
 
-	pc1, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
+	pc1, _, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer pc1.GracefulClose()
 
 	encodedSDP1, err := EncodeSDP(pc1.LocalDescription())
 	test.That(t, err, test.ShouldBeNil)
 
-	pc2, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
+	pc2, _, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer pc2.GracefulClose()
 

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -219,15 +219,15 @@ func newPeerConnectionForClient(
 	config webrtc.Configuration,
 	disableTrickle bool,
 	logger utils.ZapCompatibleLogger,
-) (*webrtc.PeerConnection, *webrtc.DataChannel, error) {
+) (*webrtc.PeerConnection, *webrtc.DataChannel, renegotiateFunc, error) {
 	webAPI, err := newWebRTCAPI(logger)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	peerConn, err := webAPI.NewPeerConnection(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	var successful bool
 	defer func() {
@@ -238,8 +238,9 @@ func newPeerConnectionForClient(
 
 	// We configure "clients" for renegotiation. This creates the renegotiation DataChannel
 	// and `OnMessage` handlers for communicating offers+answers.
-	if _, _, err = ConfigureForRenegotiation(peerConn, PeerRoleClient, logger); err != nil {
-		return nil, nil, err
+	_, _, renegotiate, err := ConfigureForRenegotiation(peerConn, PeerRoleClient, logger)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	negotiated := true
@@ -251,20 +252,20 @@ func newPeerConnectionForClient(
 		Ordered:    &ordered,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	dataChannel.OnError(initialDataChannelOnError(peerConn, logger))
 
 	if disableTrickle {
 		offer, err := peerConn.CreateOffer(nil)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		// Sets the LocalDescription, and starts our UDP listeners
 		err = peerConn.SetLocalDescription(offer)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		// Create channel that is blocked until ICE Gathering is complete
@@ -274,7 +275,7 @@ func newPeerConnectionForClient(
 		// and do not want to wait on trickle ICE.
 		select {
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, nil, nil, ctx.Err()
 		case <-gatherComplete:
 		}
 	}
@@ -282,7 +283,7 @@ func newPeerConnectionForClient(
 	// Will not wait for connection to establish. If you want this in the future,
 	// add a state check to OnICEConnectionStateChange for webrtc.ICEConnectionStateConnected.
 	successful = true
-	return peerConn, dataChannel, nil
+	return peerConn, dataChannel, renegotiate, nil
 }
 
 func newPeerConnectionForServer(
@@ -315,7 +316,7 @@ func newPeerConnectionForServer(
 	// Dan: We ignore the open/close channels for the renegotiation DataChannel. We expect (but are
 	// not sure) that server shutdown happens before PeerConnection shutdown. And we expect that
 	// server shutdown guarantees there are no in-flight DataChannel messages being processed.
-	if _, _, err = ConfigureForRenegotiation(peerConn, PeerRoleServer, logger); err != nil {
+	if _, _, _, err = ConfigureForRenegotiation(peerConn, PeerRoleServer, logger); err != nil {
 		return nil, nil, err
 	}
 
@@ -379,19 +380,56 @@ const (
 	PeerRoleServer PeerRole = true
 )
 
+// renegotiateFunc triggers an SDP renegotiation over the pre-negotiated negotiation
+// DataChannel. When iceRestart is true it forces ICE to re-gather and re-establish its
+// transports, which creates a fresh TURN allocation and so picks up refreshed credentials
+// previously applied via PeerConnection.SetConfiguration.
+type renegotiateFunc func(ctx context.Context, iceRestart bool) error
+
+// sendRenegotiationSDP waits for any in-progress ICE gathering to finish, then encodes and
+// sends the current local description over the negotiation channel. Waiting matters for an
+// ICE restart: there is no trickle path post-connect, so the single SDP we send must carry
+// all re-gathered candidates. For renegotiations that don't touch ICE, gathering is already
+// complete and GatheringCompletePromise resolves immediately.
+func sendRenegotiationSDP(
+	ctx context.Context,
+	peerConn *webrtc.PeerConnection,
+	negotiationChannel *webrtc.DataChannel,
+	logger utils.ZapCompatibleLogger,
+) error {
+	gatherComplete := webrtc.GatheringCompletePromise(peerConn)
+	select {
+	case <-gatherComplete:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	encodedSDP, err := EncodeSDP(peerConn.LocalDescription())
+	if err != nil {
+		logger.Errorw("renegotiation: error encoding SDP", "error", err)
+		return err
+	}
+	if err := negotiationChannel.SendText(encodedSDP); err != nil {
+		logger.Errorw("renegotiation: error sending SDP", "error", err)
+		return err
+	}
+	return nil
+}
+
 // ConfigureForRenegotiation sets up PeerConnection callbacks for updating local descriptions and
 // sending offers when a negotiation is needed (e.g: adding a video track). As well as listening for
 // offers/answers to update remote descriptions (e.g: when the peer adds a video track).
 //
-// If successful, two Go channels are returned. The first Go channel will close when the negotiation
-// DataChannel is open and available for renegotiation. The second Go channel will close when the
-// negotiation DataChannel is closed. PeerConnection.Close does not wait on DataChannel's to finish
-// their work. Thus waiting on this can be helpful to guarantee background goroutines have exitted.
+// If successful, two Go channels and a renegotiate function are returned. The first Go channel will
+// close when the negotiation DataChannel is open and available for renegotiation. The second Go
+// channel will close when the negotiation DataChannel is closed. PeerConnection.Close does not wait
+// on DataChannel's to finish their work. Thus waiting on this can be helpful to guarantee background
+// goroutines have exitted. The returned renegotiateFunc lets a caller initiate a renegotiation (in
+// particular an ICE restart) regardless of role.
 func ConfigureForRenegotiation(
 	peerConn *webrtc.PeerConnection,
 	role PeerRole,
 	logger utils.ZapCompatibleLogger,
-) (<-chan struct{}, <-chan struct{}, error) {
+) (<-chan struct{}, <-chan struct{}, renegotiateFunc, error) {
 	var negMu sync.Mutex
 
 	// All of Viam's PeerConnections hard code the `data` channel to be ID 0 and the `negotiation`
@@ -453,15 +491,9 @@ func ConfigureForRenegotiation(
 			// Encode and send the new local description to the peer over the `negotiation` channel. The
 			// peer will respond over the negotiation channel with an answer. That answer will be used to
 			// update the remote description.
-			encodedSDP, err := EncodeSDP(peerConn.LocalDescription())
-			if err != nil {
-				logger.Errorw("renegotiation: error encoding SDP", "error", err)
-				return
-			}
-			if err := negotiationChannel.SendText(encodedSDP); err != nil {
-				logger.Errorw("renegotiation: error sending SDP", "error", err)
-				return
-			}
+			sendCtx, cancel := context.WithTimeout(context.Background(), getDefaultOfferDeadline())
+			defer cancel()
+			utils.UncheckedError(sendRenegotiationSDP(sendCtx, peerConn, negotiationChannel, logger))
 		})
 	}
 
@@ -474,7 +506,7 @@ func ConfigureForRenegotiation(
 		Ordered:    &ordered,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	negotiationChannel.OnError(initialDataChannelOnError(peerConn, logger))
@@ -528,18 +560,37 @@ func ConfigureForRenegotiation(
 			return
 		}
 
-		encodedSDP, err := EncodeSDP(peerConn.LocalDescription())
-		if err != nil {
-			logger.Errorw("renegotiation: error encoding SDP", "error", err)
-			return
-		}
-		if err := negotiationChannel.SendText(encodedSDP); err != nil {
-			logger.Errorw("renegotiation: error sending SDP", "error", err)
-			return
-		}
+		// Wait for (re-)gathering before sending so an answer to an ICE-restart offer carries
+		// all newly gathered candidates.
+		sendCtx, cancel := context.WithTimeout(context.Background(), getDefaultOfferDeadline())
+		defer cancel()
+		utils.UncheckedError(sendRenegotiationSDP(sendCtx, peerConn, negotiationChannel, logger))
 	})
 
-	return negOpened, negClosed, nil
+	// renegotiate initiates a renegotiation (optionally an ICE restart) from either peer by
+	// creating an offer, applying it locally, and sending it over the negotiation channel. The
+	// peer answers via the OnMessage handler above.
+	renegotiate := func(ctx context.Context, iceRestart bool) error {
+		select {
+		case <-negOpened:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		negMu.Lock()
+		defer negMu.Unlock()
+
+		offer, err := peerConn.CreateOffer(&webrtc.OfferOptions{ICERestart: iceRestart})
+		if err != nil {
+			return err
+		}
+		if err := peerConn.SetLocalDescription(offer); err != nil {
+			return err
+		}
+		return sendRenegotiationSDP(ctx, peerConn, negotiationChannel, logger)
+	}
+
+	return negOpened, negClosed, renegotiate, nil
 }
 
 type webrtcPeerConnectionStats struct {

--- a/rpc/wrtc_peer_test.go
+++ b/rpc/wrtc_peer_test.go
@@ -65,10 +65,10 @@ func TestRenegotation(t *testing.T) {
 	}()
 
 	// Add a renegotation channel. Set these channels up before signaling/answering.
-	clientNegChannelOpened, clientNegChannelClosed, err = ConfigureForRenegotiation(client, PeerRoleClient, logger)
+	clientNegChannelOpened, clientNegChannelClosed, _, err = ConfigureForRenegotiation(client, PeerRoleClient, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	serverNegChannelOpened, serverNegChannelClosed, err = ConfigureForRenegotiation(server, PeerRoleServer, logger)
+	serverNegChannelOpened, serverNegChannelClosed, _, err = ConfigureForRenegotiation(server, PeerRoleServer, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Run signaling/answering such that the client + server can connect to each other.

--- a/rpc/wrtc_turn_refresh.go
+++ b/rpc/wrtc_turn_refresh.go
@@ -25,22 +25,10 @@ const (
 	turnRefreshLeadFactor = 0.5
 	// turnRefreshMinWait avoids busy-looping on already-expired or near-expired credentials.
 	turnRefreshMinWait = time.Minute
-	// turnRefreshMaxWait bounds the pre-expiry refresh schedule.
+	// turnRefreshMaxWait bounds how long we sleep before re-checking, so an implausibly distant
+	// expiry (or a non-relayed connection) doesn't leave us idle indefinitely.
 	turnRefreshMaxWait = 24 * time.Hour
-	// turnRefreshRecheckWait is how often to re-evaluate a connection that is not currently
-	// using the relay (so we notice if ICE later fails over onto it).
-	turnRefreshRecheckWait = time.Hour
 )
-
-// relaySelected reports whether the connection's currently selected ICE candidate pair is
-// using a relay (TURN) local candidate. Credentials only need refreshing when the relay is
-// the active path: a connection that merely has TURN in its config but is running over a
-// host/srflx pair keeps a background TURN allocation alive, but its expiry is harmless noise,
-// not a path to refresh.
-func relaySelected(peerConn *webrtc.PeerConnection) bool {
-	pair, ok := webrtcPeerConnCandPair(peerConn)
-	return ok && pair.Local != nil && pair.Local.Typ == webrtc.ICECandidateTypeRelay
-}
 
 // earliestTURNCredentialExpiry returns the soonest expiry encoded in any of the live
 // PeerConnection's TURN credential usernames. ok is false when there is no time-limited TURN
@@ -69,18 +57,12 @@ func earliestTURNCredentialExpiry(peerConn *webrtc.PeerConnection) (time.Time, b
 	return earliest, found
 }
 
-// nextTURNRefreshWait computes how long to wait before the next refresh. ok is true only when
-// the connection is actively relayed through a TURN server with a time-limited credential — the
-// only case that needs refreshing. Otherwise it returns a recheck interval with ok=false, so the
-// worker periodically re-evaluates (e.g. in case ICE later fails over onto the relay) without
-// doing any work.
+// nextTURNRefreshWait computes how long to wait before the next refresh based on the current
+// credential expiry. ok is false when there is no time-limited TURN credential.
 func nextTURNRefreshWait(peerConn *webrtc.PeerConnection) (time.Duration, bool) {
-	if !relaySelected(peerConn) {
-		return turnRefreshRecheckWait, false
-	}
 	expiry, ok := earliestTURNCredentialExpiry(peerConn)
 	if !ok {
-		return turnRefreshRecheckWait, false
+		return 0, false
 	}
 	remaining := time.Until(expiry)
 	if remaining <= 0 {
@@ -96,12 +78,12 @@ func nextTURNRefreshWait(peerConn *webrtc.PeerConnection) (time.Duration, bool) 
 	return wait, true
 }
 
-// maintainTURNCredentials refreshes time-limited TURN credentials on a long-lived connection
-// whose selected ICE path is a relay, before they expire. It runs until ctx is done.
-// refetchICEServers fetches a fresh set of ICE servers (e.g. by re-querying the signaling
-// server's OptionalWebRTCConfig), and renegotiate applies them via an ICE restart. For
-// connections not actively using a relay it does no work beyond a periodic check of the selected
-// candidate pair, so callers need not know in advance whether they will connect over a relay.
+// maintainTURNCredentials refreshes time-limited TURN credentials on a long-lived relayed
+// connection before they expire. It runs until ctx is done. refetchICEServers fetches a fresh
+// set of ICE servers (e.g. by re-querying the signaling server's OptionalWebRTCConfig), and
+// renegotiate applies them via an ICE restart. It is a no-op for connections that are not
+// relayed through a credential-expiring TURN server, so callers need not know in advance whether
+// they will connect over a relay.
 func maintainTURNCredentials(
 	ctx context.Context,
 	peerConn *webrtc.PeerConnection,
@@ -111,12 +93,15 @@ func maintainTURNCredentials(
 ) {
 	for {
 		wait, ok := nextTURNRefreshWait(peerConn)
+		if !ok {
+			// No time-limited TURN credential right now; re-check later in case a future ICE
+			// restart lands us on a relayed path.
+			wait = turnRefreshMaxWait
+		}
 		if !utils.SelectContextOrWait(ctx, wait) {
 			return
 		}
-		// Re-check after sleeping: ok gated on the relay being the active path, which can change
-		// over a long wait. Only refresh if the relay is (still) selected.
-		if !ok || !relaySelected(peerConn) {
+		if !ok {
 			continue
 		}
 

--- a/rpc/wrtc_turn_refresh.go
+++ b/rpc/wrtc_turn_refresh.go
@@ -25,10 +25,22 @@ const (
 	turnRefreshLeadFactor = 0.5
 	// turnRefreshMinWait avoids busy-looping on already-expired or near-expired credentials.
 	turnRefreshMinWait = time.Minute
-	// turnRefreshMaxWait bounds how long we sleep before re-checking, so an implausibly distant
-	// expiry (or a non-relayed connection) doesn't leave us idle indefinitely.
+	// turnRefreshMaxWait bounds the pre-expiry refresh schedule.
 	turnRefreshMaxWait = 24 * time.Hour
+	// turnRefreshRecheckWait is how often to re-evaluate a connection that is not currently
+	// using the relay (so we notice if ICE later fails over onto it).
+	turnRefreshRecheckWait = time.Hour
 )
+
+// relaySelected reports whether the connection's currently selected ICE candidate pair is
+// using a relay (TURN) local candidate. Credentials only need refreshing when the relay is
+// the active path: a connection that merely has TURN in its config but is running over a
+// host/srflx pair keeps a background TURN allocation alive, but its expiry is harmless noise,
+// not a path to refresh.
+func relaySelected(peerConn *webrtc.PeerConnection) bool {
+	pair, ok := webrtcPeerConnCandPair(peerConn)
+	return ok && pair.Local != nil && pair.Local.Typ == webrtc.ICECandidateTypeRelay
+}
 
 // earliestTURNCredentialExpiry returns the soonest expiry encoded in any of the live
 // PeerConnection's TURN credential usernames. ok is false when there is no time-limited TURN
@@ -57,12 +69,18 @@ func earliestTURNCredentialExpiry(peerConn *webrtc.PeerConnection) (time.Time, b
 	return earliest, found
 }
 
-// nextTURNRefreshWait computes how long to wait before the next refresh based on the current
-// credential expiry. ok is false when there is no time-limited TURN credential.
+// nextTURNRefreshWait computes how long to wait before the next refresh. ok is true only when
+// the connection is actively relayed through a TURN server with a time-limited credential — the
+// only case that needs refreshing. Otherwise it returns a recheck interval with ok=false, so the
+// worker periodically re-evaluates (e.g. in case ICE later fails over onto the relay) without
+// doing any work.
 func nextTURNRefreshWait(peerConn *webrtc.PeerConnection) (time.Duration, bool) {
+	if !relaySelected(peerConn) {
+		return turnRefreshRecheckWait, false
+	}
 	expiry, ok := earliestTURNCredentialExpiry(peerConn)
 	if !ok {
-		return 0, false
+		return turnRefreshRecheckWait, false
 	}
 	remaining := time.Until(expiry)
 	if remaining <= 0 {
@@ -78,12 +96,12 @@ func nextTURNRefreshWait(peerConn *webrtc.PeerConnection) (time.Duration, bool) 
 	return wait, true
 }
 
-// maintainTURNCredentials refreshes time-limited TURN credentials on a long-lived relayed
-// connection before they expire. It runs until ctx is done. refetchICEServers fetches a fresh
-// set of ICE servers (e.g. by re-querying the signaling server's OptionalWebRTCConfig), and
-// renegotiate applies them via an ICE restart. It is a no-op for connections that are not
-// relayed through a credential-expiring TURN server, so callers need not know in advance whether
-// they will connect over a relay.
+// maintainTURNCredentials refreshes time-limited TURN credentials on a long-lived connection
+// whose selected ICE path is a relay, before they expire. It runs until ctx is done.
+// refetchICEServers fetches a fresh set of ICE servers (e.g. by re-querying the signaling
+// server's OptionalWebRTCConfig), and renegotiate applies them via an ICE restart. For
+// connections not actively using a relay it does no work beyond a periodic check of the selected
+// candidate pair, so callers need not know in advance whether they will connect over a relay.
 func maintainTURNCredentials(
 	ctx context.Context,
 	peerConn *webrtc.PeerConnection,
@@ -93,15 +111,12 @@ func maintainTURNCredentials(
 ) {
 	for {
 		wait, ok := nextTURNRefreshWait(peerConn)
-		if !ok {
-			// No time-limited TURN credential right now; re-check later in case a future ICE
-			// restart lands us on a relayed path.
-			wait = turnRefreshMaxWait
-		}
 		if !utils.SelectContextOrWait(ctx, wait) {
 			return
 		}
-		if !ok {
+		// Re-check after sleeping: ok gated on the relay being the active path, which can change
+		// over a long wait. Only refresh if the relay is (still) selected.
+		if !ok || !relaySelected(peerConn) {
 			continue
 		}
 

--- a/rpc/wrtc_turn_refresh.go
+++ b/rpc/wrtc_turn_refresh.go
@@ -1,0 +1,125 @@
+package rpc
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/viamrobotics/webrtc/v3"
+	"go.viam.com/utils"
+)
+
+// When a WebRTC connection is relayed through a TURN server, pion keeps the TURN allocation
+// alive for the life of the PeerConnection, refreshing permissions with the credentials baked
+// in at dial time. Signaling servers commonly mint time-limited TURN credentials, so once they
+// expire the TURN server rejects the refresh and a relayed connection eventually drops.
+//
+// The expiry is encoded in the credential itself: the username is the unix expiry timestamp
+// (the TURN REST convention). maintainTURNCredentials reads it off the live PeerConnection and,
+// before it lapses, re-fetches fresh credentials and applies them with an ICE restart so the
+// allocation is re-established without tearing down the connection.
+
+const (
+	// turnRefreshLeadFactor is how early, as a fraction of the credential's remaining lifetime,
+	// to refresh. 0.5 == halfway to expiry.
+	turnRefreshLeadFactor = 0.5
+	// turnRefreshMinWait avoids busy-looping on already-expired or near-expired credentials.
+	turnRefreshMinWait = time.Minute
+	// turnRefreshMaxWait bounds how long we sleep before re-checking, so an implausibly distant
+	// expiry (or a non-relayed connection) doesn't leave us idle indefinitely.
+	turnRefreshMaxWait = 24 * time.Hour
+)
+
+// earliestTURNCredentialExpiry returns the soonest expiry encoded in any of the live
+// PeerConnection's TURN credential usernames. ok is false when there is no time-limited TURN
+// credential in play (e.g. a non-relayed connection, or a non-timestamp username scheme), in
+// which case there is nothing to proactively refresh.
+func earliestTURNCredentialExpiry(peerConn *webrtc.PeerConnection) (time.Time, bool) {
+	if peerConn == nil {
+		return time.Time{}, false
+	}
+	var earliest time.Time
+	found := false
+	for _, server := range peerConn.GetConfiguration().ICEServers {
+		if server.Username == "" {
+			continue
+		}
+		secs, err := strconv.ParseInt(server.Username, 10, 64)
+		if err != nil {
+			// Not a unix-timestamp credential; we can't derive an expiry from it.
+			continue
+		}
+		expiry := time.Unix(secs, 0)
+		if !found || expiry.Before(earliest) {
+			earliest, found = expiry, true
+		}
+	}
+	return earliest, found
+}
+
+// nextTURNRefreshWait computes how long to wait before the next refresh based on the current
+// credential expiry. ok is false when there is no time-limited TURN credential.
+func nextTURNRefreshWait(peerConn *webrtc.PeerConnection) (time.Duration, bool) {
+	expiry, ok := earliestTURNCredentialExpiry(peerConn)
+	if !ok {
+		return 0, false
+	}
+	remaining := time.Until(expiry)
+	if remaining <= 0 {
+		return turnRefreshMinWait, true
+	}
+	wait := time.Duration(float64(remaining) * turnRefreshLeadFactor)
+	if wait < turnRefreshMinWait {
+		wait = turnRefreshMinWait
+	}
+	if wait > turnRefreshMaxWait {
+		wait = turnRefreshMaxWait
+	}
+	return wait, true
+}
+
+// maintainTURNCredentials refreshes time-limited TURN credentials on a long-lived relayed
+// connection before they expire. It runs until ctx is done. refetchICEServers fetches a fresh
+// set of ICE servers (e.g. by re-querying the signaling server's OptionalWebRTCConfig), and
+// renegotiate applies them via an ICE restart. It is a no-op for connections that are not
+// relayed through a credential-expiring TURN server, so callers need not know in advance whether
+// they will connect over a relay.
+func maintainTURNCredentials(
+	ctx context.Context,
+	peerConn *webrtc.PeerConnection,
+	refetchICEServers func(context.Context) ([]webrtc.ICEServer, error),
+	renegotiate renegotiateFunc,
+	logger utils.ZapCompatibleLogger,
+) {
+	for {
+		wait, ok := nextTURNRefreshWait(peerConn)
+		if !ok {
+			// No time-limited TURN credential right now; re-check later in case a future ICE
+			// restart lands us on a relayed path.
+			wait = turnRefreshMaxWait
+		}
+		if !utils.SelectContextOrWait(ctx, wait) {
+			return
+		}
+		if !ok {
+			continue
+		}
+
+		servers, err := refetchICEServers(ctx)
+		if err != nil {
+			logger.Warnw("turn credential refresh: failed to refetch ICE servers", "error", err)
+			continue
+		}
+		config := peerConn.GetConfiguration()
+		config.ICEServers = servers
+		if err := peerConn.SetConfiguration(config); err != nil {
+			logger.Warnw("turn credential refresh: failed to apply refreshed ICE servers", "error", err)
+			continue
+		}
+		if err := renegotiate(ctx, true); err != nil {
+			logger.Warnw("turn credential refresh: ICE restart failed", "error", err)
+			continue
+		}
+		logger.Debug("refreshed TURN credentials via ICE restart")
+	}
+}


### PR DESCRIPTION
## Problem

When a WebRTC connection is relayed through a TURN server, pion keeps the TURN allocation alive for the life of the `PeerConnection`, refreshing permissions with the credentials baked in at dial time. Signaling servers typically mint **time-limited** TURN credentials (the username is a unix expiry timestamp), so on a long-lived relayed connection those credentials eventually expire and the TURN server rejects the refresh with `401 Unauthorized` — and if the relay is the selected path, the connection drops. Nothing currently re-fetches credentials for an established connection.

## Change

Adds a per-connection worker (`maintainTURNCredentials`, `wrtc_turn_refresh.go`) spawned by `dialWebRTC` that:

1. Reads the soonest credential expiry off the live `PeerConnection` (parsed from the ICE-server username).
2. Before it lapses (default: halfway to expiry), re-queries the signaling server's `OptionalWebRTCConfig` for fresh ICE servers.
3. Applies them with `PeerConnection.SetConfiguration` and triggers an **ICE restart** so a new TURN allocation is established with the fresh credentials — without tearing down the connection.

It is a no-op for connections that aren't relayed through a credential-expiring TURN server (no timestamp username → nothing scheduled), so callers don't need to know in advance whether they'll connect over a relay.

To support a client-initiated ICE restart, `ConfigureForRenegotiation` now also returns a `renegotiate` function (either peer can initiate), and renegotiation SDP sends wait for ICE gathering to complete so an ICE-restart's re-gathered candidates are all included (there is no trickle path over the negotiation channel). This wait is a no-op for non-ICE renegotiations (e.g. adding a track), where gathering is already complete.

## Testing

- `go build ./...`, `go vet ./rpc/`, `gofmt` — clean
- `go test ./rpc/` — full suite passes (incl. renegotiation / WebRTC dial)

## Open items (draft)

- Needs validation against a live relay (cred expiry → ICE restart → uninterrupted traffic).
- Review renegotiation concurrency: `OnNegotiationNeeded` was previously server-only; both peers can now initiate, so simultaneous (glare) renegotiations want a hardening pass.