### PR TITLE
RSDK-14167 Work around OpenCensus omitting golang memory metrics

### DIFF
--- a/perf/metrics.go
+++ b/perf/metrics.go
@@ -12,6 +12,9 @@ func registerApplicationViews() error {
 	utils.UncheckedError(runmetrics.Enable(runmetrics.RunMetricOptions{
 		EnableCPU:    true,
 		EnableMemory: true,
+		// Required to workaround known opencensus bug with memory metrics
+		// https://github.com/census-instrumentation/opencensus-go/issues/1295
+		UseDerivedCumulative: true,
 	}))
 
 	return multierr.Combine(


### PR DESCRIPTION
See https://viam.atlassian.net/browse/RSDK-14167 for further details. Summary reproduced below:

OpenCensus metrics emitted by `perf/metrics.go` are impacted by OpenCensus bug https://github.com/census-instrumentation/opencensus-go/issues/1295 (filed in 2023). The issue means that a variety of Golang runtime metrics (particularly around memory/GC) are emitted but always with zero values. And given this OpenCensus bug is almost certainly abandoned since OpenCensus was superseded by OpenTelemetry, our remaining option is to work around it.

This change is the workaround, which switches to specifying `UseDerivedCumulative`. As a side effect the existing metrics will see their type change from gauge to cumulative (counter).

