### PR TITLE
RSDK-13987 pexec: flaky test fix TestManagedProcessStart/Managed/starting with a canceled context should have no effect

### DIFF
--- a/pexec/managed_process_test.go
+++ b/pexec/managed_process_test.go
@@ -196,12 +196,21 @@ func TestManagedProcessStart(t *testing.T) {
 			cancel()
 
 			test.That(t, proc.Start(ctx), test.ShouldBeNil)
+			// A managed (non-oneshot) process ignores the context passed to Start,
+			// so the short-lived "echo hello" process starts despite the canceled
+			// context. By the time Stop runs, that process may or may not have
+			// already exited, so Stop's result is timing dependent.
+			stopErr := proc.Stop()
 			if runtime.GOOS == "windows" {
-				// on windows, we return a process not found error here
-				var processNotExistsErr *ProcessNotExistsError
-				test.That(t, errors.As(proc.Stop(), &processNotExistsErr), test.ShouldBeTrue)
+				// On windows, if the process already exited we return a process not
+				// found error; if it was still running we terminate it and return
+				// nil. Both outcomes are valid, but any other error is unexpected.
+				if stopErr != nil {
+					var processNotExistsErr *ProcessNotExistsError
+					test.That(t, errors.As(stopErr, &processNotExistsErr), test.ShouldBeTrue)
+				}
 			} else {
-				test.That(t, proc.Stop(), test.ShouldBeNil)
+				test.That(t, stopErr, test.ShouldBeNil)
 			}
 		})
 		t.Run("starting with a normal context should run until stop", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes an intermittent (flaky) Windows failure in
`TestManagedProcessStart/Managed/starting_with_a_canceled_context_should_have_no_effect`
that surfaced during a goutils release on Windows.

## Root cause

The subtest starts a **managed** (non-oneshot) process running `bash -c "echo hello"`. For managed processes the context passed to `Start` is ignored (it is only used for one-shot processes), so the canceled context has no effect and the process starts normally — which is exactly what the test verifies with `proc.Start(ctx) == nil`.

The test then asserted that, on Windows, `proc.Stop()` **always** returns a `ProcessNotExistsError`. That assumes the short-lived `echo hello` process has already fully exited (and been reaped) by the time `Stop` runs, so `taskkill` reports `not found`.

That assumption is racy. The failure log shows the process was still running when `Stop` was called:

```
pexec/managed_process_windows.go:51  killing process 7800
pexec/managed_process_windows.go:68  must force terminate process
pexec/managed_process.go:539         Stopped module did not exit cleanly {"err": "exit status 0xc000013a"}
managed_process_test.go:202: Expected: true
    Actual:   false
```

- `taskkill /pid` reported `This process can only be terminated forcefully` (`must force terminate process`) — which only happens for a **live** console process.
- The `CTRL_BREAK_EVENT` then terminated it (`exit status 0xc000013a` = `STATUS_CONTROL_C_EXIT`).
- `kill()` returned `(false, nil)` and `Stop()` returned `nil` instead of a `ProcessNotExistsError`, so the assertion failed.

So, depending on timing, `Stop()` legitimately returns either `nil` (process still running → terminated) or a `ProcessNotExistsError` (process already gone). The test only accepted the latter.

## Fix

Accept both valid outcomes on Windows: `nil` or a `ProcessNotExistsError`. Any other error still fails the test, so genuine regressions are not masked. Non-Windows behavior is unchanged (`Stop() == nil`).

## Testing

The full `pexec` test binary cannot be compiled in this sandbox because transitive **test** dependencies (mongo-driver → GCP libraries) require network hosts that are outside the environment allowlist. Verified within these constraints:

- `go build ./pexec/` succeeds for both `linux` and `windows` targets.
- `gofmt` reports no formatting changes.
- The changed assertion logic was validated with a standalone reproduction: it passes for `nil`, a `*ProcessNotExistsError`, and a wrapped `*ProcessNotExistsError`, and correctly fails for any other error.

Key: RSDK-13987

Co-authored by Claude agent for Jira.