### PR TITLE
rpc: skip the dial connection report in test binaries

### DIFF
--- a/rpc/dial.go
+++ b/rpc/dial.go
@@ -81,7 +81,11 @@ func dialInner(
 			return conn, err
 		})
 
-	defer func() { go sendDialReport(ctx, address, logger, report, err) }()
+	defer func() {
+		if dialReportingEnabled() {
+			go sendDialReport(ctx, address, logger, report, err)
+		}
+	}()
 
 	if err != nil {
 		return nil, err

--- a/rpc/wrtc_client_report.go
+++ b/rpc/wrtc_client_report.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"slices"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/viamrobotics/webrtc/v3"
@@ -43,6 +44,10 @@ func fixUpReportDialOpts(dOpts dialOptions) *dialOptions {
 	}
 	return &dOpts
 }
+
+// dialReportingEnabled reports whether a dial should deliver its connection report. Disabled in tests
+// so the report goroutine can't outlive its test and trip goroutine-leak checks or log after the test ends.
+var dialReportingEnabled = func() bool { return !testing.Testing() }
 
 // sendDialReport delivers a single connection report for a logical dial, if there is one to send and an
 // app to send it to. It detaches from the dial context (so a cancelled or timed-out dial still reports)

--- a/rpc/wrtc_client_report_test.go
+++ b/rpc/wrtc_client_report_test.go
@@ -153,6 +153,12 @@ func TestReportConnectionMetadataOncePerDial(t *testing.T) {
 	testutils.SkipUnlessInternet(t)
 	logger := golog.NewTestLogger(t)
 
+	// Reporting is disabled in tests by default (see dialReportingEnabled). This test
+	// exercises the reporting path, so re-enable it for the test's duration.
+	origReportingEnabled := dialReportingEnabled
+	dialReportingEnabled = func() bool { return true }
+	defer func() { dialReportingEnabled = origReportingEnabled }()
+
 	// The client only reports to a signaling server it classifies as the app. Treat this test's
 	// loopback signaling server as an app host so the reporting path is exercised.
 	origCloudHosts := viamCloudSignalingHosts


### PR DESCRIPTION
## Problem

v0.10.0 (#583) delivers each dial's connection report from a fire-and-forget goroutine:

```go
defer func() { go sendDialReport(ctx, address, logger, report, err) }()
```

`sendDialReport` detaches from the dial's context and opens its own connection to app. With no owner and nothing waiting on it, that goroutine outlives the dial, which surfaces in tests two ways:

1. Goroutine-leak checks fail (rdk robot/web) — the report goroutine is still mid grpc-dial to app when a leak check snapshots goroutines.
2. It logs through a test-scoped logger after the test completed, which panics.

Both are the same root cause: a background goroutine with no lifecycle owner.

## Fix

Keep reporting in the background but skip it in test binaries:

```go
var dialReportingEnabled = func() bool { return !testing.Testing() }
```