### PR TITLE
RSDK-14271 Expose `WaitForStateChange`

### DIFF
--- a/grpchelpers/grpchelpers.go
+++ b/grpchelpers/grpchelpers.go
@@ -2,6 +2,7 @@
 package grpchelpers
 
 import (
+	"context"
 	"errors"
 
 	"google.golang.org/grpc"
@@ -9,10 +10,13 @@ import (
 )
 
 // ConnectivityState allows callers to check the connectivity state of
-// the connection
+// the connection and to be notified of state transition events
 // see https://github.com/grpc/grpc-go/blob/master/clientconn.go#L648
 type ConnectivityState interface {
 	GetState() connectivity.State
+	// WaitForStateChange blocks until the connectivity state of the connection changes from
+	// sourceState or ctx expires, returning true in the former case and false in the latter.
+	WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool
 }
 
 // ConnConnectivityState returns the connectivity.State of the current connection, if available.

--- a/grpchelpers/grpchelpers.go
+++ b/grpchelpers/grpchelpers.go
@@ -16,7 +16,7 @@ type ConnectivityState interface {
 	GetState() connectivity.State
 	// WaitForStateChange blocks until the connectivity state of the connection changes from
 	// sourceState or ctx expires, returning true in the former case and false in the latter.
-	WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool
+	WaitForStateChange(ctx context.Context, sourceState connectivity.State) (bool, error)
 }
 
 // ConnConnectivityState returns the connectivity.State of the current connection, if available.

--- a/grpchelpers/grpchelpers.go
+++ b/grpchelpers/grpchelpers.go
@@ -11,7 +11,7 @@ import (
 
 // ConnectivityState allows callers to check the connectivity state of
 // the connection and to be notified of state transition events
-// see https://github.com/grpc/grpc-go/blob/master/clientconn.go#L648
+// see https://github.com/grpc/grpc-go/blob/v1.79.3/clientconn.go#L724
 type ConnectivityState interface {
 	GetState() connectivity.State
 	// WaitForStateChange blocks until the connectivity state of the connection changes from

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -685,6 +685,21 @@ func (cc clientConnRPCAuthenticator) GetState() connectivity.State {
 	return checker.GetState()
 }
 
+// WaitForStateChange blocks until the connectivity state of the underlying connection changes from
+// sourceState or ctx expires, returning true in the former case and false in the latter. It is
+// exposed if it is available on the underlying type; otherwise it blocks until ctx expires and
+// returns false.
+func (cc clientConnRPCAuthenticator) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
+	// WaitForStateChange is only expected to be called on connections to app,
+	// which we assume will always be GrpcOverHTTPClientConn.
+	subscriber, ok := cc.ClientConn.(GrpcOverHTTPClientConn)
+	if !ok {
+		<-ctx.Done()
+		return false
+	}
+	return subscriber.WaitForStateChange(ctx, sourceState)
+}
+
 type staticPerRPCJWTCredentials struct {
 	authMaterial string
 }

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -685,13 +685,11 @@ func (cc clientConnRPCAuthenticator) GetState() connectivity.State {
 	return checker.GetState()
 }
 
-// WaitForStateChange blocks until the connectivity state of the underlying connection changes from
-// sourceState or ctx expires, returning true in the former case and false in the latter. It is
-// exposed if it is available on the underlying type; otherwise it blocks until ctx expires and
-// returns false.
+// WaitForStateChange blocks until the connectivity state of the underlying connection
+// changes from sourceState or ctx expires, returning true in the former case and false in
+// the latter. It returns false and an error in the case that the client connection does
+// not allow waiting for state change.
 func (cc clientConnRPCAuthenticator) WaitForStateChange(ctx context.Context, sourceState connectivity.State) (bool, error) {
-	// WaitForStateChange is only expected to be called on connections to app,
-	// which we assume will always be GrpcOverHTTPClientConn.
 	subscriber, ok := cc.ClientConn.(GrpcOverHTTPClientConn)
 	if !ok {
 		return false, errors.New("underlying connection does not allow waiting for state change")

--- a/rpc/dialer.go
+++ b/rpc/dialer.go
@@ -689,15 +689,14 @@ func (cc clientConnRPCAuthenticator) GetState() connectivity.State {
 // sourceState or ctx expires, returning true in the former case and false in the latter. It is
 // exposed if it is available on the underlying type; otherwise it blocks until ctx expires and
 // returns false.
-func (cc clientConnRPCAuthenticator) WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool {
+func (cc clientConnRPCAuthenticator) WaitForStateChange(ctx context.Context, sourceState connectivity.State) (bool, error) {
 	// WaitForStateChange is only expected to be called on connections to app,
 	// which we assume will always be GrpcOverHTTPClientConn.
 	subscriber, ok := cc.ClientConn.(GrpcOverHTTPClientConn)
 	if !ok {
-		<-ctx.Done()
-		return false
+		return false, errors.New("underlying connection does not allow waiting for state change")
 	}
-	return subscriber.WaitForStateChange(ctx, sourceState)
+	return subscriber.WaitForStateChange(ctx, sourceState), nil
 }
 
 type staticPerRPCJWTCredentials struct {


### PR DESCRIPTION
RSDK-14271

## What

Adds `WaitForStateChange` to the `grpchelpers.ConnectivityState` interface, exposing gRPC's blocking state-transition notification API (`(*grpc.ClientConn).WaitForStateChange`) alongside the existing `GetState`. Also adds a forwarding implementation on `clientConnRPCAuthenticator`, mirroring its existing `GetState` forwarding, so that credentialed connections to app satisfy the updated interface.

## Why

Callers holding a connection to app can currently only poll GetState to observe connectivity. WaitForStateChange blocks until the connectivity state actually transitions, letting callers subscribe to lost/regained-connection events without polling. The immediate consumer is `viam-server`'s AppConn in `rdk` ([PR here](https://github.com/viamrobotics/rdk/pull/6234/changes)), which uses it to log Info-level "Lost connection to app" / "Regained connection to app" messages so offline periods are visible in robot logs.

[Description generated by Claude 🤖]