### PR TITLE
Replace stale operator document on call queue startup instead of failing

### DIFF
--- a/rpc/wrtc_call_queue_mongodb.go
+++ b/rpc/wrtc_call_queue_mongodb.go
@@ -308,17 +308,44 @@ func NewMongoDBWebRTCCallQueue(
 		return nil, err
 	}
 
-	result, err := operatorsColl.InsertOne(ctx, bson.D{
-		{webrtcOperatorIDField, operatorID},
-		{webrtcOperatorExpireAtField, time.Now().Add(operatorHeartbeatWindow)},
-	})
-	if err != nil {
-		return nil, err
-	}
-	logger.Infow(
-		"successfully added operator document to operators collection",
-		"operator_id", operatorID, "document_id", result.InsertedID,
+	// A document with our ID may remain from a previous process with the same identity
+	// (e.g. a restarted container) whose TTL has not yet fired; replace it rather than
+	// failing startup. Replacing also clears the predecessor's stale host counts.
+	priorOperator := operatorsColl.FindOneAndReplace(
+		ctx,
+		bson.D{{webrtcOperatorIDField, operatorID}},
+		bson.D{
+			{webrtcOperatorIDField, operatorID},
+			{webrtcOperatorExpireAtField, time.Now().Add(operatorHeartbeatWindow)},
+		},
+		options.FindOneAndReplace().SetUpsert(true).SetReturnDocument(options.Before),
 	)
+	var prior struct {
+		ExpireAt time.Time `bson:"expire_at"`
+	}
+	switch err := priorOperator.Decode(&prior); {
+	case errors.Is(err, mongo.ErrNoDocuments):
+		logger.Infow(
+			"successfully added operator document to operators collection",
+			"operator_id", operatorID,
+		)
+	case err != nil:
+		return nil, err
+	case time.Now().Before(prior.ExpireAt):
+		// An unexpired document should only be our own recently-dead predecessor. If
+		// operator IDs are not unique as required, another live operator now silently
+		// shares this document; treat this log as a tripwire for that misconfiguration.
+		logger.Warnw(
+			"replaced an unexpired operator document; a previous process with this identity "+
+				"terminated recently, or operator IDs are not unique",
+			"operator_id", operatorID, "prior_expire_at", prior.ExpireAt,
+		)
+	default:
+		logger.Infow(
+			"replaced expired operator document from previous process",
+			"operator_id", operatorID,
+		)
+	}
 
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	queue := &mongoDBWebRTCCallQueue{

--- a/rpc/wrtc_call_queue_mongodb_test.go
+++ b/rpc/wrtc_call_queue_mongodb_test.go
@@ -259,6 +259,33 @@ func TestMongoDBWebRTCCallQueueOperatorDocDeleted(t *testing.T) {
 	wg.Wait()
 }
 
+func TestMongoDBWebRTCCallQueueOperatorReRegistration(t *testing.T) {
+	logger := golog.NewTestLogger(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := testutils.BackingMongoDBClient(t)
+	test.That(t, client.Database(mongodbWebRTCCallQueueDBName).Drop(ctx), test.ShouldBeNil)
+
+	// A process that dies without cleanup leaves an unexpired operator document behind
+	// (Close does not delete it). A successor with the same identity (e.g. a restarted
+	// container) must be able to register over it rather than fail on a duplicate key.
+	opID := uuid.NewString()
+	firstQueue, err := NewMongoDBWebRTCCallQueue(ctx, opID, 50, client, logger, nil, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, firstQueue.Close(), test.ShouldBeNil)
+
+	secondQueue, err := NewMongoDBWebRTCCallQueue(ctx, opID, 50, client, logger, nil, nil)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, secondQueue.Close(), test.ShouldBeNil)
+
+	count, err := client.Database(mongodbWebRTCCallQueueDBName).
+		Collection(mongodbWebRTCCallQueueOperatorsCollName).
+		CountDocuments(ctx, bson.M{"_id": opID})
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, count, test.ShouldEqual, 1)
+}
+
 func addFakeAnswererForHost(t *testing.T, client *mongo.Client, host string) {
 	t.Helper()
 	_, err := client.Database(mongodbWebRTCCallQueueDBName).Collection(mongodbWebRTCCallQueueOperatorsCollName).InsertOne(context.Background(),


### PR DESCRIPTION
## What changed

`NewMongoDBWebRTCCallQueue` now registers its operator document with a guarded upsert (`FindOneAndReplace` + upsert) instead of `InsertOne`:

- No prior doc → same behavior as before.
- Prior **expired** doc (TTL sweep hasn't fired yet) → replaced silently.
- Prior **unexpired** doc → replaced with a warning log, since that means a same-identity predecessor died within the heartbeat window — or operator IDs are not unique as required, which the warning acts as a tripwire for.

Replacing also clears the predecessor's stale host counts immediately instead of letting them pollute queue-size maxima and host-online checks until the TTL sweep (which runs only ~every 60s).

## Why

A process that dies without cleanup (`Close` does not delete the doc) leaves an unexpired operator document behind. A successor with the same operator ID — e.g. a restarted container — previously crashed on startup with `E11000 duplicate key error collection: rpc.operators` until the TTL sweep removed the doc. This is the crashloop seen on nearly every app GKE deploy in staging usw4 (amplified by pods sharing the node's instance ID — fixed separately in viamrobotics/app#13274).

Jira: [APP-17636](https://viam.atlassian.net/browse/APP-17636)

## Testing

- New `TestMongoDBWebRTCCallQueueOperatorReRegistration` reproduces the exact E11000 against the old code and passes with this change.
- Full `TestMongoDBWebRTCCallQueue*` suite passes against a single-node replica-set Mongo; `make lint-go` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-17636]: https://viam.atlassian.net/browse/APP-17636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ