### PR TITLE
Add OpenCensus collector exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require go.viam.com/api v0.1.493
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1
+	contrib.go.opencensus.io/exporter/ocagent v0.7.0
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/googleapis/gax-go/v2 v2.13.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ cloud.google.com/go/trace v1.11.0 h1:UHX6cOJm45Zw/KIbqHe4kII8PupLt/V5tscZUkeiJVI
 cloud.google.com/go/trace v1.11.0/go.mod h1:Aiemdi52635dBR7o3zuc9lLjXo3BwGaChEjCa3tJNmM=
 contrib.go.opencensus.io/exporter/jaeger v0.2.1 h1:yGBYzYMewVL0yO9qqJv3Z5+IRhPdU7e9o/2oKpX4YvI=
 contrib.go.opencensus.io/exporter/jaeger v0.2.1/go.mod h1:Y8IsLgdxqh1QxYxPC5IgXVmBaeLUeQFfBeBi9PbeZd0=
+contrib.go.opencensus.io/exporter/ocagent v0.7.0 h1:BEfdCTXfMV30tLZD8c9n64V/tIZX5+9sXiuFLnrr1k8=
+contrib.go.opencensus.io/exporter/ocagent v0.7.0/go.mod h1:IshRmMJBhDfFj5Y67nVhMYTTIze91RUeT73ipWKs/GY=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4 h1:ksUxwH3OD5sxkjzEqGxNTl+Xjsmu3BnC/300MhSVTSc=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -55,6 +57,7 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.36.30 h1:hAwyfe7eZa7sM+S5mIJZFiNFwJMia9Whz6CYblioLoU=
 github.com/aws/aws-sdk-go v1.36.30/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
@@ -106,6 +109,7 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
@@ -170,6 +174,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
@@ -220,6 +225,7 @@ github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvK
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
+github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 h1:8Tjv8EJ+pM1xP8mK6egEbD1OgnVTyacbefKhmbLhIhU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2/go.mod h1:pkJQ2tZHJ0aFOVEEot6oZmaVEZcRme73eIFmhiVuRWs=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -351,6 +357,7 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
@@ -516,6 +523,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -523,6 +531,7 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -580,6 +589,7 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -693,6 +703,7 @@ google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
+google.golang.org/api v0.25.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/api v0.196.0 h1:k/RafYqebaIJBO3+SMnfEGtFVlvp5vSgqTUF54UN/zg=
 google.golang.org/api v0.196.0/go.mod h1:g9IL21uGkYgvQ5BZg6BAtoGJQIm8r6EgaAbpNey5wBE=
@@ -721,7 +732,9 @@ google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
+google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20240903143218-8af14fe29dc1 h1:BulPr26Jqjnd4eYDVe+YvyR7Yc2vJGkO5/0UxD0/jZU=
 google.golang.org/genproto v0.0.0-20240903143218-8af14fe29dc1/go.mod h1:hL97c3SYopEHblzpxRL4lSs523++l8DYxGM1FQiYmb4=
 google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
@@ -750,6 +763,7 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
@@ -762,6 +776,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/perf/exporters.go
+++ b/perf/exporters.go
@@ -133,20 +133,26 @@ func NewCloudExporter(opts CloudOptions) (Exporter, error) {
 		sdExporter: sd,
 	}
 
-	if byNamePerSec := envOpts.SamplingByNamePerSec; byNamePerSec != 0 {
-		opts.Logger.Infow("Using root name rate limiting sampler for tracing",
-			"samplePerSec", byNamePerSec)
-		e.sampler = NewRootNameRateLimitingSampler(byNamePerSec)
-	} else if prob := envOpts.SamplingProbability; prob != 0 {
-		opts.Logger.Infow("Using probability sampler for tracing",
-			"probability", prob)
-		e.sampler = trace.ProbabilitySampler(prob)
-	} else {
-		opts.Logger.Info("No sampling config found; sampling all traces by default")
-		e.sampler = trace.AlwaysSample()
-	}
+	e.sampler = samplerFromEnvOpts(envOpts.SamplingByNamePerSec, envOpts.SamplingProbability, opts.Logger)
 
 	return &e, nil
+}
+
+// samplerFromEnvOpts picks the trace sampler from the OC_SAMPLING_BY_NAME_PER_SEC and
+// OC_SAMPLING_PROB env values shared by the cloud and opencensus agent exporters.
+func samplerFromEnvOpts(byNamePerSec, prob float64, logger utils.ZapCompatibleLogger) trace.Sampler {
+	if byNamePerSec != 0 {
+		logger.Infow("Using root name rate limiting sampler for tracing",
+			"samplePerSec", byNamePerSec)
+		return NewRootNameRateLimitingSampler(byNamePerSec)
+	}
+	if prob != 0 {
+		logger.Infow("Using probability sampler for tracing",
+			"probability", prob)
+		return trace.ProbabilitySampler(prob)
+	}
+	logger.Info("No sampling config found; sampling all traces by default")
+	return trace.AlwaysSample()
 }
 
 type sdExporter struct {

--- a/perf/ocagent_exporter.go
+++ b/perf/ocagent_exporter.go
@@ -1,0 +1,108 @@
+package perf
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/ocagent"
+	"github.com/caarlos0/env/v11"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
+
+	"go.viam.com/utils"
+)
+
+// OCAgentExporter exports traces and metrics over gRPC to an OpenCensus
+// agent/collector. The OpenTelemetry Collector accepts the same protocol via
+// its "opencensus" receiver.
+type OCAgentExporter struct {
+	e       *ocagent.Exporter
+	sampler trace.Sampler
+}
+
+var _ Exporter = &OCAgentExporter{}
+
+// OCAgentOptions is used to configure [OCAgentExporter].
+type OCAgentOptions struct {
+	Logger utils.ZapCompatibleLogger
+	// Address is the "host:port" of the collector. If empty, OC_AGENT_ADDRESS
+	// is used instead.
+	Address string
+}
+
+// NewOCAgentExporter creates a new OpenCensus agent/collector [Exporter],
+// configured from the environment:
+//
+//	OC_AGENT_ADDRESS             collector "host:port" (used when OCAgentOptions.Address is empty)
+//	OC_AGENT_INSECURE            dial without TLS (default true)
+//	OC_AGENT_RECONNECTION_PERIOD retry interval for reconnecting to the collector
+//	OC_SAMPLING_BY_NAME_PER_SEC  same sampling behavior as the cloud exporter
+//	OC_SAMPLING_PROB             same sampling behavior as the cloud exporter
+//	SERVICE_NAME                 service name reported with spans
+func NewOCAgentExporter(opts OCAgentOptions) (*OCAgentExporter, error) {
+	envOpts, err := env.ParseAs[struct {
+		Address              string        `env:"OC_AGENT_ADDRESS"`
+		Insecure             bool          `env:"OC_AGENT_INSECURE"            envDefault:"true"`
+		ReconnectionPeriod   time.Duration `env:"OC_AGENT_RECONNECTION_PERIOD"`
+		SamplingByNamePerSec float64       `env:"OC_SAMPLING_BY_NAME_PER_SEC"  envDefault:"0"`
+		SamplingProbability  float64       `env:"OC_SAMPLING_PROB"             envDefault:"1"`
+	}]()
+	if err != nil {
+		opts.Logger.Errorf("failed to parse opencensus agent exporter options from env, will use defaults: %v", err)
+		envOpts.Insecure = true
+		envOpts.SamplingProbability = 1
+	}
+
+	address := opts.Address
+	if address == "" {
+		address = envOpts.Address
+	}
+	if address == "" {
+		return nil, errors.New("must specify collector address via OCAgentOptions.Address or OC_AGENT_ADDRESS")
+	}
+
+	ocOpts := []ocagent.ExporterOption{ocagent.WithAddress(address)}
+	if envOpts.Insecure {
+		ocOpts = append(ocOpts, ocagent.WithInsecure())
+	}
+	if envOpts.ReconnectionPeriod > 0 {
+		ocOpts = append(ocOpts, ocagent.WithReconnectionPeriod(envOpts.ReconnectionPeriod))
+	}
+	if serviceName := os.Getenv("SERVICE_NAME"); serviceName != "" {
+		ocOpts = append(ocOpts, ocagent.WithServiceName(serviceName))
+	}
+
+	exp, err := ocagent.NewUnstartedExporter(ocOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &OCAgentExporter{
+		e:       exp,
+		sampler: samplerFromEnvOpts(envOpts.SamplingByNamePerSec, envOpts.SamplingProbability, opts.Logger),
+	}, nil
+}
+
+// Start implements [Exporter]. Registers views and starts trace/metric
+// exporting to the collector.
+func (o *OCAgentExporter) Start() error {
+	if err := registerApplicationViews(); err != nil {
+		return err
+	}
+	if err := o.e.Start(); err != nil {
+		return err
+	}
+	view.RegisterExporter(o.e)
+	trace.RegisterExporter(o.e)
+	trace.ApplyConfig(trace.Config{DefaultSampler: o.sampler})
+	return nil
+}
+
+// Stop implements [Exporter]. Flushes any pending spans/metrics and closes the
+// connection to the collector.
+func (o *OCAgentExporter) Stop() {
+	trace.UnregisterExporter(o.e)
+	view.UnregisterExporter(o.e)
+	o.e.Flush()
+	utils.UncheckedError(o.e.Stop())
+}

--- a/perf/ocagent_exporter.go
+++ b/perf/ocagent_exporter.go
@@ -46,6 +46,8 @@ func NewOCAgentExporter(opts OCAgentOptions) (*OCAgentExporter, error) {
 		ReconnectionPeriod   time.Duration `env:"OC_AGENT_RECONNECTION_PERIOD"`
 		SamplingByNamePerSec float64       `env:"OC_SAMPLING_BY_NAME_PER_SEC"  envDefault:"0"`
 		SamplingProbability  float64       `env:"OC_SAMPLING_PROB"             envDefault:"1"`
+		KService             string        `env:"K_SERVICE"`
+		GAEService           string        `env:"GAE_SERVICE"`
 		ServiceName          string        `env:"SERVICE_NAME"`
 	}]()
 	if err != nil {
@@ -69,8 +71,11 @@ func NewOCAgentExporter(opts OCAgentOptions) (*OCAgentExporter, error) {
 	if envOpts.ReconnectionPeriod > 0 {
 		ocOpts = append(ocOpts, ocagent.WithReconnectionPeriod(envOpts.ReconnectionPeriod))
 	}
-	if envOpts.ServiceName != "" {
-		ocOpts = append(ocOpts, ocagent.WithServiceName(envOpts.ServiceName))
+	for _, serviceName := range []string{envOpts.KService, envOpts.GAEService, envOpts.ServiceName} {
+		if serviceName != "" {
+			ocOpts = append(ocOpts, ocagent.WithServiceName(serviceName))
+			break
+		}
 	}
 
 	exp, err := ocagent.NewUnstartedExporter(ocOpts...)

--- a/perf/ocagent_exporter.go
+++ b/perf/ocagent_exporter.go
@@ -2,7 +2,6 @@ package perf
 
 import (
 	"errors"
-	"os"
 	"time"
 
 	"contrib.go.opencensus.io/exporter/ocagent"
@@ -47,6 +46,7 @@ func NewOCAgentExporter(opts OCAgentOptions) (*OCAgentExporter, error) {
 		ReconnectionPeriod   time.Duration `env:"OC_AGENT_RECONNECTION_PERIOD"`
 		SamplingByNamePerSec float64       `env:"OC_SAMPLING_BY_NAME_PER_SEC"  envDefault:"0"`
 		SamplingProbability  float64       `env:"OC_SAMPLING_PROB"             envDefault:"1"`
+		ServiceName          string        `env:"SERVICE_NAME"`
 	}]()
 	if err != nil {
 		opts.Logger.Errorf("failed to parse opencensus agent exporter options from env, will use defaults: %v", err)
@@ -69,8 +69,8 @@ func NewOCAgentExporter(opts OCAgentOptions) (*OCAgentExporter, error) {
 	if envOpts.ReconnectionPeriod > 0 {
 		ocOpts = append(ocOpts, ocagent.WithReconnectionPeriod(envOpts.ReconnectionPeriod))
 	}
-	if serviceName := os.Getenv("SERVICE_NAME"); serviceName != "" {
-		ocOpts = append(ocOpts, ocagent.WithServiceName(serviceName))
+	if envOpts.ServiceName != "" {
+		ocOpts = append(ocOpts, ocagent.WithServiceName(envOpts.ServiceName))
 	}
 
 	exp, err := ocagent.NewUnstartedExporter(ocOpts...)

--- a/perf/ocagent_exporter_test.go
+++ b/perf/ocagent_exporter_test.go
@@ -1,0 +1,30 @@
+package perf
+
+import (
+	"testing"
+
+	"github.com/edaniels/golog"
+	"go.viam.com/test"
+)
+
+func TestNewOCAgentExporterRequiresAddress(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	_, err := NewOCAgentExporter(OCAgentOptions{Logger: logger})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "OC_AGENT_ADDRESS")
+}
+
+func TestNewOCAgentExporterAddressFromEnv(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	t.Setenv("OC_AGENT_ADDRESS", "localhost:55678")
+	exp, err := NewOCAgentExporter(OCAgentOptions{Logger: logger})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, exp, test.ShouldNotBeNil)
+}
+
+func TestNewOCAgentExporterAddressFromOptions(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	exp, err := NewOCAgentExporter(OCAgentOptions{Logger: logger, Address: "localhost:55678"})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, exp, test.ShouldNotBeNil)
+}


### PR DESCRIPTION
This adds the `ocagent` go library, which provides support for exporting trace data to an OpenCensus agent. This will be used to send trace data to an OpenTelemetry collector configured to receive OpenCensus agent messages