### PR TITLE
Retry backing MongoDB test client connection

### DIFF
--- a/testutils/mongodb.go
+++ b/testutils/mongodb.go
@@ -99,6 +99,12 @@ func backingMongoDBClient() (*mongo.Client, error) {
 	return backingMongoDBClientWithOptions(options.Client())
 }
 
+const (
+	backingMongoDBConnectAttempts       = 3
+	backingMongoDBConnectAttemptTimeout = 10 * time.Second
+	backingMongoDBConnectRetryBackoff   = time.Second
+)
+
 func backingMongoDBClientWithOptions(baseOptions *options.ClientOptions) (*mongo.Client, error) {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
@@ -112,8 +118,6 @@ func backingMongoDBClientWithOptions(baseOptions *options.ClientOptions) (*mongo
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
 	var clientOptions *options.ClientOptions
 	if baseOptions == nil {
@@ -122,22 +126,40 @@ func backingMongoDBClientWithOptions(baseOptions *options.ClientOptions) (*mongo
 		clientOptions = baseOptions.ApplyURI(mongoURI)
 	}
 
+	// Retries ride out transient unavailability (e.g. an overloaded CI runner); the error is
+	// cached only after all attempts fail, so later tests in the process still fail fast.
+	var connectErr error
+	for attempt := 0; attempt < backingMongoDBConnectAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(backingMongoDBConnectRetryBackoff)
+		}
+		client, err := connectBackingMongoDB(clientOptions)
+		if err == nil {
+			cachedBackingMongoDBClient = client
+			cachedBackingMongoDBClientConnected = true
+			errCachedBackingMongoDBClient = nil
+			return client, nil
+		}
+		connectErr = err
+	}
+	errCachedBackingMongoDBClient = connectErr
+	return nil, errCachedBackingMongoDBClient
+}
+
+func connectBackingMongoDB(clientOptions *options.ClientOptions) (*mongo.Client, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), backingMongoDBConnectAttemptTimeout)
+	defer cancel()
+
 	client, err := mongo.Connect(ctx, clientOptions)
 	if err != nil {
-		errCachedBackingMongoDBClient = err
-		return nil, errCachedBackingMongoDBClient
+		return nil, err
 	}
 	if err := client.Ping(ctx, readpref.Primary()); err != nil {
-		errCachedBackingMongoDBClient = multierr.Combine(err, client.Disconnect(ctx))
-		return nil, errCachedBackingMongoDBClient
+		return nil, multierr.Combine(err, client.Disconnect(ctx))
 	}
 	if result := client.Database("admin").RunCommand(ctx, bson.D{{"replSetGetStatus", 1}}); result.Err() != nil {
-		errCachedBackingMongoDBClient = multierr.Combine(result.Err(), client.Disconnect(ctx))
-		return nil, errCachedBackingMongoDBClient
+		return nil, multierr.Combine(result.Err(), client.Disconnect(ctx))
 	}
-	cachedBackingMongoDBClient = client
-	cachedBackingMongoDBClientConnected = true
-	errCachedBackingMongoDBClient = nil
 	return client, nil
 }
 


### PR DESCRIPTION
## What

`backingMongoDBClientWithOptions` in `testutils/mongodb.go` gave the initial connection one attempt with a 5s budget shared across Connect, Ping, and `replSetGetStatus`, and cached any failure for the life of the test process. This change gives it 3 attempts of 10s each, 1s apart, and caches the error only after all attempts fail — so a hard outage still fails fast for the rest of the process.

## Why

On a loaded CI runner, one missed 5s ping poisons every test in the package. In viamrobotics/app, [a single transient blip](https://github.com/viamrobotics/app/actions/runs/30258491158/job/91035279434) failed all 56 tests in the `auth` package: the first test burned the 5s budget, the remaining 55 failed instantly on the cached error. The 56-failure count then exceeded gotestsum's `--rerun-fails-max-failures` cap, so its retry never ran. This has hit app CI three times; each rerun passed with no code change. (viamrobotics/app#13040 raises the gotestsum cap as the in-repo guard; this PR removes the amplification at the source.)

## Notes

- Only a successful client is cached during the retry window; the failure-caching behavior for a genuinely down MongoDB is unchanged, it just happens after 3 attempts (~32s) instead of one (5s).
- No API change; `BackingMongoDBClient` / `BackingMongoDBClientWithOptions` behave the same on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)