### PR TITLE
Add granular additive WebRTC dial options

### DIFF
--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -191,6 +191,13 @@ func WithTLSConfig(config *tls.Config) DialOption {
 
 // WithWebRTCOptions returns a DialOption which sets the WebRTC options
 // to use if the dialer tries to establish a WebRTC connection.
+//
+// Note: this replaces the entire DialWebRTCOptions struct in one shot, so it
+// clashes with the granular dial options (WithForceP2P, WithForceRelay,
+// WithTurnURI, etc.). Combining it with any of those is order-dependent —
+// whichever DialOption is applied last wins — which can produce unexpected
+// behavior. For additive tweaks that leave other fields intact, prefer the
+// granular options.
 func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts = webrtcOpts
@@ -201,6 +208,9 @@ func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
 // WithForceP2P returns a DialOption which forces ICE connections to use only
 // non-relay candidates (host, server-reflexive, and peer-reflexive) by
 // stripping TURN servers.
+//
+// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
+// whichever is applied last wins and may cause unexpected behavior.
 func WithForceP2P() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.ForceP2P = true
@@ -209,6 +219,9 @@ func WithForceP2P() DialOption {
 
 // WithForceRelay returns a DialOption which forces ICE connections to use relay
 // (TURN) candidates only.
+//
+// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
+// whichever is applied last wins and may cause unexpected behavior.
 func WithForceRelay() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.ForceRelay = true
@@ -219,6 +232,9 @@ func WithForceRelay() DialOption {
 // list down to the server whose parsed URI matches uri (e.g.
 // "turn:turn.viam.com:443"). Has no effect when ForceP2P is set, since TURN
 // servers are stripped in that case.
+//
+// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
+// whichever is applied last wins and may cause unexpected behavior.
 func WithTurnURI(uri string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnURI = uri
@@ -227,6 +243,9 @@ func WithTurnURI(uri string) DialOption {
 
 // WithTurnScheme returns a DialOption which overrides the scheme ("turn" or
 // "turns") of the URI matched by WithTurnURI.
+//
+// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
+// whichever is applied last wins and may cause unexpected behavior.
 func WithTurnScheme(scheme string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnScheme = scheme
@@ -235,6 +254,9 @@ func WithTurnScheme(scheme string) DialOption {
 
 // WithTurnTransport returns a DialOption which overrides the transport ("tcp" or
 // "udp") of the URI matched by WithTurnURI.
+//
+// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
+// whichever is applied last wins and may cause unexpected behavior.
 func WithTurnTransport(transport string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnTransport = transport
@@ -243,6 +265,9 @@ func WithTurnTransport(transport string) DialOption {
 
 // WithTurnPort returns a DialOption which overrides the port of the URI matched
 // by WithTurnURI. A port of 0 means no override.
+//
+// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
+// whichever is applied last wins and may cause unexpected behavior.
 func WithTurnPort(port int) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnPort = port

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -199,11 +199,8 @@ func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
 }
 
 // WithForceP2P returns a DialOption which forces ICE connections to use only
-// host and server-reflexive candidates, stripping TURN servers. Unlike
-// WithWebRTCOptions it only sets the ForceP2P field and leaves every other
-// WebRTC option in place, so it composes additively with previously-applied
-// WebRTC options. Apply it after WithWebRTCOptions, since that option replaces
-// the whole WebRTC options struct.
+// non-relay candidates (host, server-reflexive, and peer-reflexive) by
+// stripping TURN servers.
 func WithForceP2P() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.ForceP2P = true
@@ -211,8 +208,7 @@ func WithForceP2P() DialOption {
 }
 
 // WithForceRelay returns a DialOption which forces ICE connections to use relay
-// (TURN) candidates only. Like WithForceP2P, it only sets its own field and
-// leaves every other WebRTC option in place. Apply it after WithWebRTCOptions.
+// (TURN) candidates only.
 func WithForceRelay() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.ForceRelay = true
@@ -221,9 +217,8 @@ func WithForceRelay() DialOption {
 
 // WithTurnURI returns a DialOption which filters the signaling server's TURN
 // list down to the server whose parsed URI matches uri (e.g.
-// "turn:turn.viam.com:443"). Like the force options it only sets its own field
-// and leaves every other WebRTC option in place. Has no effect when ForceP2P is
-// set, since TURN servers are stripped in that case.
+// "turn:turn.viam.com:443"). Has no effect when ForceP2P is set, since TURN
+// servers are stripped in that case.
 func WithTurnURI(uri string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnURI = uri
@@ -231,7 +226,7 @@ func WithTurnURI(uri string) DialOption {
 }
 
 // WithTurnScheme returns a DialOption which overrides the scheme ("turn" or
-// "turns") of the URI matched by WithTurnURI. Only sets its own field.
+// "turns") of the URI matched by WithTurnURI.
 func WithTurnScheme(scheme string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnScheme = scheme
@@ -239,7 +234,7 @@ func WithTurnScheme(scheme string) DialOption {
 }
 
 // WithTurnTransport returns a DialOption which overrides the transport ("tcp" or
-// "udp") of the URI matched by WithTurnURI. Only sets its own field.
+// "udp") of the URI matched by WithTurnURI.
 func WithTurnTransport(transport string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnTransport = transport
@@ -247,7 +242,7 @@ func WithTurnTransport(transport string) DialOption {
 }
 
 // WithTurnPort returns a DialOption which overrides the port of the URI matched
-// by WithTurnURI. A port of 0 means no override. Only sets its own field.
+// by WithTurnURI. A port of 0 means no override.
 func WithTurnPort(port int) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnPort = port

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -192,12 +192,11 @@ func WithTLSConfig(config *tls.Config) DialOption {
 // WithWebRTCOptions returns a DialOption which sets the WebRTC options
 // to use if the dialer tries to establish a WebRTC connection.
 //
-// Note: this sets the complete DialWebRTCOptions struct, replacing any WebRTC
-// options set before it — including values from the granular options like
-// WithForceP2P and WithTurnURI. Those granular options are meant to layer on
-// top of this base, so apply them after WithWebRTCOptions. The base struct is
-// typically established first (often by the dialer itself), so this ordering is
-// the norm.
+// Note: this sets the complete DialWebRTCOptions base struct, replacing WebRTC
+// options set before it. The granular ICE/TURN options (WithForceP2P,
+// WithForceRelay, WithTurn*) are meant to layer on top, so pass them after
+// WithWebRTCOptions and they override just their own fields. The base struct is
+// typically set first (often by the dialer), so this ordering is the norm.
 func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts = webrtcOpts

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -198,6 +198,62 @@ func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
 	})
 }
 
+// WithForceP2P returns a DialOption which forces ICE connections to use only
+// host and server-reflexive candidates, stripping TURN servers. Unlike
+// WithWebRTCOptions it only sets the ForceP2P field and leaves every other
+// WebRTC option in place, so it composes additively with previously-applied
+// WebRTC options. Apply it after WithWebRTCOptions, since that option replaces
+// the whole WebRTC options struct.
+func WithForceP2P() DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.webrtcOpts.ForceP2P = true
+	})
+}
+
+// WithForceRelay returns a DialOption which forces ICE connections to use relay
+// (TURN) candidates only. Like WithForceP2P, it only sets its own field and
+// leaves every other WebRTC option in place. Apply it after WithWebRTCOptions.
+func WithForceRelay() DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.webrtcOpts.ForceRelay = true
+	})
+}
+
+// WithTurnURI returns a DialOption which filters the signaling server's TURN
+// list down to the server whose parsed URI matches uri (e.g.
+// "turn:turn.viam.com:443"). Like the force options it only sets its own field
+// and leaves every other WebRTC option in place. Has no effect when ForceP2P is
+// set, since TURN servers are stripped in that case.
+func WithTurnURI(uri string) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.webrtcOpts.TurnURI = uri
+	})
+}
+
+// WithTurnScheme returns a DialOption which overrides the scheme ("turn" or
+// "turns") of the URI matched by WithTurnURI. Only sets its own field.
+func WithTurnScheme(scheme string) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.webrtcOpts.TurnScheme = scheme
+	})
+}
+
+// WithTurnTransport returns a DialOption which overrides the transport ("tcp" or
+// "udp") of the URI matched by WithTurnURI. Only sets its own field.
+func WithTurnTransport(transport string) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.webrtcOpts.TurnTransport = transport
+	})
+}
+
+// WithTurnPort returns a DialOption which overrides the port of the URI matched
+// by WithTurnURI. A port of 0 means no override. Only sets its own field.
+func WithTurnPort(port int) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.webrtcOpts.TurnPort = port
+	})
+}
+
 // WithDialDebug returns a DialOption which informs the client to be in a
 // debug mode as much as possible.
 func WithDialDebug() DialOption {

--- a/rpc/dial_options.go
+++ b/rpc/dial_options.go
@@ -192,12 +192,12 @@ func WithTLSConfig(config *tls.Config) DialOption {
 // WithWebRTCOptions returns a DialOption which sets the WebRTC options
 // to use if the dialer tries to establish a WebRTC connection.
 //
-// Note: this replaces the entire DialWebRTCOptions struct in one shot, so it
-// clashes with the granular dial options (WithForceP2P, WithForceRelay,
-// WithTurnURI, etc.). Combining it with any of those is order-dependent —
-// whichever DialOption is applied last wins — which can produce unexpected
-// behavior. For additive tweaks that leave other fields intact, prefer the
-// granular options.
+// Note: this sets the complete DialWebRTCOptions struct, replacing any WebRTC
+// options set before it — including values from the granular options like
+// WithForceP2P and WithTurnURI. Those granular options are meant to layer on
+// top of this base, so apply them after WithWebRTCOptions. The base struct is
+// typically established first (often by the dialer itself), so this ordering is
+// the norm.
 func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts = webrtcOpts
@@ -209,8 +209,9 @@ func WithWebRTCOptions(webrtcOpts DialWebRTCOptions) DialOption {
 // non-relay candidates (host, server-reflexive, and peer-reflexive) by
 // stripping TURN servers.
 //
-// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
-// whichever is applied last wins and may cause unexpected behavior.
+// Note: this sets only its own field, layering on top of any WithWebRTCOptions.
+// Apply it after WithWebRTCOptions, since a later WithWebRTCOptions replaces the
+// entire struct and would overwrite this.
 func WithForceP2P() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.ForceP2P = true
@@ -220,8 +221,9 @@ func WithForceP2P() DialOption {
 // WithForceRelay returns a DialOption which forces ICE connections to use relay
 // (TURN) candidates only.
 //
-// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
-// whichever is applied last wins and may cause unexpected behavior.
+// Note: this sets only its own field, layering on top of any WithWebRTCOptions.
+// Apply it after WithWebRTCOptions, since a later WithWebRTCOptions replaces the
+// entire struct and would overwrite this.
 func WithForceRelay() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.ForceRelay = true
@@ -233,8 +235,9 @@ func WithForceRelay() DialOption {
 // "turn:turn.viam.com:443"). Has no effect when ForceP2P is set, since TURN
 // servers are stripped in that case.
 //
-// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
-// whichever is applied last wins and may cause unexpected behavior.
+// Note: this sets only its own field, layering on top of any WithWebRTCOptions.
+// Apply it after WithWebRTCOptions, since a later WithWebRTCOptions replaces the
+// entire struct and would overwrite this.
 func WithTurnURI(uri string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnURI = uri
@@ -244,8 +247,9 @@ func WithTurnURI(uri string) DialOption {
 // WithTurnScheme returns a DialOption which overrides the scheme ("turn" or
 // "turns") of the URI matched by WithTurnURI.
 //
-// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
-// whichever is applied last wins and may cause unexpected behavior.
+// Note: this sets only its own field, layering on top of any WithWebRTCOptions.
+// Apply it after WithWebRTCOptions, since a later WithWebRTCOptions replaces the
+// entire struct and would overwrite this.
 func WithTurnScheme(scheme string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnScheme = scheme
@@ -255,8 +259,9 @@ func WithTurnScheme(scheme string) DialOption {
 // WithTurnTransport returns a DialOption which overrides the transport ("tcp" or
 // "udp") of the URI matched by WithTurnURI.
 //
-// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
-// whichever is applied last wins and may cause unexpected behavior.
+// Note: this sets only its own field, layering on top of any WithWebRTCOptions.
+// Apply it after WithWebRTCOptions, since a later WithWebRTCOptions replaces the
+// entire struct and would overwrite this.
 func WithTurnTransport(transport string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnTransport = transport
@@ -266,8 +271,9 @@ func WithTurnTransport(transport string) DialOption {
 // WithTurnPort returns a DialOption which overrides the port of the URI matched
 // by WithTurnURI. A port of 0 means no override.
 //
-// Note: clashes with the deprecated WithWebRTCOptions; if both are passed,
-// whichever is applied last wins and may cause unexpected behavior.
+// Note: this sets only its own field, layering on top of any WithWebRTCOptions.
+// Apply it after WithWebRTCOptions, since a later WithWebRTCOptions replaces the
+// entire struct and would overwrite this.
 func WithTurnPort(port int) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.webrtcOpts.TurnPort = port


### PR DESCRIPTION
## Description

`WithWebRTCOptions(...)` does a replacement of the whole `DialWebRTCOptions` struct. So setting a single flag like `ForceP2P` clobbers everything else, e.g. `SignalingServerAddress`, `SignalingCreds`, `Config`, the TURN knobs etc...

Callers work around this today by re-passing the whole struct and manually constructing `DialWebRTCOptions` with all the desired fields. This PR adds granular dial options that mutate only their own field on `o.webrtcOpts`, leaving every other WebRTC option in place:

- `WithForceP2P()`
- `WithForceRelay()`
- `WithTurnURI(uri)`
- `WithTurnScheme(scheme)`
- `WithTurnTransport(transport)`
- `WithTurnPort(port)`

Semantics: **additive** when applied after `WithWebRTCOptions(...)`, **last-writer-wins** if two touch the same field.

Ex.
```go
rpc.Dial(ctx, address, logger,
    rpc.WithEntityCredentials(entity, creds),
    rpc.WithWebRTCOptions(rpc.DialWebRTCOptions{SignalingServerAddress: signalingAddr}),
    rpc.WithForceRelay(),
    rpc.WithTurnURI("turn:turn.viam.com:443"),
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)