### PR TITLE
APP-17548 - rpc: count attempts whose reported SDK was unclassified

### DIFF
--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -101,6 +101,23 @@ var (
 		},
 	)
 
+	// Filtering the other metrics on sdk_type does not cover this: a client whose viam_client
+	// was unrecognized may still be classified by a fallback, and would then be indistinguishable
+	// from a client that reported that SDK properly.
+	unclassifiedSDKAttempts = statz.NewCounter1[string](
+		"signaling/unclassified_sdk_attempts",
+		statz.MetricConfig{
+			Description: "The total number of connection establishment attempts whose reported viam_client could not be fully classified.",
+			Unit:        units.Dimensionless,
+			Labels: []statz.Label{
+				{
+					Name:        "sdk_type",
+					Description: "The SDK type settled on, which may have come from a fallback rather than from what the client reported.",
+				},
+			},
+		},
+	)
+
 	connectionEstablishmentFailures = statz.NewCounter3[string, string, string](
 		"signaling/connection_establishment_failures",
 		statz.MetricConfig{
@@ -1218,6 +1235,7 @@ func (queue *mongoDBWebRTCCallQueue) SendOfferInit(
 	// new SDK or embedder gets noticed. Never used as a metric label.
 	if sdkInfo.Raw != "" {
 		span.AddAttributes(trace.StringAttribute("sdk_type_raw", sdkInfo.Raw))
+		unclassifiedSDKAttempts.Inc(sdkType)
 		queue.logger.Infow("unclassified client SDK", "host", host, "sdk_type_raw", sdkInfo.Raw)
 	}
 


### PR DESCRIPTION
Follow-up to #596.

## Why a dedicated counter

#596 logs the raw `viam_client` value when it can't be fully classified, which makes a new SDK or embedder **discoverable** but not **alertable**.

Filtering the existing metrics on `sdk_type` isn't equivalent, because of the fallback path: a client whose `viam_client` is unrecognized can still be classified from `x-grpc-web` or `user-agent`. It then records as `typescript` or `python/c++` and is indistinguishable from a client that reported that SDK properly. Those are exactly the cases most worth noticing — a new TypeScript-based SDK or embedder would otherwise be absorbed into the existing series with no signal at all.

So the counter fires on the same condition as the log (`SDKInfo.Raw != ""`), labeled by the type we settled on:

```go
if sdkInfo.Raw != "" {
    span.AddAttributes(trace.StringAttribute("sdk_type_raw", sdkInfo.Raw))
    unclassifiedSDKAttempts.Inc(sdkType)
    queue.logger.Infow("unclassified client SDK", "host", host, "sdk_type_raw", sdkInfo.Raw)
}
```

`unclassified_sdk_attempts{sdk_type="unknown"}` is the client we couldn't place at all; `{sdk_type="typescript"}` is the one a fallback rescued but whose self-report we didn't understand. The raw value itself stays out of the label — it's client-supplied, so it belongs in the log and the span only.

## Placement

`SendOfferInit` is the only signaling path that sees every dialing client, which is why the counter goes here rather than app-side. app's `ReportConnectionMetadata` is reached only by the goutils Go dialer, whose `viam_client` always parses, so an equivalent counter there would sit at zero.

## Testing

`go build`, `golangci-lint run ./rpc/...` → 0 issues. No behaviour change beyond the new counter; existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)