### PR TITLE
Grant check-approvals actions:write to auto-refresh required status

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -24,6 +24,10 @@ jobs:
       # write (not read) to post the "Review Required" comment: commenting on a
       # PR needs pull-requests: write; issues: write does not cover PRs.
       pull-requests: write
+      # lets the action re-run the stale pull_request run for this commit once
+      # approvals are satisfied, so the required status turns green without a
+      # manual re-run (viamrobotics/claude-ci-workflows#123).
+      actions: write
     steps:
       # Flaky-test fixes and dependabot bumps only require a single approval;
       # everything else needs two. Title/branch are read via env (never interpolated


### PR DESCRIPTION
## Why

The `check-approvals` gate runs on both `pull_request` (incl. `synchronize`) and `pull_request_review`. When a PR's final commit lands **before** the required approvals exist, the `synchronize`-triggered run fails and branch protection pins the required status to it. A later approving review passes on a *separate* run but doesn't clear the gate — so the gate stays red until someone manually re-runs the failed `pull_request` run. Hit on #569.

## Change

[viamrobotics/claude-ci-workflows#123](https://github.com/viamrobotics/claude-ci-workflows/pull/123) teaches the composite action to re-run that stale `pull_request` run automatically once approvals are satisfied. That re-run uses the `GITHUB_TOKEN`, which needs `actions: write`. This PR grants it on the `check-approvals` job (currently only `pull-requests: write`).

## Note

Takes effect once the pinned `claude-ci-workflows` ref in this workflow is bumped to a release containing #123. Harmless no-op until then (the action falls back to a warning if the permission is absent, so there's no regression either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)