### PR TITLE
RSDK-14147 Correctly log stack of internal panics caused by gRPC requests

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -361,9 +362,12 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 	unaryInterceptors = append(unaryInterceptors,
 		grpc_recovery.UnaryServerInterceptor(grpc_recovery.WithRecoveryHandler(
 			grpc_recovery.RecoveryHandlerFunc(func(p interface{}) error {
-				err := status.Errorf(codes.Internal, "%v", p)
-				grpcLogger.Errorw("panicked while calling unary server method", "error", errors.WithStack(err))
-				return err
+				grpcLogger.Errorw("panicked while calling unary server method",
+					"panic", fmt.Sprintf("%v", p),
+					"stack", string(debug.Stack()))
+				// Do not include the stack in the error returned to the client; it leaks
+				// server internals. It is logged above for internal diagnosis only.
+				return status.Errorf(codes.Internal, "%v", p)
 			}))),
 		grpcUnaryServerInterceptor(grpcLogger),
 		unaryServerCodeInterceptor(),
@@ -394,9 +398,12 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 	streamInterceptors = append(streamInterceptors,
 		grpc_recovery.StreamServerInterceptor(grpc_recovery.WithRecoveryHandler(
 			grpc_recovery.RecoveryHandlerFunc(func(p interface{}) error {
-				err := status.Errorf(codes.Internal, "%s", p)
-				grpcLogger.Errorw("panicked while calling stream server method", "error", errors.WithStack(err))
-				return err
+				grpcLogger.Errorw("panicked while calling stream server method",
+					"panic", fmt.Sprintf("%v", p),
+					"stack", string(debug.Stack()))
+				// Do not include the stack in the error returned to the client; it leaks
+				// server internals. It is logged above for internal diagnosis only.
+				return status.Errorf(codes.Internal, "%v", p)
 			}))),
 		grpcStreamServerInterceptor(grpcLogger),
 		streamServerCodeInterceptor(),


### PR DESCRIPTION
[RDSK-14147](https://viam.atlassian.net/browse/RSDK-14147)

gRPC requests to `viam-server` can cause internal panics within `rdk` or `goutils` code. We use `grpc_recovery.WithRecoveryHandler` to recover from those panics (not crash the main program), log the panic, and return an error to the client that invoked the gRPC method that caused the panic. 

The logging of the panic, in particular, attempts to capture information about the panic using `errors.WithStack`. That function [just reports the stack of its caller](https://pkg.go.dev/github.com/pkg/errors#WithStack), and is not actually a goroutine dump that would say where the panic occurred. So, we end up with logs like:

```
graph_node.go:316: 2026-05-15T13:13:47.125Z	ERROR	TestConfigRemoteWithAuth.rdk.resource_manager.rdk:remote:/bar	resource/graph_node.go:316	error connecting to remote: couldn't connect to robot remote (something-different): rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference	{"remote":"bar"}
```

That do not actually report where the panic was.

We should use `debug.Stack()` instead to give the full goroutine dump.