### PR TITLE
jwks: retry the initial OIDC discovery and JWKS fetch

### DIFF
--- a/jwks/jwks.go
+++ b/jwks/jwks.go
@@ -76,10 +76,43 @@ func (cp *cachingKeyProvider) Fetch(ctx context.Context) (KeySet, error) {
 // ensure interface is met.
 var _ KeyProvider = &cachingKeyProvider{}
 
+// Backoff schedule for the initial discovery and JWKS fetches; a transient network
+// failure at process startup would otherwise be fatal to the caller.
+const (
+	oidcFetchInitialRetryDelay = 500 * time.Millisecond
+	oidcFetchMaxRetryDelay     = 5 * time.Second
+	oidcFetchMaxRetryElapsed   = 30 * time.Second
+)
+
 // NewCachingOIDCJWKKeyProvider creates a CachingKeyProvider based on the issuer url
-// base domain and starts the auto refresh. Call CachingKeyProvider.Stop() to stop any
-// background goroutines.
+// base domain and starts the auto refresh. Transient failures fetching the discovery
+// document or the initial JWKS retry with backoff for up to 30s, bounded by ctx.
+// Call CachingKeyProvider.Stop() to stop any background goroutines.
 func NewCachingOIDCJWKKeyProvider(ctx context.Context, issuer string) (KeyProvider, error) {
+	delay := oidcFetchInitialRetryDelay
+	var elapsed time.Duration
+	for {
+		provider, err := newCachingOIDCJWKKeyProviderOnce(ctx, issuer)
+		if err == nil || errors.Is(err, oidc.ErrIssuerInvalid) || elapsed >= oidcFetchMaxRetryElapsed {
+			return provider, err
+		}
+		if remaining := oidcFetchMaxRetryElapsed - elapsed; delay > remaining {
+			delay = remaining
+		}
+		select {
+		case <-ctx.Done():
+			return nil, errors.Join(err, ctx.Err())
+		case <-time.After(delay):
+		}
+		elapsed += delay
+		delay *= 2
+		if delay > oidcFetchMaxRetryDelay {
+			delay = oidcFetchMaxRetryDelay
+		}
+	}
+}
+
+func newCachingOIDCJWKKeyProviderOnce(ctx context.Context, issuer string) (KeyProvider, error) {
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	httpClient := &http.Client{
 		Transport: httpTransport,

--- a/jwks/jwksutils/jwks_test.go
+++ b/jwks/jwksutils/jwks_test.go
@@ -34,6 +34,27 @@ func TestFetch(t *testing.T) {
 	test.That(t, ok, test.ShouldBeTrue)
 }
 
+func TestFetchRetriesTransientFailures(t *testing.T) {
+	ctx := context.Background()
+
+	set, _, err := NewTestKeySet(1)
+	test.That(t, err, test.ShouldBeNil)
+
+	address, closeFakeOIDC := ServeFakeOIDCEndpointWithFailures(t, set, 1)
+	defer closeFakeOIDC()
+
+	keyProvider, err := jwks.NewCachingOIDCJWKKeyProvider(ctx, address)
+	test.That(t, err, test.ShouldBeNil)
+
+	defer keyProvider.Close()
+
+	keyset, err := keyProvider.Fetch(ctx)
+	test.That(t, err, test.ShouldBeNil)
+
+	_, ok := keyset.LookupKeyID("key-id-1")
+	test.That(t, ok, test.ShouldBeTrue)
+}
+
 func TestStaticKeySet(t *testing.T) {
 	ctx := context.Background()
 

--- a/jwks/jwksutils/utils.go
+++ b/jwks/jwksutils/utils.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +26,18 @@ import (
 
 // ServeFakeOIDCEndpoint is a test helper for serving a OIDC endpoint from a static keyset.
 func ServeFakeOIDCEndpoint(t *testing.T, keyset jwks.KeySet) (string, func()) {
+	t.Helper()
+	return serveFakeOIDCEndpoint(t, keyset, 0)
+}
+
+// ServeFakeOIDCEndpointWithFailures behaves like ServeFakeOIDCEndpoint after answering
+// the first failures requests with a 500.
+func ServeFakeOIDCEndpointWithFailures(t *testing.T, keyset jwks.KeySet, failures int) (string, func()) {
+	t.Helper()
+	return serveFakeOIDCEndpoint(t, keyset, failures)
+}
+
+func serveFakeOIDCEndpoint(t *testing.T, keyset jwks.KeySet, failures int) (string, func()) {
 	t.Helper()
 
 	var lc net.ListenConfig
@@ -67,9 +80,21 @@ func ServeFakeOIDCEndpoint(t *testing.T, keyset jwks.KeySet) (string, func()) {
 
 	logger := golog.NewTestLogger(t)
 
+	remaining := int64(failures)
+	handler := http.Handler(mux)
+	if failures > 0 {
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if atomic.AddInt64(&remaining, -1) >= 0 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			mux.ServeHTTP(w, r)
+		})
+	}
+
 	server := &http.Server{
 		Addr:              listener.Addr().String(),
-		Handler:           mux,
+		Handler:           handler,
 		ReadHeaderTimeout: time.Second * 5,
 	}
 


### PR DESCRIPTION
NewCachingOIDCJWKKeyProvider makes two network calls (the discovery GET and the initial JWKS refresh) with no retry, so a single reset TCP connection is fatal to every caller at process startup; viamrobotics/app nightly E2E run 33142747007 lost a shard exactly this way, since all four app server binaries call this at init. Transient failures retry with exponential backoff (500ms doubling to 5s, 30s cap), bounded by the caller's context; oidc.ErrIssuerInvalid returns immediately since retrying a misconfigured issuer cannot help. The loop is hand-rolled to avoid adding a backoff dependency to the library. ServeFakeOIDCEndpointWithFailures injects 500s into the existing fake OIDC server so the new test exercises one failed round trip before success.

Replaces viamrobotics/app#13353, which put the retry app-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)