### PR TITLE
RSDK-13302: retry TLS probe on transient error

### DIFF
--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -405,21 +405,49 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 
 		var downgrade bool
 		if dOpts.allowInsecureDowngrade || dOpts.allowInsecureWithCredsDowngrade {
+			// TLS probe: try to make a TLS connection. If the returned error is "tls: first record does not look like a TLS handshake",
+			// downgrade to insecure.
+			// The tls DialContext may error with transient errors, especially when used in quick succession, particularly on Windows, so
+			// retry on the ones we're aware of.
+			// Note: If the probe errors for a reason not covered here, we don't downgrade and will continue with the tlsConfig, but
+			// because of grpc.WithBlock DialOption, if the server does not actually support TLS, the dial will keep failing on the same
+			// tls error and repeatedly retry until its deadline (and will return context deadline exceeded).
 			var dialer tls.Dialer
 			dialer.Config = tlsConfig
-			conn, err := dialer.DialContext(ctx, "tcp", address)
-			if err == nil {
-				// will use TLS
-				utils.UncheckedError(conn.Close())
-			} else if strings.Contains(err.Error(), "tls: first record does not look like a TLS handshake") {
-				// unfortunately there's no explicit error value for this, so we do a string check
-				hasLocalCreds := dOpts.creds.Type != "" && dOpts.externalAuthAddr == ""
-				if dOpts.creds.Type == "" || !hasLocalCreds || dOpts.allowInsecureWithCredsDowngrade {
-					logger.Warnw("downgrading from TLS to plaintext", "address", address, "with_credentials", hasLocalCreds)
-					downgrade = true
-				} else if hasLocalCreds {
-					return nil, false, ErrInsecureWithCredentials
+			maxTries := 2
+			for tries := 0; tries <= maxTries; tries++ {
+				conn, err := dialer.DialContext(ctx, "tcp", address)
+				switch {
+				case err == nil:
+					utils.UncheckedError(conn.Close())
+				case strings.Contains(err.Error(), "tls: first record does not look like a TLS handshake"):
+					hasLocalCreds := dOpts.creds.Type != "" && dOpts.externalAuthAddr == ""
+					if dOpts.creds.Type == "" || !hasLocalCreds || dOpts.allowInsecureWithCredsDowngrade {
+						logger.Warnw("downgrading from TLS to plaintext", "address", address, "with_credentials", hasLocalCreds)
+						downgrade = true
+					} else if hasLocalCreds {
+						return nil, false, ErrInsecureWithCredentials
+					}
+				case strings.Contains(err.Error(), "i/o timeout"):
+					fallthrough
+				case strings.Contains(err.Error(), "forcibly closed by the remote host"):
+					// one example of this is "wsarecv: An existing connection was forcibly closed by the remote host." on Windows, which
+					// we can't easily match on.
+					logger.Debugw("TLS downgrade probe failed. retrying", "address", address, "err", err,
+						"attempt", fmt.Sprintf("%d/%d", tries+1, maxTries))
+					timer := time.NewTimer(time.Millisecond * 300)
+					select {
+					case <-timer.C:
+						timer.Stop()
+					case <-ctx.Done():
+						timer.Stop()
+						return nil, false, err
+					}
+					continue
+				default:
+					logger.Debugw("TLS downgrade probe failed. not retrying. continuing with TLS dial", "address", address, "err", err)
 				}
+				break
 			}
 		}
 		if downgrade {

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -414,8 +414,8 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 			// tls error and repeatedly retry until its deadline (and will return context deadline exceeded).
 			var dialer tls.Dialer
 			dialer.Config = tlsConfig
-			maxTries := 2
-			for tries := 0; tries <= maxTries; tries++ {
+			maxTries := 3
+			for tries := 1; tries <= maxTries; tries++ {
 				conn, err := dialer.DialContext(ctx, "tcp", address)
 				switch {
 				case err == nil:
@@ -433,8 +433,8 @@ func dialDirectGRPC(ctx context.Context, address string, dOpts dialOptions, logg
 				case strings.Contains(err.Error(), "forcibly closed by the remote host"):
 					// one example of this is "wsarecv: An existing connection was forcibly closed by the remote host." on Windows, which
 					// we can't easily match on.
-					logger.Debugw("TLS downgrade probe failed. retrying", "address", address, "err", err,
-						"attempt", fmt.Sprintf("%d/%d", tries+1, maxTries))
+					logger.Debugw("TLS downgrade probe failed", "address", address, "err", err,
+						"attempt", fmt.Sprintf("%d/%d", tries, maxTries))
 					timer := time.NewTimer(time.Millisecond * 300)
 					select {
 					case <-timer.C:


### PR DESCRIPTION
If the probe for whether the server supports TLS (using `tls.Dialer.DialContext`) fails with an error other than `tls: first record does not look like a TLS handshake`, we ignore the error and continue to the real dial (grpc) without downgrading. 

The grpc dial will also fail with "tls: first record does not look like a TLS handshake", but it will keep retrying (and failing) with exponential backoff until `context deadline exceeded` because of the `grpc.WithBlock`* dial option. 

*Note: with [WithBlock](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md#the-wrong-way-grpcdial), GRPC retries on temporary, non-temporary, and unknown (this one) errors by default. It also has two potentially interesting options:
* `WithReturnConnectionError` (default false): return the real error along with `context deadline exceeded`, instead of swallowing it. Sounds useful, but we'd need to investigate if this will mess with our error handling.
* `FailOnNonTempDialError` (default false): for non-temporary errors, return immediately instead of retrying (not directly relevant here).