### PR TITLE
pexec: treat EPERM from a process-group signal as already gone

### DIFF
--- a/pexec/managed_process_unix.go
+++ b/pexec/managed_process_unix.go
@@ -110,15 +110,8 @@ func (p *managedProcess) kill() (bool, error) {
 	select {
 	case <-timer.C:
 		p.logger.Infof("stopping entire process group %d with signal %s", p.cmd.Process.Pid, p.stopSig)
-		if err := syscall.Kill(-p.cmd.Process.Pid, p.stopSig); err != nil {
-			var errno syscall.Errno
-			if errors.As(err, &errno) && errno == syscall.ESRCH {
-				return false, &ProcessNotExistsError{err}
-			} else if errors.Is(err, os.ErrProcessDone) {
-				return false, &ProcessNotExistsError{err}
-			}
-			return false, errors.Wrapf(err, "error signaling process group %d with signal %s",
-				p.cmd.Process.Pid, p.stopSig)
+		if err := p.killGroup(p.stopSig); err != nil {
+			return false, err
 		}
 	case <-p.managingCh:
 		timer.Stop()
@@ -131,15 +124,8 @@ func (p *managedProcess) kill() (bool, error) {
 	select {
 	case <-timer2.C:
 		p.logger.Infof("killing entire process group %d", p.cmd.Process.Pid)
-		if err := syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL); err != nil {
-			var errno syscall.Errno
-			if errors.As(err, &errno) && errno == syscall.ESRCH {
-				return false, &ProcessNotExistsError{err}
-			} else if errors.Is(err, os.ErrProcessDone) {
-				return false, &ProcessNotExistsError{err}
-			}
-			return false, errors.Wrapf(err, "error signaling process group %d with signal %s",
-				p.cmd.Process.Pid, p.stopSig)
+		if err := p.killGroup(syscall.SIGKILL); err != nil {
+			return false, err
 		}
 		forceKilled = true
 	case <-p.managingCh:
@@ -147,6 +133,36 @@ func (p *managedProcess) kill() (bool, error) {
 	}
 
 	return forceKilled, nil
+}
+
+// killGroup signals every process in the managed process's group. Landing on nothing is
+// reported as a ProcessNotExistsError rather than as a failure to stop: kill has already
+// signaled the process itself by this point, so this sweep exists only to catch orphaned
+// children, and an empty group means it has none to catch.
+func (p *managedProcess) killGroup(sig syscall.Signal) error {
+	if err := syscall.Kill(-p.cmd.Process.Pid, sig); err != nil {
+		if processGroupGone(err) {
+			return &ProcessNotExistsError{err}
+		}
+		return errors.Wrapf(err, "error signaling process group %d with signal %s", p.cmd.Process.Pid, sig)
+	}
+	return nil
+}
+
+// processGroupGone reports whether err from signaling a process group means there was nothing
+// left in it to signal.
+//
+// The two ways that happens are not reported alike. Once the process has been reaped its group
+// is gone and kill(2) answers ESRCH, but in the window where it has exited and not yet been
+// reaped the group still holds a zombie: Linux signals that group without complaint, while
+// Darwin finds a member it cannot signal and answers EPERM. Reading EPERM as a permission
+// failure would therefore turn a clean shutdown into an error on macOS alone.
+func processGroupGone(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ESRCH || errno == syscall.EPERM
+	}
+	return errors.Is(err, os.ErrProcessDone)
 }
 
 // forceKillGroup kills everything in the process group. This will not wait for completion and may result the

--- a/pexec/managed_process_unix_test.go
+++ b/pexec/managed_process_unix_test.go
@@ -1,0 +1,41 @@
+//go:build linux || darwin
+
+package pexec
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestProcessGroupGone(t *testing.T) {
+	wrapped := func(err error) error {
+		return fmt.Errorf("error signaling process group 1234 with signal terminated: %w", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// The group is gone entirely, which is what remains once the process has been reaped.
+		{"ESRCH", syscall.ESRCH, true},
+		// Darwin's answer for a group whose only member is an unreaped zombie.
+		{"EPERM", syscall.EPERM, true},
+		{"wrapped ESRCH", wrapped(syscall.ESRCH), true},
+		{"wrapped EPERM", wrapped(syscall.EPERM), true},
+		{"ErrProcessDone", os.ErrProcessDone, true},
+		{"wrapped ErrProcessDone", wrapped(os.ErrProcessDone), true},
+		{"unrelated errno", syscall.EACCES, false},
+		{"unrelated error", errors.New("could not stop process"), false},
+		{"nil", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			test.That(t, processGroupGone(tc.err), test.ShouldEqual, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`kill` sweeps the process group a few seconds after signaling the process itself, to catch orphaned children. When the process has already exited there is nothing to catch — but that reports two different ways. Reaped, the group is gone and `kill(2)` answers `ESRCH`, which is already handled. Exited-but-unreaped, the group still holds a zombie: Linux signals it without complaint, Darwin answers `EPERM`.

Reading that `EPERM` as a permission failure turned a clean shutdown into a failure to stop, on macOS alone. It also bypassed `ProcessNotExistsError`: rdk's `modManager` ignores that error when stopping a module, and instead saw a hard failure whenever a module process exited promptly.

Accept `EPERM` alongside `ESRCH`, folding the classification duplicated at both group-signal sites into `killGroup`/`processGroupGone`. Drive-by: the SIGKILL site named `p.stopSig` in its error rather than the signal it actually sent.

Related: viamrobotics/rdk#6379 makes rdk's own tests robust to this. The two are complementary and neither depends on the other — see that PR for how they fit together.

## Testing

- New table test on the classifier; the full `./pexec/` suite passes on darwin/arm64.
- Darwin behavior confirmed with a probe (own process group: zombie → `EPERM`, reaped → `ESRCH`). The timing window that triggers it is load-dependent, so it is not reproduced in a test.

<details>
<summary>Claude Code prompts used</summary>

- "You said that "the real fix belongs upstream in goutils", Can you create a worktree and create the fix in goutils directly? goutils is available at @../../../../goutils"
- "open a draft PR for goutils
Since the change in rdk is complementary you probably need to update the description, it states that the real fix is in goutils which turns out to not be true. You should link the goutils PR in the rdk PR description and explain how they are related"

</details>
