### PR TITLE
ci: bump claude-ci-workflows to v2.2.4

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
       # lets the action re-run the stale pull_request run for this commit once
       # approvals are satisfied, so the required status turns green without a
-      # manual re-run (viamrobotics/claude-ci-workflows#123).
+      # manual re-run.
       actions: write
     steps:
       # Flaky-test fixes and dependabot bumps only require a single approval;
@@ -51,12 +51,12 @@ jobs:
             echo "Requiring 2 approvals."
           fi
 
-      # viamrobotics/claude-ci-workflows@v2.2.1
+      # viamrobotics/claude-ci-workflows@v2.2.4
       - name: Checkout claude-ci-workflows for composite action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: viamrobotics/claude-ci-workflows
-          ref: 5506bdaf04cc7d1adbd2df0f31f108834b01aea6
+          ref: c27e2ba8d7e6e818f74271132041ab48707cc0ca
           path: .claude-ci-workflows
           sparse-checkout: |
             .github/actions/check-approvals/


### PR DESCRIPTION
## What

Bumps the pinned `claude-ci-workflows` ref in `check-approvals.yml` from v2.2.1 → **v2.2.4** (`c27e2ba`).

## Why

v2.2.4 includes [viamrobotics/claude-ci-workflows#123](https://github.com/viamrobotics/claude-ci-workflows/pull/123) — the fix for the very issue this repo hit on goutils#569: when a PR's final commit lands before approvals exist, the `synchronize`-triggered `check-approvals` run fails and branch protection pins the required status to that failed run; a later approving review passes as a *separate* run, so the merge box stays red until someone manually re-runs the failed one.

The fix re-runs the stale `pull_request` run for the same commit once approvals are satisfied. The `actions: write` permission it needs is **already granted** on the `check-approvals` job here, so this PR is just the ref bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)