### PR TITLE
Allow unsafe PR checkouts (forks)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 2
+        # Fork PRs only reach pull_request_target runs behind the 'safe to test' label (see pr-labeler.yml).
+        allow-unsafe-pr-checkout: true
 
 
     - name: Install toolchain
@@ -122,6 +124,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+        allow-unsafe-pr-checkout: true
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod


### PR DESCRIPTION
Same as https://github.com/viamrobotics/rdk/pull/6245 for goutils.