### PR TITLE
RSDK-14415 Pull metadata off auth.State / internalForeverJWT

### DIFF
--- a/rpc/server_auth.go
+++ b/rpc/server_auth.go
@@ -429,9 +429,22 @@ func (ss *simpleServer) ensureAuthed(ctx context.Context) (context.Context, erro
 		entityData = data
 	}
 
+	// Auth metadata (e.g. app user id, email) normally rides in the JWT's rpc_auth_md
+	// claim, but some tokens (such as the machine page's metadata-less internal token)
+	// carry none even though the server-verified entity data still knows the caller's
+	// identity. Fall back to metadata the entity data can supply so every downstream
+	// consumer (e.g. WebRTC signaling forwarding a caller's identity to an answerer)
+	// reads it off EntityInfo.AuthMetadata like any other.
+	authMetadata := claims.Metadata()
+	if len(authMetadata) == 0 {
+		if provider, ok := entityData.(interface{ CreateMetadata() map[string]string }); ok {
+			authMetadata = provider.CreateMetadata()
+		}
+	}
+
 	return ContextWithAuthEntity(ctx, EntityInfo{
 		Entity:       claimsEntity,
 		Data:         entityData,
-		AuthMetadata: claims.Metadata(),
+		AuthMetadata: authMetadata,
 	}), nil
 }

--- a/rpc/wrtc_signaling_server.go
+++ b/rpc/wrtc_signaling_server.go
@@ -203,7 +203,7 @@ func (srv *WebRTCSignalingServer) Call(req *webrtcpb.CallRequest, server webrtcp
 		callerAuthEntity, callerAuthMetadata = entity.Entity, entity.AuthMetadata
 
 		// Auth metadata (app user ID, email) should be in the JWT token, but the
-		// internalForeverJWT used by the machine page has no metadata. Hackily pull it off
+		// internalForeverJWT used by the machine page has no metadata. Pull it off
 		// `entity.Data`.
 		if callerAuthMetadata == nil {
 			if provider, ok := entity.Data.(interface{ CreateMetadata() map[string]string }); ok {

--- a/rpc/wrtc_signaling_server.go
+++ b/rpc/wrtc_signaling_server.go
@@ -201,15 +201,6 @@ func (srv *WebRTCSignalingServer) Call(req *webrtcpb.CallRequest, server webrtcp
 	var callerAuthMetadata map[string]string
 	if entity, ok := ContextAuthEntity(ctx); ok {
 		callerAuthEntity, callerAuthMetadata = entity.Entity, entity.AuthMetadata
-
-		// Auth metadata (app user ID, email) should be in the JWT token, but the
-		// internalForeverJWT used by the machine page has no metadata. Pull it off
-		// `entity.Data`.
-		if callerAuthMetadata == nil {
-			if provider, ok := entity.Data.(interface{ CreateMetadata() map[string]string }); ok {
-				callerAuthMetadata = provider.CreateMetadata()
-			}
-		}
 	}
 	uuid, respCh, respDone, sendCancel, err := srv.callQueue.SendOfferInit(
 		ctx, host, req.GetSdp(), req.GetDisableTrickle(), callerAuthEntity, callerAuthMetadata)

--- a/rpc/wrtc_signaling_server.go
+++ b/rpc/wrtc_signaling_server.go
@@ -201,6 +201,15 @@ func (srv *WebRTCSignalingServer) Call(req *webrtcpb.CallRequest, server webrtcp
 	var callerAuthMetadata map[string]string
 	if entity, ok := ContextAuthEntity(ctx); ok {
 		callerAuthEntity, callerAuthMetadata = entity.Entity, entity.AuthMetadata
+
+		// Auth metadata (app user ID, email) should be in the JWT token, but the
+		// internalForeverJWT used by the machine page has no metadata. Hackily pull it off
+		// `entity.Data`.
+		if callerAuthMetadata == nil {
+			if provider, ok := entity.Data.(interface{ CreateMetadata() map[string]string }); ok {
+				callerAuthMetadata = provider.CreateMetadata()
+			}
+		}
 	}
 	uuid, respCh, respDone, sendCancel, err := srv.callQueue.SendOfferInit(
 		ctx, host, req.GetSdp(), req.GetDisableTrickle(), callerAuthEntity, callerAuthMetadata)


### PR DESCRIPTION
RSDK-14415

## What

If `entity.AuthMetadata` is empty (`rpc_auth_md` was missing in the JWT token headers), try to use `CreateMetadata` instead. See [PR for app-side implementation](https://github.com/viamrobotics/app/pull/13406) of `CreateMetadata`.

## Why

App currently uses the `internalForeverJWT` for all machine page connections in the `Authorization` header. There is no metadata on that token, so the `app_user_id` and `email` are unclear. We can pull those pieces of information from `State.AppUser` and `State.User` where `State` is `entity.Data` in the signaling server code. That should let us insert metadata with `internalForeverJWT` connections for now.

A future app-side change may stop using `internalForeverJWT` entirely and actually invoke `Call` with proper a `Authorization` header. This change is a stopgap until that point.