### PR TITLE
rpc: refresh relayed TURN credentials via server-initiated ICE restart

### DIFF
--- a/rpc/wrtc_base_channel_test.go
+++ b/rpc/wrtc_base_channel_test.go
@@ -18,13 +18,13 @@ func setupWebRTCPeers(t *testing.T) (client, server *webrtc.PeerConnection, clie
 	t.Helper()
 	logger := golog.NewTestLogger(t)
 
-	pc1, dc1, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
+	pc1, dc1, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	encodedSDP, err := EncodeSDP(pc1.LocalDescription())
 	test.That(t, err, test.ShouldBeNil)
 
-	pc2, dc2, err := newPeerConnectionForServer(context.Background(), encodedSDP, webrtc.Configuration{}, true, logger)
+	pc2, dc2, _, err := newPeerConnectionForServer(context.Background(), encodedSDP, webrtc.Configuration{}, true, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	test.That(t, pc1.SetRemoteDescription(*pc2.LocalDescription()), test.ShouldBeNil)

--- a/rpc/wrtc_client.go
+++ b/rpc/wrtc_client.go
@@ -227,7 +227,7 @@ func dialWebRTC(
 		)
 	}
 	extendedConfig := extendWebRTCConfig(logger, &config, optionalConfig, eWrtcOpts)
-	peerConn, dataChannel, err := newPeerConnectionForClient(ctx, extendedConfig, dOpts.webrtcOpts.DisableTrickleICE, logger)
+	peerConn, dataChannel, _, err := newPeerConnectionForClient(ctx, extendedConfig, dOpts.webrtcOpts.DisableTrickleICE, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -504,6 +504,29 @@ func dialWebRTC(
 		})
 		return nil, exchangeErr
 	}
+
+	// Keep our own TURN credentials fresh while the connection is relayed, so that when the server
+	// initiates an ICE restart (the sole initiator, to avoid glare) we re-gather a fresh relay
+	// allocation. This is config-only; the client never initiates a renegotiation. It is a no-op
+	// unless the connection is actually using a relay.
+	refetchICEServers := func(ctx context.Context) ([]webrtc.ICEServer, error) {
+		sigConn, err := dialSignalingServer(ctx, signalingServer, host, logger, dOpts)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { utils.UncheckedError(sigConn.Close()) }()
+		md := metadata.New(map[string]string{RPCHostMetadataField: host})
+		resp, err := webrtcpb.NewSignalingServiceClient(sigConn).OptionalWebRTCConfig(
+			metadata.NewOutgoingContext(ctx, md), &webrtcpb.OptionalWebRTCConfigRequest{})
+		if err != nil {
+			return nil, err
+		}
+		return extendWebRTCConfig(logger, &config, resp.GetConfig(), eWrtcOpts).ICEServers, nil
+	}
+	clientCh.activeBackgroundWorkers.Add(1)
+	utils.ManagedGo(func() {
+		refreshOwnTURNCredentials(clientCh.ctx, peerConn, refetchICEServers, logger)
+	}, clientCh.activeBackgroundWorkers.Done)
 
 	return clientCh, nil
 }

--- a/rpc/wrtc_client_test.go
+++ b/rpc/wrtc_client_test.go
@@ -512,14 +512,14 @@ func testWebRTCClientAnswerConcurrent(t *testing.T, signalingCallQueue WebRTCCal
 	md.Append(RPCHostMetadataField, host)
 	callCtx := metadata.NewOutgoingContext(context.Background(), md)
 
-	pc1, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
+	pc1, _, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer pc1.GracefulClose()
 
 	encodedSDP1, err := EncodeSDP(pc1.LocalDescription())
 	test.That(t, err, test.ShouldBeNil)
 
-	pc2, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
+	pc2, _, _, err := newPeerConnectionForClient(context.Background(), webrtc.Configuration{}, true, logger)
 	test.That(t, err, test.ShouldBeNil)
 	defer pc2.GracefulClose()
 

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -219,15 +219,15 @@ func newPeerConnectionForClient(
 	config webrtc.Configuration,
 	disableTrickle bool,
 	logger utils.ZapCompatibleLogger,
-) (*webrtc.PeerConnection, *webrtc.DataChannel, error) {
+) (*webrtc.PeerConnection, *webrtc.DataChannel, renegotiateFunc, error) {
 	webAPI, err := newWebRTCAPI(logger)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	peerConn, err := webAPI.NewPeerConnection(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	var successful bool
 	defer func() {
@@ -238,8 +238,9 @@ func newPeerConnectionForClient(
 
 	// We configure "clients" for renegotiation. This creates the renegotiation DataChannel
 	// and `OnMessage` handlers for communicating offers+answers.
-	if _, _, err = ConfigureForRenegotiation(peerConn, PeerRoleClient, logger); err != nil {
-		return nil, nil, err
+	_, _, renegotiate, err := ConfigureForRenegotiation(peerConn, PeerRoleClient, logger)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	negotiated := true
@@ -251,20 +252,20 @@ func newPeerConnectionForClient(
 		Ordered:    &ordered,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	dataChannel.OnError(initialDataChannelOnError(peerConn, logger))
 
 	if disableTrickle {
 		offer, err := peerConn.CreateOffer(nil)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		// Sets the LocalDescription, and starts our UDP listeners
 		err = peerConn.SetLocalDescription(offer)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		// Create channel that is blocked until ICE Gathering is complete
@@ -274,7 +275,7 @@ func newPeerConnectionForClient(
 		// and do not want to wait on trickle ICE.
 		select {
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, nil, nil, ctx.Err()
 		case <-gatherComplete:
 		}
 	}
@@ -282,7 +283,7 @@ func newPeerConnectionForClient(
 	// Will not wait for connection to establish. If you want this in the future,
 	// add a state check to OnICEConnectionStateChange for webrtc.ICEConnectionStateConnected.
 	successful = true
-	return peerConn, dataChannel, nil
+	return peerConn, dataChannel, renegotiate, nil
 }
 
 func newPeerConnectionForServer(
@@ -291,15 +292,15 @@ func newPeerConnectionForServer(
 	config webrtc.Configuration,
 	disableTrickle bool,
 	logger utils.ZapCompatibleLogger,
-) (*webrtc.PeerConnection, *webrtc.DataChannel, error) {
+) (*webrtc.PeerConnection, *webrtc.DataChannel, renegotiateFunc, error) {
 	webAPI, err := newWebRTCAPI(logger)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	peerConn, err := webAPI.NewPeerConnection(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	var successful bool
 	defer func() {
@@ -312,11 +313,15 @@ func newPeerConnectionForServer(
 	// - Creates the DataChannel and `OnMessage` handlers for communicating offers+answers.
 	// - Sets up an `OnNegotiationNeeded` callback to initiate an SDP change.
 	//
+	// The returned renegotiate function lets the server initiate an ICE restart (e.g. to refresh
+	// relayed TURN credentials); the server is the sole initiator, which avoids glare.
+	//
 	// Dan: We ignore the open/close channels for the renegotiation DataChannel. We expect (but are
 	// not sure) that server shutdown happens before PeerConnection shutdown. And we expect that
 	// server shutdown guarantees there are no in-flight DataChannel messages being processed.
-	if _, _, err = ConfigureForRenegotiation(peerConn, PeerRoleServer, logger); err != nil {
-		return nil, nil, err
+	_, _, renegotiate, err := ConfigureForRenegotiation(peerConn, PeerRoleServer, logger)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	negotiated := true
@@ -328,29 +333,29 @@ func newPeerConnectionForServer(
 		Ordered:    &ordered,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	dataChannel.OnError(initialDataChannelOnError(peerConn, logger))
 
 	offer := webrtc.SessionDescription{}
 	if err := DecodeSDP(sdp, &offer); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	err = peerConn.SetRemoteDescription(offer)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if disableTrickle {
 		answer, err := peerConn.CreateAnswer(nil)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		err = peerConn.SetLocalDescription(answer)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		// Create channel that is blocked until ICE Gathering is complete
@@ -360,13 +365,13 @@ func newPeerConnectionForServer(
 		// and do not want to wait on trickle ICE.
 		select {
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, nil, nil, ctx.Err()
 		case <-gatherComplete:
 		}
 	}
 
 	successful = true
-	return peerConn, dataChannel, nil
+	return peerConn, dataChannel, renegotiate, nil
 }
 
 // PeerRole identifies which role of a Client/Server relationship a peer is assuming.
@@ -379,19 +384,56 @@ const (
 	PeerRoleServer PeerRole = true
 )
 
+// renegotiateFunc triggers an SDP renegotiation over the pre-negotiated negotiation
+// DataChannel. When iceRestart is true it forces ICE to re-gather and re-establish its
+// transports, which creates a fresh TURN allocation and so picks up refreshed credentials
+// previously applied via PeerConnection.SetConfiguration.
+type renegotiateFunc func(ctx context.Context, iceRestart bool) error
+
+// sendRenegotiationSDP waits for any in-progress ICE gathering to finish, then encodes and
+// sends the current local description over the negotiation channel. Waiting matters for an
+// ICE restart: there is no trickle path post-connect, so the single SDP we send must carry
+// all re-gathered candidates. For renegotiations that don't touch ICE, gathering is already
+// complete and GatheringCompletePromise resolves immediately.
+func sendRenegotiationSDP(
+	ctx context.Context,
+	peerConn *webrtc.PeerConnection,
+	negotiationChannel *webrtc.DataChannel,
+	logger utils.ZapCompatibleLogger,
+) error {
+	gatherComplete := webrtc.GatheringCompletePromise(peerConn)
+	select {
+	case <-gatherComplete:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	encodedSDP, err := EncodeSDP(peerConn.LocalDescription())
+	if err != nil {
+		logger.Errorw("renegotiation: error encoding SDP", "error", err)
+		return err
+	}
+	if err := negotiationChannel.SendText(encodedSDP); err != nil {
+		logger.Errorw("renegotiation: error sending SDP", "error", err)
+		return err
+	}
+	return nil
+}
+
 // ConfigureForRenegotiation sets up PeerConnection callbacks for updating local descriptions and
 // sending offers when a negotiation is needed (e.g: adding a video track). As well as listening for
 // offers/answers to update remote descriptions (e.g: when the peer adds a video track).
 //
-// If successful, two Go channels are returned. The first Go channel will close when the negotiation
-// DataChannel is open and available for renegotiation. The second Go channel will close when the
-// negotiation DataChannel is closed. PeerConnection.Close does not wait on DataChannel's to finish
-// their work. Thus waiting on this can be helpful to guarantee background goroutines have exitted.
+// If successful, two Go channels and a renegotiate function are returned. The first Go channel will
+// close when the negotiation DataChannel is open and available for renegotiation. The second Go
+// channel will close when the negotiation DataChannel is closed. PeerConnection.Close does not wait
+// on DataChannel's to finish their work. Thus waiting on this can be helpful to guarantee background
+// goroutines have exitted. The returned renegotiateFunc lets a caller initiate a renegotiation (in
+// particular an ICE restart) regardless of role.
 func ConfigureForRenegotiation(
 	peerConn *webrtc.PeerConnection,
 	role PeerRole,
 	logger utils.ZapCompatibleLogger,
-) (<-chan struct{}, <-chan struct{}, error) {
+) (<-chan struct{}, <-chan struct{}, renegotiateFunc, error) {
 	var negMu sync.Mutex
 
 	// All of Viam's PeerConnections hard code the `data` channel to be ID 0 and the `negotiation`
@@ -453,15 +495,9 @@ func ConfigureForRenegotiation(
 			// Encode and send the new local description to the peer over the `negotiation` channel. The
 			// peer will respond over the negotiation channel with an answer. That answer will be used to
 			// update the remote description.
-			encodedSDP, err := EncodeSDP(peerConn.LocalDescription())
-			if err != nil {
-				logger.Errorw("renegotiation: error encoding SDP", "error", err)
-				return
-			}
-			if err := negotiationChannel.SendText(encodedSDP); err != nil {
-				logger.Errorw("renegotiation: error sending SDP", "error", err)
-				return
-			}
+			sendCtx, cancel := context.WithTimeout(context.Background(), getDefaultOfferDeadline())
+			defer cancel()
+			utils.UncheckedError(sendRenegotiationSDP(sendCtx, peerConn, negotiationChannel, logger))
 		})
 	}
 
@@ -474,7 +510,7 @@ func ConfigureForRenegotiation(
 		Ordered:    &ordered,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	negotiationChannel.OnError(initialDataChannelOnError(peerConn, logger))
@@ -528,18 +564,37 @@ func ConfigureForRenegotiation(
 			return
 		}
 
-		encodedSDP, err := EncodeSDP(peerConn.LocalDescription())
-		if err != nil {
-			logger.Errorw("renegotiation: error encoding SDP", "error", err)
-			return
-		}
-		if err := negotiationChannel.SendText(encodedSDP); err != nil {
-			logger.Errorw("renegotiation: error sending SDP", "error", err)
-			return
-		}
+		// Wait for (re-)gathering before sending so an answer to an ICE-restart offer carries
+		// all newly gathered candidates.
+		sendCtx, cancel := context.WithTimeout(context.Background(), getDefaultOfferDeadline())
+		defer cancel()
+		utils.UncheckedError(sendRenegotiationSDP(sendCtx, peerConn, negotiationChannel, logger))
 	})
 
-	return negOpened, negClosed, nil
+	// renegotiate initiates a renegotiation (optionally an ICE restart) from either peer by
+	// creating an offer, applying it locally, and sending it over the negotiation channel. The
+	// peer answers via the OnMessage handler above.
+	renegotiate := func(ctx context.Context, iceRestart bool) error {
+		select {
+		case <-negOpened:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		negMu.Lock()
+		defer negMu.Unlock()
+
+		offer, err := peerConn.CreateOffer(&webrtc.OfferOptions{ICERestart: iceRestart})
+		if err != nil {
+			return err
+		}
+		if err := peerConn.SetLocalDescription(offer); err != nil {
+			return err
+		}
+		return sendRenegotiationSDP(ctx, peerConn, negotiationChannel, logger)
+	}
+
+	return negOpened, negClosed, renegotiate, nil
 }
 
 type webrtcPeerConnectionStats struct {

--- a/rpc/wrtc_peer_test.go
+++ b/rpc/wrtc_peer_test.go
@@ -65,10 +65,10 @@ func TestRenegotation(t *testing.T) {
 	}()
 
 	// Add a renegotation channel. Set these channels up before signaling/answering.
-	clientNegChannelOpened, clientNegChannelClosed, err = ConfigureForRenegotiation(client, PeerRoleClient, logger)
+	clientNegChannelOpened, clientNegChannelClosed, _, err = ConfigureForRenegotiation(client, PeerRoleClient, logger)
 	test.That(t, err, test.ShouldBeNil)
 
-	serverNegChannelOpened, serverNegChannelClosed, err = ConfigureForRenegotiation(server, PeerRoleServer, logger)
+	serverNegChannelOpened, serverNegChannelClosed, _, err = ConfigureForRenegotiation(server, PeerRoleServer, logger)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Run signaling/answering such that the client + server can connect to each other.

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -412,7 +412,7 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 		webrtcConfig = extendWebRTCConfig(aa.logger, &webrtcConfig, configResp.GetConfig(), eWrtcOpts)
 	}
 
-	pc, dc, err := newPeerConnectionForServer(
+	pc, dc, renegotiate, err := newPeerConnectionForServer(
 		ctx,
 		aa.offerSDP,
 		webrtcConfig,
@@ -466,6 +466,31 @@ func (aa *answerAttempt) connect(ctx context.Context) (err error) {
 	// handlers for transitioning to the open/closed/error states. As well as backpressure when the
 	// amount of data to send gets high.
 	serverChannel := aa.server.NewChannel(pc, dc, aa.hosts)
+
+	// Refresh relayed TURN credentials before they expire. The server is the sole initiator of the
+	// ICE restart (this avoids glare, which our webrtc fork can't recover from). serverRefetch
+	// re-queries the signaling server for fresh credentials; it's only used if this server itself
+	// holds time-limited TURN credentials (e.g. behind a proxy). Tied to the channel's context.
+	serverRefetch := func(ctx context.Context) ([]webrtc.ICEServer, error) {
+		aa.connMu.Lock()
+		conn := aa.conn
+		aa.connMu.Unlock()
+		if conn == nil {
+			return nil, errors.New("no signaling connection for TURN credential refresh")
+		}
+		md := metadata.New(map[string]string{RPCHostMetadataField: aa.hosts[0]})
+		resp, err := webrtcpb.NewSignalingServiceClient(conn).OptionalWebRTCConfig(
+			metadata.NewOutgoingContext(ctx, md), &webrtcpb.OptionalWebRTCConfigRequest{})
+		if err != nil {
+			return nil, err
+		}
+		base := aa.webrtcConfig
+		return extendWebRTCConfig(aa.logger, &base, resp.GetConfig(), eWrtcOpts).ICEServers, nil
+	}
+	serverChannel.activeBackgroundWorkers.Add(1)
+	utils.ManagedGo(func() {
+		initiateTURNRefresh(serverChannel.ctx, pc, serverRefetch, renegotiate, aa.logger)
+	}, serverChannel.activeBackgroundWorkers.Done)
 
 	initSent := make(chan struct{})
 	if aa.trickleEnabled {

--- a/rpc/wrtc_turn_refresh.go
+++ b/rpc/wrtc_turn_refresh.go
@@ -1,0 +1,176 @@
+package rpc
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/viamrobotics/webrtc/v3"
+	"go.viam.com/utils"
+)
+
+// A connection relayed through a TURN server holds a relay allocation whose time-limited credentials
+// (the username is the unix expiry timestamp, per the TURN REST convention) eventually expire; once
+// they do the relay path drops. There is no way to swap credentials on a live allocation, so we
+// refresh by performing an ICE restart that re-gathers a fresh allocation.
+//
+// To avoid glare (simultaneous offers, which our webrtc fork cannot recover from — it has no
+// SDP rollback), the SERVER is the sole initiator: it periodically initiates the ICE restart
+// (initiateTURNRefresh). Each peer keeps its OWN credentials fresh in its config
+// (refreshOwnTURNCredentials), so that when the restart re-gathers, both sides produce a relay
+// allocation with valid credentials. We only do any of this while the connection is actually using
+// a relay (either end of the selected pair).
+
+const (
+	// turnClientRefreshLeadFactor: a peer refreshes its config this fraction into the credential
+	// lifetime, comfortably before the server initiates the restart.
+	turnClientRefreshLeadFactor = 0.4
+	// turnServerInitiateInterval: the server initiates an ICE restart on this fixed cadence. It
+	// assumes the signaling server's ~24h TURN credential TTL and is chosen to land after a peer's
+	// config refresh (~0.4 of lifetime) and well before expiry.
+	turnServerInitiateInterval = 12 * time.Hour
+	// turnRefreshMinWait avoids busy-looping on already-expired or near-expired credentials.
+	turnRefreshMinWait = time.Minute
+	// turnRefreshMaxWait bounds the pre-expiry refresh schedule.
+	turnRefreshMaxWait = 24 * time.Hour
+	// turnRefreshRecheckWait is how often to re-evaluate a connection that isn't currently using a
+	// relay, so we notice if ICE later settles on (or fails over to) one.
+	turnRefreshRecheckWait = time.Hour
+)
+
+// relaySelected reports whether the connection's currently selected ICE candidate pair uses a relay
+// (TURN) candidate at either end — our own (local) or the peer's (remote).
+func relaySelected(peerConn *webrtc.PeerConnection) bool {
+	if peerConn == nil {
+		return false
+	}
+	pair, ok := webrtcPeerConnCandPair(peerConn)
+	if !ok || pair == nil {
+		return false
+	}
+	return (pair.Local != nil && pair.Local.Typ == webrtc.ICECandidateTypeRelay) ||
+		(pair.Remote != nil && pair.Remote.Typ == webrtc.ICECandidateTypeRelay)
+}
+
+// earliestTURNCredentialExpiry returns the soonest expiry encoded in any of the connection's TURN
+// credential usernames. ok is false when there is no time-limited TURN credential (e.g. a
+// non-timestamp username scheme, or — for an answerer — no TURN servers configured at all).
+func earliestTURNCredentialExpiry(peerConn *webrtc.PeerConnection) (time.Time, bool) {
+	if peerConn == nil {
+		return time.Time{}, false
+	}
+	var earliest time.Time
+	found := false
+	for _, server := range peerConn.GetConfiguration().ICEServers {
+		if server.Username == "" {
+			continue
+		}
+		secs, err := strconv.ParseInt(server.Username, 10, 64)
+		if err != nil {
+			continue
+		}
+		expiry := time.Unix(secs, 0)
+		if !found || expiry.Before(earliest) {
+			earliest, found = expiry, true
+		}
+	}
+	return earliest, found
+}
+
+// refreshOwnTURNCredentials keeps this peer's ICE config stocked with fresh credentials while the
+// connection is relayed, so that when the server initiates an ICE restart this peer re-gathers a
+// relay allocation with valid credentials. It is config-only: it never initiates a renegotiation
+// (only the server does, to avoid glare). refetch fetches a fresh ICE-server set (e.g. by
+// re-querying the signaling server's OptionalWebRTCConfig). Runs until ctx is done.
+func refreshOwnTURNCredentials(
+	ctx context.Context,
+	peerConn *webrtc.PeerConnection,
+	refetch func(context.Context) ([]webrtc.ICEServer, error),
+	logger utils.ZapCompatibleLogger,
+) {
+	for {
+		wait, relayed := nextOwnRefreshWait(peerConn)
+		if !utils.SelectContextOrWait(ctx, wait) {
+			return
+		}
+		if !relayed || !relaySelected(peerConn) {
+			continue
+		}
+		servers, err := refetch(ctx)
+		if err != nil {
+			logger.Warnw("turn credential refresh: failed to refetch ICE servers", "error", err)
+			continue
+		}
+		config := peerConn.GetConfiguration()
+		config.ICEServers = servers
+		if err := peerConn.SetConfiguration(config); err != nil {
+			logger.Warnw("turn credential refresh: failed to apply refreshed ICE servers", "error", err)
+			continue
+		}
+		logger.Debug("refreshed own TURN credentials in config ahead of next ICE restart")
+	}
+}
+
+// nextOwnRefreshWait computes how long to wait before refreshing our own credentials. ok is true
+// only when the connection is actively relayed with a time-limited credential; otherwise it returns
+// a recheck interval.
+func nextOwnRefreshWait(peerConn *webrtc.PeerConnection) (time.Duration, bool) {
+	if !relaySelected(peerConn) {
+		return turnRefreshRecheckWait, false
+	}
+	expiry, ok := earliestTURNCredentialExpiry(peerConn)
+	if !ok {
+		return turnRefreshRecheckWait, false
+	}
+	remaining := time.Until(expiry)
+	if remaining <= 0 {
+		return turnRefreshMinWait, true
+	}
+	wait := time.Duration(float64(remaining) * turnClientRefreshLeadFactor)
+	if wait < turnRefreshMinWait {
+		wait = turnRefreshMinWait
+	}
+	if wait > turnRefreshMaxWait {
+		wait = turnRefreshMaxWait
+	}
+	return wait, true
+}
+
+// initiateTURNRefresh periodically initiates an ICE restart so a relayed connection re-establishes
+// its TURN allocation with fresh credentials. The server is the sole initiator, which avoids glare.
+// It only acts while the connection is actually using a relay. If this peer itself holds
+// time-limited credentials (e.g. an answerer behind a proxy), it refreshes its own config first so
+// its re-gather is fresh too. Runs until ctx is done.
+func initiateTURNRefresh(
+	ctx context.Context,
+	peerConn *webrtc.PeerConnection,
+	refetch func(context.Context) ([]webrtc.ICEServer, error),
+	renegotiate renegotiateFunc,
+	logger utils.ZapCompatibleLogger,
+) {
+	for {
+		if !utils.SelectContextOrWait(ctx, turnServerInitiateInterval) {
+			return
+		}
+		if !relaySelected(peerConn) {
+			continue
+		}
+		// If we hold our own time-limited credentials, refresh them before re-gathering.
+		if _, ok := earliestTURNCredentialExpiry(peerConn); ok {
+			if servers, err := refetch(ctx); err != nil {
+				logger.Warnw("turn credential refresh: server failed to refetch own ICE servers", "error", err)
+			} else {
+				config := peerConn.GetConfiguration()
+				config.ICEServers = servers
+				if err := peerConn.SetConfiguration(config); err != nil {
+					logger.Warnw("turn credential refresh: server failed to apply refreshed ICE servers", "error", err)
+				}
+			}
+		}
+		if err := renegotiate(ctx, true); err != nil {
+			logger.Warnw("turn credential refresh: server ICE restart failed", "error", err)
+			continue
+		}
+		logger.Debug("initiated ICE restart to refresh relayed TURN credentials")
+	}
+}


### PR DESCRIPTION
## Problem

A long-lived connection relayed through a TURN server holds a relay allocation whose time-limited credentials (the username is the unix expiry timestamp) eventually expire (~24h). There's no way to swap credentials on a live allocation, so the relay path drops and pion logs repeated `Fail to refresh permissions: 401`.

## Approach — server-initiated ICE restart

Refresh **in-band** (no reconnect) via an ICE restart that re-gathers a fresh relay allocation. The hard part is doing this without glare (simultaneous offers), which our webrtc fork can't recover from — it has no SDP rollback. The fix is **single-initiator**:

- **The server is the sole initiator.** `newPeerConnectionForServer` now returns a `renegotiate` function; the answerer spawns `initiateTURNRefresh`, which — while the connection is using a relay — periodically initiates an ICE restart. Since only the server ever creates offers (for both track changes and this), there is no glare and no rollback is needed.
- **Each peer keeps its own credentials fresh** (`refreshOwnTURNCredentials`, config-only, never initiates). So when the restart re-gathers, both ends produce an allocation with valid credentials. The server also refreshes its own config before initiating, if it holds time-limited creds (e.g. behind a proxy).
- Everything is **gated on the connection actually using a relay** (either end of the selected candidate pair); it's a no-op otherwise.

## Why this over a full re-dial

A re-dial (separate proposal) is simpler and refreshes both sides for free, but drops the connection briefly (~once/day). This keeps the connection up across the refresh. The trade-off is the machinery below.

## Notes / open items

- **Timing is a fixed cadence.** The server initiates every `turnServerInitiateInterval` (12h), which assumes the signaling server's ~24h TTL; each peer refreshes its config at ~0.4 of its credential lifetime, comfortably ahead. The server has no per-connection credential expiry to read (its config is often STUN-only), so a fixed cadence is intentional — but it bakes in the 24h-TTL assumption.
- **Coordination is timing-based, not signaled.** A peer's config refresh must land before the server's restart; the lead factors are chosen to ensure that, but there's no explicit handshake. A more robust design would have the receiver refresh its creds on detecting an ICE-restart offer (avoids the timing assumption) — not done here to keep the change smaller.
- **Draft — not validated against a live relay.** The in-band ICE-restart path (full-SDP candidate exchange over the negotiation channel, answerer handling an ICE-restart offer, reconvergence) is untested end to end here; the existing renegotiation/answerer tests pass (`go test ./rpc/`), which covers no-regression but not the new restart path. Unit tests for `relaySelected` / `earliestTURNCredentialExpiry` / scheduling are easy wins before merge.
- Higher blast radius than a client-side change: the worker runs on every relayed connection a viam-server answers, so a bug in the restart path affects the server side broadly.
