### PR TITLE
Log noisy offline no connection errors at most once if conn state is TRANSIENT_FAILURE or CONNECTING

### DIFF
--- a/grpchelpers/grpchelpers.go
+++ b/grpchelpers/grpchelpers.go
@@ -1,0 +1,32 @@
+// Package grpchelpers provides some grpc helper utilities.
+package grpchelpers
+
+import (
+	"errors"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// ConnectivityState allows callers to check the connectivity state of
+// the connection
+// see https://github.com/grpc/grpc-go/blob/master/clientconn.go#L648
+type ConnectivityState interface {
+	GetState() connectivity.State
+}
+
+// ConnConnectivityState returns the connectivity.State of the current connection, if available.
+// When offline, conn's state should alternate between connectivity.TransientFailure and connectivity.Connecting while the grpc library
+// tries to reconnect in the background at a cadence defined by the backoff specified with grpc.ConnectParams (default: exponential & capped
+// at 2 mins). Making an RPC call will not bypass this (it will not trigger an immediate reconnection attempt).
+// Note: using this to test the connection before making an RPC call, while often useful, is considered an antipattern.
+// Official docs recommend using the grpc.WaitForReady CallOption instead if possible.
+func ConnConnectivityState(conn grpc.ClientConnInterface) (connectivity.State, bool) {
+	if cs, ok := conn.(ConnectivityState); ok {
+		return cs.GetState(), true
+	}
+	return -1, false
+}
+
+// ErrConnNotReady can be used to signal that the conn may not be in a immediately usable state (user defined).
+var ErrConnNotReady = errors.New("conn is not in a ready state")

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -174,14 +174,6 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 		ans.connMu.Lock()
 		conn := ans.conn
 		ans.connMu.Unlock()
-		// do not attempt to answer if the connection is not in a ready state.
-		// we could exclude the connectivity.Connecting check and move this block closer to the Answer call for lower latency,
-		// but we retry often enough (2x/sec) that it shouldn't make a noticeable difference.
-		if cs, ok := grpchelpers.ConnConnectivityState(conn); ok {
-			if cs == connectivity.TransientFailure || cs == connectivity.Connecting {
-				return nil, grpchelpers.ErrConnNotReady
-			}
-		}
 		client := webrtcpb.NewSignalingServiceClient(conn)
 		md := metadata.New(nil)
 		md.Append(RPCHostMetadataField, ans.hosts...)
@@ -205,25 +197,42 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 				ans.logger.Warnf("closing send side of answering client failed", "error", err)
 			}
 		}()
+		errsSinceLastOnline := make(map[string]struct{})
+		var clearOfflineErrMap bool
 		for {
 			if ctx.Err() != nil {
 				return
+			}
+			if clearOfflineErrMap {
+				clear(errsSinceLastOnline)
+				clearOfflineErrMap = false
 			}
 
 			var err error
 			// `newAnswer` opens a bidi grpc stream to the signaling server. But otherwise sends no requests.
 			client, err = newAnswer()
 			if err != nil {
-				switch {
-				case errors.Is(err, grpchelpers.ErrConnNotReady):
-					ans.logger.Debugw("did not attempt to answer because connection is not in a ready state", "error", err)
-					utils.SelectContextOrWait(ctx, answererReconnectWait)
-				case isNetworkError(err):
+				if isNetworkError(err) {
+					{
+						// Reduce log spam: Check connectivity state. If we may be offline, start collecting errors
+						// and emit newly seen ones at most once. Do this until we're able to successfully create an answer client again
+						ans.connMu.Lock()
+						cs, csOk := grpchelpers.ConnConnectivityState(ans.conn)
+						ans.connMu.Unlock()
+						if csOk && cs == connectivity.TransientFailure || cs == connectivity.Connecting {
+							errKey := err.Error()
+							if _, ok := errsSinceLastOnline[errKey]; ok {
+								continue
+							}
+							errsSinceLastOnline[errKey] = struct{}{}
+						}
+					}
 					ans.logger.Infow("failed to communicate with signaling server", "error", err)
 					utils.SelectContextOrWait(ctx, answererReconnectWait)
 				}
 				continue
 			}
+			clearOfflineErrMap = true
 
 			var incomingCallerReq *webrtcpb.AnswerRequest
 			for {

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -14,10 +14,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/viamrobotics/webrtc/v3"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"go.viam.com/utils"
+	"go.viam.com/utils/grpchelpers"
 	webrtcpb "go.viam.com/utils/proto/rpc/webrtc/v1"
 )
 
@@ -172,6 +174,14 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 		ans.connMu.Lock()
 		conn := ans.conn
 		ans.connMu.Unlock()
+		// do not attempt to answer if the connection is not in a ready state.
+		// we could exclude the connectivity.Connecting check and move this block closer to the Answer call for lower latency,
+		// but we retry often enough (2x/sec) that it shouldn't make a noticeable difference.
+		if cs, ok := grpchelpers.ConnConnectivityState(conn); ok {
+			if cs == connectivity.TransientFailure || cs == connectivity.Connecting {
+				return nil, grpchelpers.ErrConnNotReady
+			}
+		}
 		client := webrtcpb.NewSignalingServiceClient(conn)
 		md := metadata.New(nil)
 		md.Append(RPCHostMetadataField, ans.hosts...)
@@ -204,7 +214,11 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 			// `newAnswer` opens a bidi grpc stream to the signaling server. But otherwise sends no requests.
 			client, err = newAnswer()
 			if err != nil {
-				if isNetworkError(err) {
+				switch {
+				case errors.Is(err, grpchelpers.ErrConnNotReady):
+					ans.logger.Debugw("did not attempt to answer because connection is not in a ready state", "error", err)
+					utils.SelectContextOrWait(ctx, answererReconnectWait)
+				case isNetworkError(err):
 					ans.logger.Infow("failed to communicate with signaling server", "error", err)
 					utils.SelectContextOrWait(ctx, answererReconnectWait)
 				}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -219,7 +219,7 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 						ans.connMu.Lock()
 						cs, csOk := grpchelpers.ConnConnectivityState(ans.conn)
 						ans.connMu.Unlock()
-						if csOk && cs == connectivity.TransientFailure || cs == connectivity.Connecting {
+						if csOk && (cs == connectivity.TransientFailure || cs == connectivity.Connecting) {
 							errKey := err.Error()
 							if _, ok := errsSinceLastOnline[errKey]; ok {
 								continue


### PR DESCRIPTION
I moved `ConnectivityState` from RDK to here, and will update the other PRs that use it.


This helps reduce some log spam when we go offline. Previously, every minute we'd get:
```
INFO    rdk.networking.signaler.external        rpc/wrtc_signaling_answerer.go:208      Message logged 120 times in past 1m0s: failed to communicate with signaling server      {"error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp: lookup ...
INFO    rdk.networking.signaler.external        rpc/wrtc_signaling_answerer.go:208      failed to communicate with signaling server     {"error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp: lookup...
INFO    rdk.networking.signaler.external        rpc/wrtc_signaling_answerer.go:208      failed to communicate with signaling server     {"error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp: lookup...
INFO    rdk.networking.signaler.external        rpc/wrtc_signaling_answerer.go:208      failed to communicate with signaling server     {"error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp: lookup...
``` 
