### PR TITLE
fix(ci): bootstrap mise before make tool-install in Claude workflows

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -36,7 +36,10 @@ jobs:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
       branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}
-      install_command: make tool-install
+      install_command: |
+        curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+        mise trust
+        make tool-install
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *)'
       max_turns: 50
       team_mention: '@viamrobotics/netcode'

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -68,7 +68,10 @@ jobs:
       task_complexity: ${{ github.event.client_payload.task_complexity || inputs.task_complexity || 'small' }}
       assignee: ${{ github.event.client_payload.assignee || inputs.assignee || '' }}
       assignee_email: ${{ github.event.client_payload.assignee_email || inputs.assignee_email || '' }}
-      install_command: make tool-install
+      install_command: |
+        curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+        mise trust
+        make tool-install
       jira_base_url: ${{ vars.JIRA_BASE_URL }}
       jira_user_email: ${{ vars.JIRA_USER_EMAIL }}
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*),Bash(gh pr edit*),Bash(gh pr view*),Bash(gh pr diff*)'

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -31,7 +31,10 @@ jobs:
     uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@5506bdaf04cc7d1adbd2df0f31f108834b01aea6
     with:
       container: ghcr.io/viamrobotics/rdk-devenv:amd64
-      install_command: make tool-install
+      install_command: |
+        curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+        mise trust
+        make tool-install
       allowed_tools: 'Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(make build*),Bash(make build-go*),Bash(make lint*),Bash(make lint-go*),Bash(make test-go*),Bash(make test-go-no-race*),Bash(make tool-install*),Bash(go build*),Bash(go test*),Bash(go vet*),Bash(go list *),Bash(go doc *),Bash(go mod *),Bash(gofmt *),Bash(ls *),Bash(find *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr review*),Bash(gh pr comment*),Bash(gh pr view*),Bash(gh pr diff*)'
       max_turns: 50
       extra_review_instructions: |


### PR DESCRIPTION
## Problem

The Claude CI workflows (`claude-pr-assistant`, `claude-ci-fix`, `claude-jira`) run inside `ghcr.io/viamrobotics/rdk-devenv:amd64`, which does **not** ship `mise`. But goutils' `Makefile` is entirely mise-driven (`tool-install` → `mise install`, `lint-go` → `mise r lint-go`, `test-go` → `mise r test-go`, …). So the **Install dependencies** step dies immediately:

```
Run make tool-install
mise install
make: mise: No such file or directory
make: *** [Makefile:13: tool-install] Error 127
```

Example failure: https://github.com/viamrobotics/goutils/actions/runs/27727289866/job/82026367128

Our own `test.yml` doesn't hit this because it runs on a bare `ubuntu-latest` runner and installs mise via `jdx/mise-action` before any `make`/`mise` call. The Claude reusable workflows have no such step — they just run `install_command` inside the chosen container.

## Fix

Prepend a mise bootstrap to `install_command` in all three callers:

```yaml
install_command: |
  curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
  mise trust
  make tool-install
```

- Installs the `mise` binary to `/usr/local/bin` (already on `PATH`), so the agent's later `make lint-go` / `make test-go` find it too — no `$GITHUB_PATH` juggling.
- `mise trust` is required because `rdk-devenv` has no `jdx/mise-action` to auto-trust the config; without it `mise install` refuses the untrusted `mise.toml` (`Config files ... are not trusted`).
- Keeps `make tool-install` as the source of truth — this only supplies the missing bootstrap.

`allowed_tools` is unchanged: `install_command` runs as a plain workflow `run:` step (not gated by the agent's Bash allowlist), and the agent only invokes `mise` indirectly through the already-allowed `make` targets.

## Verification

Ran end-to-end inside `ghcr.io/viamrobotics/rdk-devenv:amd64`:

- `mise` bootstraps to `/usr/local/bin/mise` (v2026.6.11).
- `mise trust` + `make tool-install` → exit 0; all tools install.
- A **fresh shell** (mimicking the agent's separate Bash invocations) resolves `go 1.25.9`, `golangci-lint 2.6.2`, `buf 1.55.1` via mise — confirming trust persists to disk for subsequent steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)