### PR TITLE
APP-17548 - rpc: identify the client SDK from one shared parser

### DIFF
--- a/rpc/sdk_info.go
+++ b/rpc/sdk_info.go
@@ -84,12 +84,16 @@ func SDKInfoFromCtx(ctx context.Context) SDKInfo {
 		}
 	}
 
+	// A version reported alongside an unrecognized SDK belongs to that SDK, not to the one the
+	// fallback infers, so it is dropped. Raw still carries it.
 	if vals := md.Get(XGRPCWebMetadataField); len(vals) > 0 && vals[0] == "1" {
 		info.Type = SDKTypeTypeScript
+		info.Version = ""
 		return info
 	}
 	if vals := md.Get(UserAgentMetadataField); len(vals) > 0 && strings.Contains(vals[0], "tonic/") {
 		info.Type = SDKTypePythonOrCPP
+		info.Version = ""
 	}
 	return info
 }

--- a/rpc/sdk_info.go
+++ b/rpc/sdk_info.go
@@ -1,0 +1,125 @@
+package rpc
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// SDK types reported by Viam SDKs in the viam_client metadata field.
+const (
+	SDKTypeGo         = "go"
+	SDKTypeTypeScript = "typescript"
+	SDKTypePython     = "python"
+
+	// SDKTypePythonOrCPP is reported when a tonic user agent is the only signal available.
+	// Python and C++ both signal through viam-rust-utils, so at that point they cannot be
+	// told apart.
+	SDKTypePythonOrCPP = "python/c++"
+)
+
+// maxSDKRawLen bounds the client-supplied viam_client value before it is logged or stored.
+const maxSDKRawLen = 128
+
+// Recognized values. Anything else is dropped rather than labeled, so that a client cannot
+// inflate the cardinality of metrics derived from SDKInfo.Label.
+var (
+	knownSDKTypes = map[string]bool{
+		SDKTypeGo:         true,
+		SDKTypeTypeScript: true,
+		SDKTypePython:     true,
+	}
+	knownSDKSources = map[string]bool{
+		"viam-app": true,
+	}
+)
+
+// SDKInfo identifies the client SDK behind a request.
+type SDKInfo struct {
+	// Type is the bounded SDK identifier, empty when the SDK could not be determined.
+	Type string
+
+	// Source is the bounded embedder wrapping the SDK, e.g. "viam-app". Empty when the client
+	// reported none or reported one that is not recognized.
+	Source string
+
+	Version string
+
+	// Raw is the reported viam_client value, truncated to maxSDKRawLen and set only when it was
+	// not fully understood — an unrecognized SDK or an unlisted source. It is how a new SDK or
+	// embedder gets noticed: safe to log or store, never to use as a metric label.
+	Raw string
+}
+
+// Label renders the SDK as a bounded metric label, qualified by source when one was
+// recognized, e.g. "typescript(viam-app)". It returns "" when the SDK is unknown so that
+// callers can apply their own sentinel.
+func (i SDKInfo) Label() string {
+	if i.Type == "" {
+		return ""
+	}
+	if i.Source == "" {
+		return i.Type
+	}
+	return i.Type + "(" + i.Source + ")"
+}
+
+// SDKInfoFromCtx determines which SDK issued the request described by ctx.
+//
+// A recognized viam_client value wins. The x-grpc-web and user-agent fallbacks cover clients
+// that do not send one: SDK releases predating viam_client, and the Python and C++ SDKs, whose
+// signaling is performed by viam-rust-utils rather than by the SDK itself.
+func SDKInfoFromCtx(ctx context.Context) SDKInfo {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return SDKInfo{}
+	}
+
+	var info SDKInfo
+	if vals := md.Get(ViamClientMetadataField); len(vals) > 0 && vals[0] != "" {
+		info = parseViamClient(vals[0])
+		if info.Type != "" {
+			return info
+		}
+	}
+
+	if vals := md.Get(XGRPCWebMetadataField); len(vals) > 0 && vals[0] == "1" {
+		info.Type = SDKTypeTypeScript
+		return info
+	}
+	if vals := md.Get(UserAgentMetadataField); len(vals) > 0 && strings.Contains(vals[0], "tonic/") {
+		info.Type = SDKTypePythonOrCPP
+	}
+	return info
+}
+
+// parseViamClient parses a "[type];[version];[apiVersion]" viam_client value, whose type may
+// carry a source qualifier as in "typescript(viam-app)".
+func parseViamClient(raw string) SDKInfo {
+	var info SDKInfo
+	sdkField, rest, _ := strings.Cut(raw, ";")
+	info.Version, _, _ = strings.Cut(rest, ";")
+
+	base, source, hasSource := strings.Cut(strings.ToLower(strings.TrimSpace(sdkField)), "(")
+	if knownSDKTypes[base] {
+		info.Type = base
+
+		// Only meaningful against a recognized SDK. Keeping it otherwise would let a fallback
+		// stamp its own Type onto someone else's source, e.g. "rust(viam-app)" over gRPC-Web
+		// labeling as "typescript(viam-app)".
+		if hasSource {
+			if source = strings.TrimSuffix(source, ")"); knownSDKSources[source] {
+				info.Source = source
+			}
+		}
+	}
+
+	if info.Type == "" || (hasSource && info.Source == "") {
+		info.Raw = raw
+		if len(info.Raw) > maxSDKRawLen {
+			info.Raw = strings.ToValidUTF8(info.Raw[:maxSDKRawLen], "")
+		}
+	}
+	return info
+}

--- a/rpc/sdk_info.go
+++ b/rpc/sdk_info.go
@@ -109,9 +109,9 @@ func parseViamClient(raw string) SDKInfo {
 	if knownSDKTypes[base] {
 		info.Type = base
 
-		// Only meaningful against a recognized SDK. Keeping it otherwise would let a fallback
-		// stamp its own Type onto someone else's source, e.g. "rust(viam-app)" over gRPC-Web
-		// labeling as "typescript(viam-app)".
+		// Gated on a recognized SDK: otherwise Type stays empty, SDKInfoFromCtx falls back to
+		// inferring it, and the label would pair that inferred type with a source the client
+		// attached to a different one.
 		if hasSource {
 			if source = strings.TrimSuffix(source, ")"); knownSDKSources[source] {
 				info.Source = source

--- a/rpc/sdk_info_test.go
+++ b/rpc/sdk_info_test.go
@@ -75,14 +75,24 @@ func TestSDKInfoFromCtx(t *testing.T) {
 		},
 		{
 			// The fallback classifies the client, but the unrecognized value is still surfaced:
-			// a new TypeScript-based SDK would otherwise be labeled and never noticed.
+			// a new TypeScript-based SDK would otherwise be labeled and never noticed. The
+			// version went with the SDK the client claimed, so only Raw keeps it.
 			name: "falls back to x-grpc-web when viam_client is unrecognized",
 			md: map[string]string{
 				ViamClientMetadataField: "rust;v1.2.3;v0.1.0",
 				XGRPCWebMetadataField:   "1",
 			},
-			expected: SDKInfo{Type: SDKTypeTypeScript, Version: "v1.2.3", Raw: "rust;v1.2.3;v0.1.0"},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Raw: "rust;v1.2.3;v0.1.0"},
 			label:    "typescript",
+		},
+		{
+			name: "falls back to tonic when viam_client is unrecognized",
+			md: map[string]string{
+				ViamClientMetadataField: "rust;v1.2.3;v0.1.0",
+				UserAgentMetadataField:  "tonic/0.12.3",
+			},
+			expected: SDKInfo{Type: SDKTypePythonOrCPP, Raw: "rust;v1.2.3;v0.1.0"},
+			label:    "python/c++",
 		},
 		{
 			// The source belongs to the SDK the client claimed, not to the one the fallback
@@ -92,7 +102,7 @@ func TestSDKInfoFromCtx(t *testing.T) {
 				ViamClientMetadataField: "rust(viam-app);v1.2.3;v0.1.0",
 				XGRPCWebMetadataField:   "1",
 			},
-			expected: SDKInfo{Type: SDKTypeTypeScript, Version: "v1.2.3", Raw: "rust(viam-app);v1.2.3;v0.1.0"},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Raw: "rust(viam-app);v1.2.3;v0.1.0"},
 			label:    "typescript",
 		},
 		{

--- a/rpc/sdk_info_test.go
+++ b/rpc/sdk_info_test.go
@@ -1,0 +1,147 @@
+package rpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.viam.com/test"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestSDKInfoFromCtx(t *testing.T) {
+	longSource := strings.Repeat("a", 200)
+
+	for _, tc := range []struct {
+		name     string
+		md       map[string]string
+		expected SDKInfo
+		label    string
+	}{
+		{
+			name:     "typescript with known source",
+			md:       map[string]string{ViamClientMetadataField: "typescript(viam-app);v0.74.2;v0.1.573"},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Source: "viam-app", Version: "v0.74.2"},
+			label:    "typescript(viam-app)",
+		},
+		{
+			name:     "go",
+			md:       map[string]string{ViamClientMetadataField: "go;v0.1.2;v0.3.4"},
+			expected: SDKInfo{Type: SDKTypeGo, Version: "v0.1.2"},
+			label:    "go",
+		},
+		{
+			name:     "python",
+			md:       map[string]string{ViamClientMetadataField: "python;v1.2.3;v0.1.0"},
+			expected: SDKInfo{Type: SDKTypePython, Version: "v1.2.3"},
+			label:    "python",
+		},
+		{
+			name:     "type only",
+			md:       map[string]string{ViamClientMetadataField: "go"},
+			expected: SDKInfo{Type: SDKTypeGo},
+			label:    "go",
+		},
+		{
+			name:     "type is case insensitive",
+			md:       map[string]string{ViamClientMetadataField: "TypeScript;v1.2.3;v0.1.0"},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Version: "v1.2.3"},
+			label:    "typescript",
+		},
+		{
+			// An unrecognized source is dropped rather than labeled, but the raw value is kept
+			// so the unrecognized embedder is still discoverable.
+			name:     "unknown source drops to bare SDK",
+			md:       map[string]string{ViamClientMetadataField: "typescript(bogus);v1.2.3;v0.1.0"},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Version: "v1.2.3", Raw: "typescript(bogus);v1.2.3;v0.1.0"},
+			label:    "typescript",
+		},
+		{
+			name:     "unknown SDK keeps raw",
+			md:       map[string]string{ViamClientMetadataField: "rust;v1.2.3;v0.1.0"},
+			expected: SDKInfo{Version: "v1.2.3", Raw: "rust;v1.2.3;v0.1.0"},
+			label:    "",
+		},
+		{
+			// Regression: viam_client used to shadow the x-grpc-web fallback entirely, so every
+			// TypeScript client reported as unknown once the SDK began sending viam_client.
+			name: "viam_client wins over x-grpc-web",
+			md: map[string]string{
+				ViamClientMetadataField: "typescript(viam-app);v0.74.2;v0.1.573",
+				XGRPCWebMetadataField:   "1",
+			},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Source: "viam-app", Version: "v0.74.2"},
+			label:    "typescript(viam-app)",
+		},
+		{
+			// The fallback classifies the client, but the unrecognized value is still surfaced:
+			// a new TypeScript-based SDK would otherwise be labeled and never noticed.
+			name: "falls back to x-grpc-web when viam_client is unrecognized",
+			md: map[string]string{
+				ViamClientMetadataField: "rust;v1.2.3;v0.1.0",
+				XGRPCWebMetadataField:   "1",
+			},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Version: "v1.2.3", Raw: "rust;v1.2.3;v0.1.0"},
+			label:    "typescript",
+		},
+		{
+			// The source belongs to the SDK the client claimed, not to the one the fallback
+			// inferred, so it must not survive into the label.
+			name: "fallback does not adopt a source from an unrecognized SDK",
+			md: map[string]string{
+				ViamClientMetadataField: "rust(viam-app);v1.2.3;v0.1.0",
+				XGRPCWebMetadataField:   "1",
+			},
+			expected: SDKInfo{Type: SDKTypeTypeScript, Version: "v1.2.3", Raw: "rust(viam-app);v1.2.3;v0.1.0"},
+			label:    "typescript",
+		},
+		{
+			name:     "x-grpc-web alone",
+			md:       map[string]string{XGRPCWebMetadataField: "1"},
+			expected: SDKInfo{Type: SDKTypeTypeScript},
+			label:    "typescript",
+		},
+		{
+			name:     "tonic user agent alone",
+			md:       map[string]string{UserAgentMetadataField: "tonic/0.12.3"},
+			expected: SDKInfo{Type: SDKTypePythonOrCPP},
+			label:    "python/c++",
+		},
+		{
+			name:     "unrecognized user agent",
+			md:       map[string]string{UserAgentMetadataField: "grpc-go/1.65.0"},
+			expected: SDKInfo{},
+			label:    "",
+		},
+		{
+			name:     "empty metadata",
+			md:       map[string]string{},
+			expected: SDKInfo{},
+			label:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(context.Background(), metadata.New(tc.md))
+			info := SDKInfoFromCtx(ctx)
+			test.That(t, info, test.ShouldResemble, tc.expected)
+			test.That(t, info.Label(), test.ShouldEqual, tc.label)
+		})
+	}
+
+	t.Run("no incoming metadata", func(t *testing.T) {
+		info := SDKInfoFromCtx(context.Background())
+		test.That(t, info, test.ShouldResemble, SDKInfo{})
+		test.That(t, info.Label(), test.ShouldEqual, "")
+	})
+
+	t.Run("raw is truncated", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+			ViamClientMetadataField: "typescript(" + longSource + ");v1.2.3;v0.1.0",
+		}))
+		info := SDKInfoFromCtx(ctx)
+		test.That(t, len(info.Raw), test.ShouldEqual, maxSDKRawLen)
+		test.That(t, info.Type, test.ShouldEqual, SDKTypeTypeScript)
+		test.That(t, info.Source, test.ShouldEqual, "")
+		test.That(t, info.Label(), test.ShouldEqual, "typescript")
+	})
+}

--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -1186,30 +1186,12 @@ func (queue *mongoDBWebRTCCallQueue) SendOfferInit(
 	defer span.End()
 
 	sdkType, organizationID := "unknown", "unknown"
-	if md, exists := metadata.FromIncomingContext(ctx); exists {
-		// TODO(RSDK-11864): Use actual structured metadata provided by the SDK to determine
-		// SDK type for the TypeScript, Python, and C++ SDKs.
-		//
-		// Hackily guess the SDK type based on a combination of the "viam_client",
-		// "x-grpc-web", and "user-agent" metadata fields. The first only exists for Golang,
-		// the second only exists for TypeScrpt, and the third is "tonic" for both Python and
-		// C++.
-		if viamClientMD, exists := md[ViamClientMetadataField]; exists && len(viamClientMD) > 0 {
-			if strings.Contains(viamClientMD[0], "go;") {
-				sdkType = "go"
-			}
-		} else if xGRPCWebMD, exists := md[XGRPCWebMetadataField]; exists &&
-			len(xGRPCWebMD) > 0 {
-			if xGRPCWebMD[0] == "1" {
-				sdkType = "typescript"
-			}
-		} else if userAgentMD, exists := md[UserAgentMetadataField]; exists &&
-			len(userAgentMD) > 0 {
-			if strings.Contains(userAgentMD[0], "tonic/") {
-				sdkType = "python/c++"
-			}
-		}
+	sdkInfo := SDKInfoFromCtx(ctx)
+	if label := sdkInfo.Label(); label != "" {
+		sdkType = label
+	}
 
+	if md, exists := metadata.FromIncomingContext(ctx); exists {
 		// TODO(RSDK-11875): Use an actual database (or, likely, cache) lookup to determine
 		// the organization ID for this host based on its DNS name.
 		//
@@ -1232,6 +1214,12 @@ func (queue *mongoDBWebRTCCallQueue) SendOfferInit(
 		trace.StringAttribute("sdk_type", sdkType),
 		trace.StringAttribute("organization_id", organizationID),
 	)
+	// Only set when the client reported something we could not fully classify, which is how a
+	// new SDK or embedder gets noticed. Never used as a metric label.
+	if sdkInfo.Raw != "" {
+		span.AddAttributes(trace.StringAttribute("sdk_type_raw", sdkInfo.Raw))
+		queue.logger.Infow("unclassified client SDK", "host", host, "sdk_type_raw", sdkInfo.Raw)
+	}
 
 	// An offer initialization (after verifying the host queue size), indicates an attempted
 	// connection establishment attempt.


### PR DESCRIPTION
## Problem

`SendOfferInit` guessed the client SDK with an `if / else if` chain over `viam_client`, `x-grpc-web`, and `user-agent`. The comment above it stated the premise: *"The first only exists for Golang, the second only exists for TypeScrpt"*.

That stopped being true in Jan 2026, when the TypeScript SDK began sending `viam_client` ([viam-typescript-sdk#710](https://github.com/viamrobotics/viam-typescript-sdk/pull/710), RSDK-12734). TS now sends **both** headers, so it enters the first branch, fails `strings.Contains(v, "go;")`, and falls out with `sdkType` still at its initialized `"unknown"` — the `x-grpc-web` fallback meant to catch it is unreachable.

Every TypeScript client has recorded as `unknown` since. That value feeds `signaling/connection_establishment_attempts`, `connection_establishment_expected_failures`, `connection_establishment_failures`, `call_exchange_duration`, the `sdk_type` span attribute, and the `sdk_type` field persisted on `rpc.calls` docs (which is re-read as a metric label later in the exchange).

## Change

New `rpc/sdk_info.go`, resolving the `TODO(RSDK-11864)` that sat on the old code:

- `SDKInfo{Type, Source, Version, Raw}`, `SDKInfoFromCtx`, and `Label()`.
- **Sequential fallbacks** instead of exclusive branches, so an unrecognized `viam_client` no longer shadows `x-grpc-web` / `user-agent`.
- **Allowlists** for both the SDK type and the embedder source. Both are client-supplied and reach metric labels, so anything unrecognized is dropped rather than labeled.
- A source qualifier (`typescript(viam-app)`) is only read when the SDK type itself was recognized — otherwise a fallback could stamp its inferred type onto someone else's source, turning `rust(viam-app)` over gRPC-Web into `typescript(viam-app)`.
- `Label()` returns `""` when unknown so each caller keeps its own sentinel (`unknown` here, `unspecified` in app).
- `Raw` retains the reported value, truncated to 128B, **only** when it was not fully understood — an unrecognized SDK or an unlisted source. It is logged and attached to the span, never used as a label.

This is how a new SDK or embedder gets noticed instead of being silently absorbed by a fallback.

## Notes

- The `user-agent: tonic/` branch is **not** legacy cruft — it is the only signal for Python and C++, whose WebRTC signaling is performed by viam-rust-utils rather than by the SDK. `python/c++` stays one value because the two are not separable at that vantage point.
- `Raw` is logged rather than persisted on the call doc: the collection's TTL is short enough that storing it buys little over the log line.
- app consumes this next (APP-17548, [viamrobotics/app#13176](https://github.com/viamrobotics/app/pull/13176)), deleting its own copy of the same parsing.
- rdk holds a third copy (`robot/client/client.go`) plus a stale `"maybe-typescript"` fallback in `robot/web/request_counter.go`, wrong for the same reason. Out of scope here.

## Testing

`rpc/sdk_info_test.go` — 16 cases, including the regression (`viam_client` + `x-grpc-web` together), the source-leak case above, unrecognized type and source both retaining `Raw`, and truncation. `golangci-lint run ./rpc/...` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)