### PR TITLE
[RSDK-14112] Demote known-benign pion log lines to debug

### DIFF
--- a/rpc/wrtc_logger.go
+++ b/rpc/wrtc_logger.go
@@ -1,11 +1,34 @@
 package rpc
 
 import (
+	"strings"
+
 	"github.com/pion/logging"
 	"go.uber.org/zap"
 
 	"go.viam.com/utils"
 )
+
+// demotedPionLogSubstrings lists substrings of pion log messages that we demote from
+// error to debug. These are known-benign messages that recur during normal operation
+// and do not reflect connection health, so logging them at error is misleading noise.
+var demotedPionLogSubstrings = []string{
+	// pion's TURN client logs "Fail to refresh permissions" once a relay allocation's
+	// time-limited credential expires and the TURN server rejects the periodic refresh.
+	// This does not reflect connection health: an in-use relay recovers by re-dialing with
+	// fresh credentials, and an idle/unused allocation (a connection that selected a direct
+	// candidate pair but still gathered a relay candidate) is unaffected on its actual data path.
+	"Fail to refresh permissions",
+}
+
+func shouldDemotePionLog(msg string) bool {
+	for _, sub := range demotedPionLogSubstrings {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+	return false
+}
 
 // WebRTCLoggerFactory wraps a utils.ZapCompatibleLogger for use with pion's webrtc logging system.
 type WebRTCLoggerFactory struct {
@@ -63,4 +86,38 @@ func (l webrtcLogger) Errorf(format string, args ...interface{}) {
 // NewLogger returns a new webrtc logger under the given scope.
 func (lf WebRTCLoggerFactory) NewLogger(scope string) logging.LeveledLogger {
 	return webrtcLogger{utils.Sublogger(lf.Logger, scope)}
+}
+
+// demotingLoggerFactory wraps another pion logging.LoggerFactory and demotes known-benign
+// error logs (see demotedPionLogSubstrings) to debug, passing every other log through to the
+// wrapped factory unchanged.
+type demotingLoggerFactory struct {
+	base logging.LoggerFactory
+}
+
+func (f demotingLoggerFactory) NewLogger(scope string) logging.LeveledLogger {
+	return demotingLogger{f.base.NewLogger(scope)}
+}
+
+// demotingLogger demotes known-benign error messages (see demotedPionLogSubstrings) to
+// debug. All other levels, and all other messages, are inherited unchanged from the embedded
+// logger.
+type demotingLogger struct {
+	logging.LeveledLogger
+}
+
+func (l demotingLogger) Error(msg string) {
+	if shouldDemotePionLog(msg) {
+		l.LeveledLogger.Debug(msg)
+		return
+	}
+	l.LeveledLogger.Error(msg)
+}
+
+func (l demotingLogger) Errorf(format string, args ...interface{}) {
+	if shouldDemotePionLog(format) {
+		l.LeveledLogger.Debugf(format, args...)
+		return
+	}
+	l.LeveledLogger.Errorf(format, args...)
 }

--- a/rpc/wrtc_logger_test.go
+++ b/rpc/wrtc_logger_test.go
@@ -1,0 +1,59 @@
+package rpc
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestShouldDemotePionLog(t *testing.T) {
+	for _, tc := range []struct {
+		msg    string
+		demote bool
+	}{
+		{"Fail to refresh permissions: CreatePermission error response (error 401: Unauthorized)", true},
+		{"Fail to refresh permissions: %s", true}, // format string also matches
+		{"some unrelated error", false},
+		{"ICE connection state changed: failed", false},
+	} {
+		test.That(t, shouldDemotePionLog(tc.msg), test.ShouldEqual, tc.demote)
+	}
+}
+
+// recordingLeveledLogger records the level at which the most recent message was logged.
+type recordingLeveledLogger struct {
+	level string
+}
+
+func (r *recordingLeveledLogger) Trace(string)          { r.level = "trace" }
+func (r *recordingLeveledLogger) Tracef(string, ...any) { r.level = "trace" }
+func (r *recordingLeveledLogger) Debug(string)          { r.level = "debug" }
+func (r *recordingLeveledLogger) Debugf(string, ...any) { r.level = "debug" }
+func (r *recordingLeveledLogger) Info(string)           { r.level = "info" }
+func (r *recordingLeveledLogger) Infof(string, ...any)  { r.level = "info" }
+func (r *recordingLeveledLogger) Warn(string)           { r.level = "warn" }
+func (r *recordingLeveledLogger) Warnf(string, ...any)  { r.level = "warn" }
+func (r *recordingLeveledLogger) Error(string)          { r.level = "error" }
+func (r *recordingLeveledLogger) Errorf(string, ...any) { r.level = "error" }
+
+func TestDemotingLogger(t *testing.T) {
+	rec := &recordingLeveledLogger{}
+	l := demotingLogger{rec}
+
+	// Demoted messages drop to debug regardless of the level pion used.
+	l.Error("Fail to refresh permissions: CreatePermission error response (error 401: Unauthorized)")
+	test.That(t, rec.level, test.ShouldEqual, "debug")
+
+	l.Errorf("Fail to refresh permissions: %s", "boom")
+	test.That(t, rec.level, test.ShouldEqual, "debug")
+
+	// Everything else passes through unchanged.
+	l.Error("a real error")
+	test.That(t, rec.level, test.ShouldEqual, "error")
+
+	l.Warn("a real warning")
+	test.That(t, rec.level, test.ShouldEqual, "warn")
+
+	l.Info("some info")
+	test.That(t, rec.level, test.ShouldEqual, "info")
+}

--- a/rpc/wrtc_peer.go
+++ b/rpc/wrtc_peer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/pion/interceptor"
+	"github.com/pion/logging"
 	"github.com/pion/sctp"
 	"github.com/pion/transport/v2"
 	"github.com/pion/transport/v2/stdnet"
@@ -131,9 +132,14 @@ func newWebRTCAPI(logger utils.ZapCompatibleLogger) (*webrtc.API, error) {
 	}
 
 	options := []func(a *webrtc.API){webrtc.WithMediaEngine(&m), webrtc.WithInterceptorRegistry(&i)}
+	// Use the same logger factory pion would normally use but wrap it to demote a
+	// small set of known-benign, recurring pion log lines (see demotedPionLogSubstrings) to
+	// debug.
+	var baseLoggerFactory logging.LoggerFactory = logging.NewDefaultLoggerFactory()
 	if utils.Debug {
-		settingEngine.LoggerFactory = WebRTCLoggerFactory{logger}
+		baseLoggerFactory = WebRTCLoggerFactory{logger}
 	}
+	settingEngine.LoggerFactory = demotingLoggerFactory{base: baseLoggerFactory}
 	options = append(options, webrtc.WithSettingEngine(settingEngine))
 	return webrtc.NewAPI(options...), nil
 }


### PR DESCRIPTION
## Description

[RSDK-14112](https://viam.atlassian.net/browse/RSDK-14112) Handle long lived client relay connections

Add a small, generic `demotingLoggerFactory` that wraps whatever pion `logging.LoggerFactory` we'd otherwise use and demotes a configurable list of known-benign pion log messages from error/warn to debug. Everything else passes through to the wrapped factory unchanged.

- `demotedPionLogSubstrings []string`: extendable list of substrings to demote
- `wrtc_peer.go` wraps the base logger factory with the `demotingLoggerFactory` so logging behavior and volume are unchanged apart from the demoted lines.

pion's TURN client begins to spam `Fail to refresh permissions`  errors once a relay allocation's time-limited credential expires and is rejected by the TURN server (server restart or evicted from cache) but does not reflect connection health:
- An in-use relay whose session is lost re-dials and recovers with fresh credentials.
- An **idle** relay allocation, gathered during ICE on a connection that actually selected a direct candidate pair, is not used; its data path stays healthy while the orphaned allocation logs these forever.

## Test
- `TestShouldDemotePionLog`, `TestDemotingLogger` (benign → debug; everything else unchanged)
- Artificially lowered coturn credential TTL and created client to staging robot with idle relay allocation, restarted coturn, observed log at debug. 

[RSDK-14112]: https://viam.atlassian.net/browse/RSDK-14112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ