### PR TITLE
RSDK-13483 Allow `nil` Stop error on Windows in TestProcessManagerStart

### DIFF
--- a/pexec/process_manager_test.go
+++ b/pexec/process_manager_test.go
@@ -185,17 +185,13 @@ func TestProcessManagerStart(t *testing.T) {
 		pm := NewProcessManager(logger)
 		defer func() {
 			if runtime.GOOS == "windows" {
-				// on windows, we return a process not found error here
-				var processNotExistsErr *ProcessNotExistsError
-				// NOTE(benjirewis): we do not _always_ return a process not found error here in
-				// CI. Log the error value for now to get more information.
-				stopErr := pm.Stop()
-				if stopErr != nil {
+				// On windows, we can return a process not found error here or nil. Fail the test
+				// on anything else.
+				if stopErr := pm.Stop(); stopErr != nil {
 					t.Logf("error from Stop on windows was %q", stopErr.Error())
-				} else {
-					t.Log("error from Stop on windows was (unexpectedly) nil")
+					var processNotExistsErr *ProcessNotExistsError
+					test.That(t, errors.As(stopErr, &processNotExistsErr), test.ShouldBeTrue)
 				}
-				test.That(t, errors.As(stopErr, &processNotExistsErr), test.ShouldBeTrue)
 			} else {
 				test.That(t, pm.Stop(), test.ShouldBeNil)
 			}


### PR DESCRIPTION
RSDK-13483

## What

Allows `pm.Stop()` to return `nil` in `TestProcessManagerStart` on Windows.

## Why

`pm.Stop()` on Windows is known to sometimes return a `*ProcessNotExistsError`. We used to assert that `pm.Stop()` always returned an instance of that error on Windows. `TestProcessManagerStart` sometimes failed saying "it wasn't a process not exists error." I then added some logging to show what the error actually was in the event that it was not an instance of `*ProcessNotExistsError`. According to the logs from the RSDK-13483 failure, the error was just `nil`. `nil` is a perfectly acceptable value here. We can allow the test to pass in the event that `pm.Stop() == nil`. If the error is anything _besides_ `nil` or `ProcessNotExistsError`, we should log that error and fail the test.