### PR TITLE
rpc: deliver the dial connection report synchronously

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -47,8 +47,8 @@ func dialInner(
 
 	// One logical dial can fan out into several WebRTC attempts (racing mDNS and cloud paths) or re-use a
 	// cached connection. Each attempt reports its outcome which is threaded back up the call stack and, on
-	// completion, delivers over a separate connection to app (only app implements the report RPC) the
-	// furthest-progressed attempt. Flushed in the background so reporting never adds latency to the dial.
+	// completion, delivered over a separate connection to app (only app implements the report RPC) as the
+	// furthest-progressed attempt.
 	var report *dialReport
 	conn, cached, err := dialFunc(
 		ctx,
@@ -81,7 +81,7 @@ func dialInner(
 			return conn, err
 		})
 
-	defer func() { go sendDialReport(ctx, address, logger, report, err) }()
+	defer sendDialReport(ctx, address, logger, report, err)
 
 	if err != nil {
 		return nil, err

--- a/rpc/wrtc_client_report.go
+++ b/rpc/wrtc_client_report.go
@@ -44,10 +44,12 @@ func fixUpReportDialOpts(dOpts dialOptions) *dialOptions {
 	return &dOpts
 }
 
-// sendDialReport delivers a single connection report for a logical dial, if there is one to send and an
-// app to send it to. It detaches from the dial context (so a cancelled or timed-out dial still reports)
-// with a 5s timeout, opens its own connection to the app signaling server, stamps the RPC host, and logs
-// any errors to report. report may be nil (a dial that produced no attempts, e.g. a cache hit).
+const dialReportTimeout = 2 * time.Second
+
+// sendDialReport delivers a single connection report for a logical dial. It is called synchronously
+// at the end of a dial but detaches from the dial context (so a cancelled or timed-out dial still reports),
+// bounded by dialReportTimeout. It opens its own connection to the app signaling server, stamps the RPC
+// host, and logs any errors. report may be nil (a dial that produced no attempts, e.g. a cache hit).
 func sendDialReport(
 	ctx context.Context,
 	host string,
@@ -64,7 +66,7 @@ func sendDialReport(
 	}
 	appDialOpts := report.appDialOpts
 
-	reportCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	reportCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dialReportTimeout)
 	defer cancel()
 
 	conn, err := dialSignalingServer(reportCtx, appDialOpts.webrtcOpts.SignalingServerAddress, host, logger, *appDialOpts)


### PR DESCRIPTION
## Problem

v0.10.0 (#583) delivers each dial's connection report from a fire-and-forget goroutine:

```go
defer func() { go sendDialReport(ctx, address, logger, report, err) }()
```

`sendDialReport` detaches from the dial's context and opens its own connection to app. With no owner and nothing waiting on it, that goroutine outlives the dial, which surfaces problems in two ways:

1. Goroutine-leak checks fail — the report goroutine is still mid grpc-dial to app when a leak check snapshots goroutines.
2. Log in report goroutine after test has completed panic

Both are the same root cause: a background goroutine with no lifecycle owner.

## Fix

Deliver the report synchronously at the end of the dial so no goroutine outlives the dial. It still detaches from the dial's context (a cancelled/timed-out dial still reports), now bounded by `dialReportTimeout` (2s).

I chose this for simplicity over lifecycle tracking machinery for the report goroutine but a dial now waits on the report, which can add up to 2s of latency (but typically far less).