### PR TITLE
RSDK-13986: Fix flaky stream reset test

### DIFF
--- a/rpc/wrtc_server_channel_test.go
+++ b/rpc/wrtc_server_channel_test.go
@@ -451,11 +451,6 @@ func TestWebRTCServerChannelResetStream(t *testing.T) {
 	})
 
 	t.Run("reset stream after message before server response", func(t *testing.T) {
-		respMd, err := proto.Marshal(&echopb.EchoResponse{
-			Message: "hello",
-		})
-		test.That(t, err, test.ShouldBeNil)
-
 		// We need to reset after the service has received the request but before
 		// its response has been written to the wire. To do this we inject a
 		// callback into the echoserver and use channels to coordinate the
@@ -466,6 +461,7 @@ func TestWebRTCServerChannelResetStream(t *testing.T) {
 			close(respWaiting)
 			<-blockResp
 		})
+		defer close(blockResp)
 		defer echoSrv.setBeforeSend(nil)
 
 		expectedMessages := []*webrtcpb.Response{
@@ -477,19 +473,10 @@ func TestWebRTCServerChannelResetStream(t *testing.T) {
 			},
 			{
 				Stream: &webrtcpb.Stream{Id: 4},
-				Type: &webrtcpb.Response_Message{
-					Message: &webrtcpb.ResponseMessage{
-						PacketMessage: &webrtcpb.PacketMessage{
-							Data: respMd,
-							Eom:  true,
-						},
-					},
-				},
-			},
-			{
-				Stream: &webrtcpb.Stream{Id: 4},
 				Type: &webrtcpb.Response_Trailers{
-					Trailers: &webrtcpb.ResponseTrailers{},
+					Trailers: &webrtcpb.ResponseTrailers{
+						Status: ErrorToStatus(status.Error(codes.Canceled, "request cancelled")).Proto(),
+					},
 				},
 			},
 		}
@@ -519,10 +506,23 @@ func TestWebRTCServerChannelResetStream(t *testing.T) {
 			Eos: true,
 		}), test.ShouldBeNil)
 
+		// here we wait until the server is ready to respond to the request we just made,
+		// to simulate an RPC that takes a long time to respond
 		<-respWaiting
+		// then, we write the reset request to the server
 		test.That(t, clientCh.writeReset(&webrtcpb.Stream{Id: 4}), test.ShouldBeNil)
-		close(blockResp)
+		// whenever the server handles the reset request, it will send the response headers to the client,
+		// then send the trailers, then tear down its stream and cancel its context
+
+		// we want the server to handle the reset before the server tries to respond to the initial request,
+		// so we sit here and wait until we get all the expected messages
 		<-messagesReadCtx.Done()
+		// after we receive the expected messages, the deferred close(blockResp) will run.
+		// also, if the above assertion fails, the deferred close will still run, so that
+		// we don't leak a goroutine if this test fails
+
+		// when the server tries to respond, it will get a closed pipe error, but we can't observe
+		// this error since the server itself throws it out
 	})
 }
 


### PR DESCRIPTION
Fix for `TestWebRTCServerChannelResetStream/reset_stream_after_message_before_server_response` flaky test

The issue here was a race between a server handling a reset and handling a request.

The test was sending a request that kicked off an RPC, and then immediately sending reset request. The intent of the test was for the server to handle the reset request before the normal response could be sent (simulating a server that received a reset request while a long-running RPC was in flight). We should have expected to see two messages come back from the server: first the headers, then the trailers indicating that the stream was closed (reset request was handled). We shouldn't see the normal response in this case - the server would later try to send it and just get a closed pipe error which we throw out.

However the test was written around the other way that this situation could go, where the normal RPC response came back before the server actually handled the reset request. `expectedMessages` has the normal RPC response. And most of the time, this is the way the test actually went, since the RPC in the test was just getting held until the reset request was _sent_ and then immediately being allowed to respond. So the normal response usually won the race and we rarely saw the "correct" response with the trailers, and without the normal response.

The fix is to update the expected messages and then just wait for all the expected messages _before_ unblocking the server. This is basically just a swap of the two lines at the end of the test, but then also changing one of the lines to a `defer` so that we don't leak a goroutine if the test fails for some other reason.

I also added a bunch of comments in this test explaining what was actually going on, will hopefully help maintainers in the future.