### PR TITLE
RSDK-14304 - Offline machines can't do local WebRTC

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -696,19 +696,19 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 		}
 
 		if sOpts.webrtcOpts.ExternalSignalingAddress != "" {
-			logger.Infow(
-				"Running external signaling",
-				"signaling_address", sOpts.webrtcOpts.ExternalSignalingAddress,
-				"for_hosts", externalSignalingHosts,
-			)
-			server.webrtcAnswerers = append(server.webrtcAnswerers, newWebRTCSignalingAnswerer(
-				sOpts.webrtcOpts.ExternalSignalingAddress,
-				externalSignalingHosts,
-				server.webrtcServer,
-				sOpts.webrtcOpts.ExternalSignalingDialOpts,
-				config,
-				utils.Sublogger(logger, "signaler.external"),
-			))
+			// logger.Infow(
+			// 	"Running external signaling",
+			// 	"signaling_address", sOpts.webrtcOpts.ExternalSignalingAddress,
+			// 	"for_hosts", externalSignalingHosts,
+			// )
+			// server.webrtcAnswerers = append(server.webrtcAnswerers, newWebRTCSignalingAnswerer(
+			// 	sOpts.webrtcOpts.ExternalSignalingAddress,
+			// 	externalSignalingHosts,
+			// 	server.webrtcServer,
+			// 	sOpts.webrtcOpts.ExternalSignalingDialOpts,
+			// 	config,
+			// 	utils.Sublogger(logger, "signaler.external"),
+			// ))
 		} else {
 			sOpts.webrtcOpts.EnableInternalSignaling = true
 		}
@@ -735,8 +735,15 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 			)
 			var answererDialOpts []DialOption
 			if sOpts.tlsConfig != nil {
+				// This TLS config exists only to match the shared TLS-serving listener; its
+				// identity/verification content is intentionally unused on this dial. The answerer
+				// dials the machine's own signaling server over loopback, so trust is guaranteed by
+				// the loopback hop, not the certificate. The machine cert has no system-trusted chain,
+				// so verifying it here always fails and (under WithBlock) stalls until the dial
+				// deadline; skip verification. ServerName is retained only for SNI.
 				tlsConfig := sOpts.tlsConfig.Clone()
 				tlsConfig.ServerName = server.firstSeenTLSCertLeaf.Subject.CommonName
+				tlsConfig.InsecureSkipVerify = true
 				answererDialOpts = append(answererDialOpts, WithTLSConfig(tlsConfig))
 			} else {
 				answererDialOpts = append(answererDialOpts, WithInsecure())

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -696,19 +696,19 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 		}
 
 		if sOpts.webrtcOpts.ExternalSignalingAddress != "" {
-			// logger.Infow(
-			// 	"Running external signaling",
-			// 	"signaling_address", sOpts.webrtcOpts.ExternalSignalingAddress,
-			// 	"for_hosts", externalSignalingHosts,
-			// )
-			// server.webrtcAnswerers = append(server.webrtcAnswerers, newWebRTCSignalingAnswerer(
-			// 	sOpts.webrtcOpts.ExternalSignalingAddress,
-			// 	externalSignalingHosts,
-			// 	server.webrtcServer,
-			// 	sOpts.webrtcOpts.ExternalSignalingDialOpts,
-			// 	config,
-			// 	utils.Sublogger(logger, "signaler.external"),
-			// ))
+			logger.Infow(
+				"Running external signaling",
+				"signaling_address", sOpts.webrtcOpts.ExternalSignalingAddress,
+				"for_hosts", externalSignalingHosts,
+			)
+			server.webrtcAnswerers = append(server.webrtcAnswerers, newWebRTCSignalingAnswerer(
+				sOpts.webrtcOpts.ExternalSignalingAddress,
+				externalSignalingHosts,
+				server.webrtcServer,
+				sOpts.webrtcOpts.ExternalSignalingDialOpts,
+				config,
+				utils.Sublogger(logger, "signaler.external"),
+			))
 		} else {
 			sOpts.webrtcOpts.EnableInternalSignaling = true
 		}

--- a/rpc/wrtc_signaling_answerer.go
+++ b/rpc/wrtc_signaling_answerer.go
@@ -228,8 +228,8 @@ func (ans *webrtcSignalingAnswerer) startAnswerer() {
 						}
 					}
 					ans.logger.Infow("failed to communicate with signaling server", "error", err)
-					utils.SelectContextOrWait(ctx, answererReconnectWait)
 				}
+				utils.SelectContextOrWait(ctx, answererReconnectWait)
 				continue
 			}
 			clearOfflineErrMap = true


### PR DESCRIPTION
Cause: The internal signaling answerer dials the machine's own TLS listener over loopback. Its client TLS config has no RootCAs, so it verifies the Viam cert against system roots and fails ("unknown authority"). Under grpc.WithBlock the failing handshake retries until the 10s timeout → answerer never registers → local calls go unanswered.

Only reproduces offline (online uses external signaling) and with a cert present (with a cert the server binds TLS; without one it binds insecure loopback and works).

Fix: Set InsecureSkipVerify = true on the internal answerer's dial TLS config in rpc/server.go. Safe because it's a loopback self-dial — trust is guaranteed by loopback, not the cert. TLS itself must stay (shared listener serves external clients).