### PR TITLE
[RSDK-14371] Expose inbound request transport (native gRPC vs gRPC-Web)

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -15,6 +15,7 @@ const (
 	ctxKeyPeerConnection
 	ctxKeyAuthEntity
 	ctxKeyAuthClaims // all jwt claims
+	ctxKeyRequestTransport
 )
 
 // contextWithHost attaches a host name to the given context.
@@ -85,4 +86,28 @@ func MustContextAuthEntity(ctx context.Context) EntityInfo {
 		panic(errors.New("no auth entity present"))
 	}
 	return authEntity
+}
+
+// RequestTransport identifies the transport an inbound RPC used to reach the server.
+type RequestTransport string
+
+const (
+	// RequestTransportGRPC is a native (HTTP/2) gRPC request.
+	RequestTransportGRPC RequestTransport = "grpc"
+	// RequestTransportGRPCWeb is a gRPC-Web request (the only transport browsers can use).
+	RequestTransportGRPCWeb RequestTransport = "grpc_web"
+)
+
+// ContextWithRequestTransport attaches the transport an inbound request used to the given
+// context. The server sets it while routing a request to its gRPC or gRPC-Web handler (and via
+// an interceptor for requests on the raw gRPC listener).
+func ContextWithRequestTransport(ctx context.Context, rt RequestTransport) context.Context {
+	return context.WithValue(ctx, ctxKeyRequestTransport, rt)
+}
+
+// ContextRequestTransport reports the transport an inbound RPC used (native gRPC vs
+// gRPC-Web), when the server recorded it. A browser can only issue gRPC-Web.
+func ContextRequestTransport(ctx context.Context) (RequestTransport, bool) {
+	rt, ok := ctx.Value(ctxKeyRequestTransport).(RequestTransport)
+	return rt, ok
 }

--- a/rpc/context_test.go
+++ b/rpc/context_test.go
@@ -38,3 +38,34 @@ func TestContextPeerConnection(t *testing.T) {
 	test.That(t, ok, test.ShouldBeTrue)
 	test.That(t, pc2, test.ShouldEqual, &pc)
 }
+
+func TestRequestTransportGRPCUnaryInterceptor(t *testing.T) {
+	// No prior stamp (raw gRPC listener) → interceptor marks it native gRPC.
+	var seen RequestTransport
+	capture := func(ctx context.Context, req interface{}) (interface{}, error) {
+		seen, _ = ContextRequestTransport(ctx)
+		return struct{}{}, nil
+	}
+	_, _ = requestTransportGRPCUnaryInterceptor(context.Background(), nil, nil, capture)
+	test.That(t, seen, test.ShouldEqual, RequestTransportGRPC)
+
+	// A prior HTTP-layer stamp (e.g. gRPC-Web from a browser) is preserved.
+	ctx := ContextWithRequestTransport(context.Background(), RequestTransportGRPCWeb)
+	_, _ = requestTransportGRPCUnaryInterceptor(ctx, nil, nil, capture)
+	test.That(t, seen, test.ShouldEqual, RequestTransportGRPCWeb)
+}
+
+func TestContextRequestTransport(t *testing.T) {
+	_, ok := ContextRequestTransport(context.Background())
+	test.That(t, ok, test.ShouldBeFalse)
+
+	ctx := ContextWithRequestTransport(context.Background(), RequestTransportGRPC)
+	rt, ok := ContextRequestTransport(ctx)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, rt, test.ShouldEqual, RequestTransportGRPC)
+
+	ctx = ContextWithRequestTransport(context.Background(), RequestTransportGRPCWeb)
+	rt, ok = ContextRequestTransport(ctx)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, rt, test.ShouldEqual, RequestTransportGRPCWeb)
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -368,6 +368,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 				// server internals. It is logged above for internal diagnosis only.
 				return status.Errorf(codes.Internal, "%v", p)
 			}))),
+		requestTransportGRPCUnaryInterceptor,
 		grpcUnaryServerInterceptor(grpcLogger),
 		unaryServerCodeInterceptor(),
 	)
@@ -404,6 +405,7 @@ func NewServer(logger utils.ZapCompatibleLogger, opts ...ServerOption) (Server, 
 				// server internals. It is logged above for internal diagnosis only.
 				return status.Errorf(codes.Internal, "%v", p)
 			}))),
+		requestTransportGRPCStreamInterceptor,
 		grpcStreamServerInterceptor(grpcLogger),
 		streamServerCodeInterceptor(),
 	)
@@ -787,6 +789,12 @@ func (ss *simpleServer) getRequestType(r *http.Request) requestType {
 	return requestTypeNone
 }
 
+// withRequestTransport annotates the request's context with the transport it arrived on,
+// so downstream RPC handlers can read it via ContextRequestTransport.
+func withRequestTransport(r *http.Request, rt RequestTransport) *http.Request {
+	return r.WithContext(ContextWithRequestTransport(r.Context(), rt))
+}
+
 func requestWithHost(r *http.Request) *http.Request {
 	if r.Host == "" {
 		return r
@@ -806,9 +814,9 @@ func (ss *simpleServer) GRPCHandler() http.Handler {
 		r = requestWithHost(r)
 		switch ss.getRequestType(r) {
 		case requestTypeGRPC:
-			ss.grpcServer.ServeHTTP(w, r)
+			ss.grpcServer.ServeHTTP(w, withRequestTransport(r, RequestTransportGRPC))
 		case requestTypeGRPCWeb:
-			ss.grpcWebServer.ServeHTTP(w, r)
+			ss.grpcWebServer.ServeHTTP(w, withRequestTransport(r, RequestTransportGRPCWeb))
 		case requestTypeNone:
 			fallthrough
 		default:
@@ -829,11 +837,11 @@ func (ss *simpleServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch ss.getRequestType(r) {
 	case requestTypeGRPC:
 		ss.counters.TCPGrpcRequestsStarted.Add(1)
-		ss.grpcServer.ServeHTTP(w, r)
+		ss.grpcServer.ServeHTTP(w, withRequestTransport(r, RequestTransportGRPC))
 		ss.counters.TCPGrpcRequestsCompleted.Add(1)
 	case requestTypeGRPCWeb:
 		ss.counters.TCPGrpcWebRequestsStarted.Add(1)
-		ss.grpcWebServer.ServeHTTP(w, r)
+		ss.grpcWebServer.ServeHTTP(w, withRequestTransport(r, RequestTransportGRPCWeb))
 		ss.counters.TCPGrpcWebRequestsCompleted.Add(1)
 	case requestTypeNone:
 		fallthrough

--- a/rpc/server_interceptors.go
+++ b/rpc/server_interceptors.go
@@ -169,3 +169,27 @@ func serverCallFields(ctx context.Context, fullMethodString string) []any {
 		"grpc.method", method,
 	}...)
 }
+
+// requestTransportGRPCUnaryInterceptor stamps a request as native gRPC when it isn't stamped yet.
+// The HTTP server stamps each request as gRPC or gRPC-Web as it routes it to the gRPC server or
+// the gRPC-Web server, so a request that arrives here unstamped instead came in directly over the
+// raw gRPC listener, which only carries native gRPC.
+func requestTransportGRPCUnaryInterceptor(
+	ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+) (interface{}, error) {
+	if _, ok := ContextRequestTransport(ctx); !ok {
+		ctx = ContextWithRequestTransport(ctx, RequestTransportGRPC)
+	}
+	return handler(ctx, req)
+}
+
+// requestTransportGRPCStreamInterceptor is the streaming counterpart of
+// requestTransportGRPCUnaryInterceptor.
+func requestTransportGRPCStreamInterceptor(
+	srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
+) error {
+	if _, ok := ContextRequestTransport(ss.Context()); !ok {
+		ss = wrapServerStream(ContextWithRequestTransport(ss.Context(), RequestTransportGRPC), ss)
+	}
+	return handler(srv, ss)
+}


### PR DESCRIPTION
## Description

[RSDK-14371](https://viam.atlassian.net/browse/RSDK-14371) TS relay-only isolation dial-options test hangs indefinitely (no TURN relay candidate gathered)

Exposes the transport an inbound RPC used (native `gRPC` vs `gRPC-Web`) via a new `ContextRequestTransport(ctx) (RequestTransport, bool)`. A consumer needs to tell a browser client (`gRPC-Web`) apart from a native-gRPC client (e.g. the TypeScript SDK running in Node). Browsers can only use `gRPC-Web`, hence why this distinction works. 

## Why
Our signaling server will use this to apply a Node-only TURN-credential workaround (since Node will fudge a coturn URI that has a username) to preserve per-org attribution for everyone else — see viamrobotics/app#13088.

## How
A gRPC request can reach the server two ways:

**1. Through the HTTP server**: The request arrives as an `*http.Request`, and `getRequestType` inspects it and routes it. Native `gRPC` to the `gRPC` server, `gRPC-Web` to the `gRPC-Web` server. While routing, it now also stamps the transport onto the request context.

**2. Directly on the raw gRPC listener**: These calls skip the HTTP server entirely, so nothing stamps them. So if a request reaches it unstamped, it must have come in on the raw listener, and is therefore native `gRPC`. A new unary + stream interceptor stamps it as such.

Both are needed: the HTTP server is the only thing that can tell `gRPC-Web` apart from native `gRPC`, and the interceptor is the only thing that catches native `gRPC` that bypassed the HTTP server. `appmain` fronts gRPC with a reverse proxy that routes the native`gRPC` content-type straight to the raw listener, so without the interceptor `ContextRequestTransport` reads empty in the Cloud Run env.

## Testing
- Node TS SDK established a successful relay connection through our coturn server using staging PR signaling server with these changes in viamrobotics/app#13088.
- Validated in PR env that a Node forceRelay dial now receives the colon-free username and the TURN Allocate succeeds. Browser (gRPC-Web) requests still get the :orgID username.


[RSDK-14371]: https://viam.atlassian.net/browse/RSDK-14371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ